### PR TITLE
Bump pyintellicenter 0.1.5 and fix entity defaults (v3.5.5)

### DIFF
--- a/custom_components/intellicenter/binary_sensor.py
+++ b/custom_components/intellicenter/binary_sensor.py
@@ -84,7 +84,8 @@ async def async_setup_entry(
                     obj,
                     attribute_key="ACT",
                     name="+ (schedule)",
-                    enabled_by_default=False,
+                    icon="mdi:clock-outline",
+                    entity_category=EntityCategory.CONFIG,
                     extra_state_attributes=["VACFLO"],
                 )
             )

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.4"],
-  "version": "3.5.4",
+  "requirements": ["pyintellicenter>=0.1.5"],
+  "version": "3.5.5",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/custom_components/intellicenter/switch.py
+++ b/custom_components/intellicenter/switch.py
@@ -137,6 +137,7 @@ class PoolVacation(PoolEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_icon = "mdi:palm-tree"
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = True
     _optimistic_state: bool | None = None
 
     def __init__(


### PR DESCRIPTION
## Summary

- Update dependency to pyintellicenter>=0.1.5 (valve support removed from library)
- Fix vacation mode to be enabled by default (was showing disabled)
- Fix schedules to be enabled by default with CONFIG entity category
- Add clock icon (`mdi:clock-outline`) to schedule entities

## Test plan

- [x] pyintellicenter 0.1.5 confirmed on PyPI
- [x] All 175 tests passing
- [x] mypy: no issues
- [x] ruff: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)