### PR TITLE
Release v3.5.3: Update to pyintellicenter 0.1.4 and remove dead code

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -205,11 +205,6 @@ class PoolEntity(CoordinatorEntity[IntelliCenterCoordinator], Entity):
         return self.coordinator.controller
 
     @property
-    def _poolObject(self) -> PoolObject:
-        """Return the pool object (backwards compatibility)."""
-        return self._pool_object
-
-    @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return bool(self.coordinator.connected)
@@ -330,11 +325,6 @@ class PoolEntity(CoordinatorEntity[IntelliCenterCoordinator], Entity):
                 self._pool_object.objnam,
                 changes,
             )
-
-    # Backwards compatibility alias
-    def requestChanges(self, changes: dict[str, Any]) -> None:
-        """Request changes (backwards compatibility alias)."""
-        self.request_changes(changes)
 
     def _check_attributes_updated(
         self, updates: dict[str, dict[str, Any]], *attributes: str

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.3"],
-  "version": "3.5.2",
+  "requirements": ["pyintellicenter>=0.1.4"],
+  "version": "3.5.3",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]


### PR DESCRIPTION
## Summary

- Update to `pyintellicenter>=0.1.4` which adds request coalescing
- Remove dead backwards compatibility code that was never used

## Changes

### Library Update
The library now handles request coalescing automatically:
- Multiple rapid calls are batched into single `SETPARAMLIST` requests
- "Latest value wins" semantics for conflicting attribute updates
- Reduces network round-trips and device load during rapid state changes

### Dead Code Removal
Removed unused backwards compatibility code from `PoolEntity`:
- `_poolObject` property - was an alias for `_pool_object`, never used externally
- `requestChanges` method - was an alias for `request_changes`, never used externally

## Test plan

- [x] All 179 tests passing
- [x] mypy strict mode passing
- [x] ruff linting and formatting passing
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)