### PR TITLE
Bump to pyintellicenter 0.1.5 (v3.5.5)

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.4"],
-  "version": "3.5.4",
+  "requirements": ["pyintellicenter>=0.1.5"],
+  "version": "3.5.5",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]


### PR DESCRIPTION
## Summary

- Update dependency to pyintellicenter>=0.1.5
- Library now has valve support removed

## Test plan

- [x] pyintellicenter 0.1.5 confirmed on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)