### PR TITLE
Release v3.5.2: Convenience methods, config entities, and code cleanup

### DIFF
--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -70,6 +70,7 @@ from pyintellicenter import (
     TIME_ATTR,
     USE_ATTR,
     VACFLO_ATTR,
+    VALVE_TYPE,
     VER_ATTR,
     VOL_ATTR,
     ICBaseController,
@@ -104,7 +105,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         TIME_ATTR,  # Egg timer duration
         FREEZE_ATTR,  # Freeze protection status
     },
-    CIRCGRP_TYPE: {CIRCUIT_ATTR},
+    CIRCGRP_TYPE: {SNAME_ATTR, STATUS_ATTR, USE_ATTR, CIRCUIT_ATTR},  # Circuit groups
     CHEM_TYPE: {
         SNAME_ATTR,
         BODY_ATTR,
@@ -149,6 +150,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
     SENSE_TYPE: {SNAME_ATTR, SOURCE_ATTR},
     SCHED_TYPE: {SNAME_ATTR, ACT_ATTR, VACFLO_ATTR},
     SYSTEM_TYPE: {MODE_ATTR, VACFLO_ATTR, VER_ATTR},  # VER_ATTR for firmware version
+    VALVE_TYPE: {SNAME_ATTR, STATUS_ATTR},  # Valve actuators for water features
 }
 
 

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.1"],
-  "version": "3.5.0",
+  "requirements": ["pyintellicenter>=0.1.3"],
+  "version": "3.5.2",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -4,7 +4,9 @@ This module provides sensor entities for various pool measurements including:
 - Temperature sensors (air, water)
 - Pump sensors (power, RPM, GPM)
 - Chemistry sensors (pH, ORP, salt level, water quality)
-- IntelliChem water chemistry settings (alkalinity, calcium hardness, cyanuric acid)
+
+Note: IntelliChem configuration values (ALK, CALC, CYACID) are in number.py
+as they are user-entered configuration, not sensor readings.
 """
 
 from __future__ import annotations
@@ -25,11 +27,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
-    ALK_ATTR,
     BODY_TYPE,
-    CALC_ATTR,
     CHEM_TYPE,
-    CYACID_ATTR,
     GPM_ATTR,
     LOTMP_ATTR,
     LSTTMP_ATTR,
@@ -256,43 +255,8 @@ async def async_setup_entry(
                             entity_category=EntityCategory.DIAGNOSTIC,
                         )
                     )
-                # Water chemistry configuration sensors (read-only)
-                if ALK_ATTR in obj.attribute_keys:
-                    sensors.append(
-                        PoolSensor(
-                            coordinator,
-                            obj,
-                            device_class=None,
-                            attribute_key=ALK_ATTR,
-                            name="+ (Alkalinity)",
-                            unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
-                            icon="mdi:flask-outline",
-                        )
-                    )
-                if CALC_ATTR in obj.attribute_keys:
-                    sensors.append(
-                        PoolSensor(
-                            coordinator,
-                            obj,
-                            device_class=None,
-                            attribute_key=CALC_ATTR,
-                            name="+ (Calcium Hardness)",
-                            unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
-                            icon="mdi:flask-outline",
-                        )
-                    )
-                if CYACID_ATTR in obj.attribute_keys:
-                    sensors.append(
-                        PoolSensor(
-                            coordinator,
-                            obj,
-                            device_class=None,
-                            attribute_key=CYACID_ATTR,
-                            name="+ (Cyanuric Acid)",
-                            unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
-                            icon="mdi:flask-outline",
-                        )
-                    )
+                # Note: ALK, CALC, CYACID are configuration values (user-entered)
+                # and are handled as number entities in number.py
             elif obj.subtype == "ICHLOR":
                 if SALT_ATTR in obj.attribute_keys:
                     sensors.append(

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -164,12 +164,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         return self._safe_float_conversion(self._pool_object[LOTMP_ATTR])
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperatures."""
+        """Set new target temperatures using convenience method."""
         target_temperature = kwargs.get(ATTR_TEMPERATURE)
         if target_temperature is not None:
             try:
                 temp_value = int(target_temperature)
-                self.request_changes({LOTMP_ATTR: str(temp_value)})
+                # Use pyintellicenter convenience method
+                await self._controller.set_setpoint(
+                    self._pool_object.objnam, temp_value
+                )
             except (ValueError, TypeError):
                 _LOGGER.exception("Invalid temperature value '%s'", target_temperature)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from pyintellicenter import (
     SCHED_TYPE,
     SENSE_TYPE,
     SYSTEM_TYPE,
+    VALVE_TYPE,
     ICModelController,
     ICSystemInfo,
     PoolModel,
@@ -219,6 +220,16 @@ def pool_model_data() -> list[dict[str, Any]]:
                 "ENABLE": "ON",
             },
         },
+        # Valve actuator
+        {
+            "objnam": "VAL01",
+            "params": {
+                "OBJTYP": VALVE_TYPE,
+                "SUBTYP": "LEGACY",
+                "SNAME": "Spillover Valve",
+                "STATUS": "OFF",
+            },
+        },
     ]
 
 
@@ -350,9 +361,29 @@ def mock_coordinator(
     # Configure model
     mock_coord.model = pool_model
 
-    # Configure controller
+    # Configure controller with all convenience methods
     mock_controller = MagicMock()
     mock_controller.request_changes = AsyncMock()
+    # Convenience methods from pyintellicenter v0.1.2
+    mock_controller.set_valve_state = AsyncMock()
+    mock_controller.set_vacation_mode = AsyncMock()
+    mock_controller.set_ph_setpoint = AsyncMock()
+    mock_controller.set_orp_setpoint = AsyncMock()
+    mock_controller.set_chlorinator_output = AsyncMock()
+    mock_controller.set_light_effect = AsyncMock()
+    mock_controller.set_setpoint = AsyncMock()
+    mock_controller.set_heat_mode = AsyncMock()
+    mock_controller.get_chlorinator_output = MagicMock(
+        return_value={"primary": 50, "secondary": 50}
+    )
+    mock_controller.is_vacation_mode = MagicMock(return_value=False)
+    # Convenience methods from pyintellicenter v0.1.3
+    mock_controller.set_alkalinity = AsyncMock()
+    mock_controller.set_calcium_hardness = AsyncMock()
+    mock_controller.set_cyanuric_acid = AsyncMock()
+    mock_controller.get_alkalinity = MagicMock(return_value=100)
+    mock_controller.get_calcium_hardness = MagicMock(return_value=300)
+    mock_controller.get_cyanuric_acid = MagicMock(return_value=40)
     mock_coord.controller = mock_controller
 
     # Configure system info
@@ -399,3 +430,17 @@ def mock_write_ha_state() -> Generator[MagicMock]:
         "homeassistant.helpers.entity.Entity.async_write_ha_state"
     ) as mock_write:
         yield mock_write
+
+
+@pytest.fixture
+def pool_object_valve() -> PoolObject:
+    """Return a PoolObject representing a valve actuator."""
+    return PoolObject(
+        "VAL01",
+        {
+            "OBJTYP": VALVE_TYPE,
+            "SUBTYP": "LEGACY",
+            "SNAME": "Spillover Valve",
+            "STATUS": "OFF",
+        },
+    )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -104,14 +104,17 @@ async def test_light_turn_on_with_effect(
     await hass.async_block_till_done()
     await light.async_turn_on(**{ATTR_EFFECT: "Party Mode"})
 
-    # Should request status ON and effect PARTY
+    # Effect is set via convenience method
+    mock_coordinator.controller.set_light_effect.assert_called_once_with(
+        "LIGHT1", "PARTY"
+    )
+
+    # Light is turned on via request_changes
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[0] == "LIGHT1"
     assert STATUS_ATTR in args[1]
     assert args[1][STATUS_ATTR] == "ON"
-    assert ACT_ATTR in args[1]
-    assert args[1][ACT_ATTR] == "PARTY"
 
 
 async def test_light_turn_off(
@@ -351,11 +354,15 @@ async def test_light_turn_on_with_each_effect(
     await hass.async_block_till_done()
     await light.async_turn_on(**{ATTR_EFFECT: effect_name})
 
-    # Verify the correct effect code was sent
+    # Effect is set via convenience method with correct code
+    mock_coordinator.controller.set_light_effect.assert_called_once_with(
+        "LIGHT1", expected_code
+    )
+
+    # Light is turned on via request_changes
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[0] == "LIGHT1"
-    assert args[1][ACT_ATTR] == expected_code
     assert args[1][STATUS_ATTR] == "ON"
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from pyintellicenter import (
     STATUS_ATTR,
     VACFLO_ATTR,
+    VALVE_TYPE,
     PoolModel,
     PoolObject,
 )
@@ -261,3 +262,103 @@ async def test_switch_device_class(
     circuit = PoolCircuit(mock_coordinator, pool_object_switch)
 
     assert circuit.device_class == SwitchDeviceClass.SWITCH
+
+
+async def test_valve_switch_properties(
+    hass: HomeAssistant,
+    pool_object_valve: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test valve switch properties."""
+    valve_switch = PoolCircuit(
+        mock_coordinator,
+        pool_object_valve,
+        icon="mdi:pipe-valve",
+    )
+
+    assert valve_switch.is_on is False
+    assert valve_switch.name == "Spillover Valve"
+    assert valve_switch.unique_id == "test_entry_VAL01"
+
+
+async def test_valve_switch_turn_on(
+    hass: HomeAssistant,
+    pool_object_valve: PoolObject,
+    mock_coordinator: MagicMock,
+    mock_write_ha_state: MagicMock,
+) -> None:
+    """Test turning on a valve switch."""
+    valve_switch = PoolCircuit(
+        mock_coordinator,
+        pool_object_valve,
+        icon="mdi:pipe-valve",
+    )
+    valve_switch.hass = hass
+
+    await hass.async_block_till_done()
+    await valve_switch.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "VAL01"
+    assert STATUS_ATTR in args[1]
+    assert args[1][STATUS_ATTR] == "ON"
+
+
+async def test_valve_switch_turn_off(
+    hass: HomeAssistant,
+    pool_object_valve: PoolObject,
+    mock_coordinator: MagicMock,
+    mock_write_ha_state: MagicMock,
+) -> None:
+    """Test turning off a valve switch."""
+    pool_object_valve.update({STATUS_ATTR: "ON"})
+
+    valve_switch = PoolCircuit(
+        mock_coordinator,
+        pool_object_valve,
+        icon="mdi:pipe-valve",
+    )
+    valve_switch.hass = hass
+
+    assert valve_switch.is_on is True
+
+    await hass.async_block_till_done()
+    await valve_switch.async_turn_off()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "VAL01"
+    assert STATUS_ATTR in args[1]
+    assert args[1][STATUS_ATTR] == "OFF"
+
+
+async def test_valve_switch_setup_creates_entity(
+    hass: HomeAssistant,
+    pool_model: PoolModel,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that valve switches are created during setup."""
+    mock_coordinator.model = pool_model
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.switch import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    # Find valve switches
+    valve_switches = [
+        e
+        for e in entities_added
+        if hasattr(e, "_pool_object") and e._pool_object.objtype == VALVE_TYPE
+    ]
+    assert len(valve_switches) == 1
+    assert valve_switches[0]._pool_object.objnam == "VAL01"

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -270,14 +270,7 @@ async def test_water_heater_set_temperature(
     pool_object_body_with_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test setting target temperature."""
-
-    mock_coordinator.controller.request_changes = AsyncMock()
-    mock_coordinator.controller.system_info = MagicMock()
-    type(mock_coordinator.controller.system_info).uses_metric = property(
-        lambda self: False
-    )
-
+    """Test setting target temperature uses convenience method."""
     water_heater = PoolWaterHeater(
         mock_coordinator,
         pool_object_body_with_heater,
@@ -287,11 +280,8 @@ async def test_water_heater_set_temperature(
 
     await water_heater.async_set_temperature(**{ATTR_TEMPERATURE: 80})
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[0] == "POOL1"
-    assert LOTMP_ATTR in args[1]
-    assert args[1][LOTMP_ATTR] == "80"
+    # Should use set_setpoint convenience method
+    mock_coordinator.controller.set_setpoint.assert_called_once_with("POOL1", 80)
 
 
 async def test_water_heater_set_temperature_invalid(


### PR DESCRIPTION
## Summary

- Update to pyintellicenter>=0.1.3 with new convenience methods
- Use convenience methods for all setpoint operations (valve, vacation mode, light effects, water heater, chemistry setpoints, chlorinator output)
- Move setpoints to EntityCategory.CONFIG: pH/ORP setpoints, IntelliChlor outputs, vacation mode, body max temperature
- Add IntelliChem configuration numbers (ALK, CALC, CYACID) as editable entities with integer precision
- Refactor number.py with dispatch table pattern for cleaner code
- Add valve switch tests

## Test plan

- [x] All 179 tests passing
- [x] mypy strict mode passing
- [x] ruff linting and formatting passing
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)