### PR TITLE
feat: Add pump speed/flow control for variable speed pumps (#19)

### DIFF
--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -47,11 +47,13 @@ from pyintellicenter import (
     ORPSET_ATTR,
     ORPTNK_ATTR,
     ORPVAL_ATTR,
+    PARENT_ATTR,
     PHHI_ATTR,
     PHLO_ATTR,
     PHSET_ATTR,
     PHTNK_ATTR,
     PHVAL_ATTR,
+    PMPCIRC_TYPE,
     PRIM_ATTR,
     PUMP_TYPE,
     PWR_ATTR,
@@ -60,9 +62,11 @@ from pyintellicenter import (
     SALT_ATTR,
     SCHED_TYPE,
     SEC_ATTR,
+    SELECT_ATTR,
     SENSE_TYPE,
     SNAME_ATTR,
     SOURCE_ATTR,
+    SPEED_ATTR,
     STATUS_ATTR,
     SUBTYP_ATTR,
     SUPER_ATTR,
@@ -145,6 +149,15 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         MIN_ATTR,
         MAXF_ATTR,
         MINF_ATTR,
+        SUBTYP_ATTR,  # Pump type: SPEED, FLOW, VSF
+    },
+    PMPCIRC_TYPE: {
+        SNAME_ATTR,
+        PARENT_ATTR,  # The pump this circuit setting belongs to
+        CIRCUIT_ATTR,  # The circuit this setting is for
+        SELECT_ATTR,  # "RPM" or "GPM" - determines which setpoint is active
+        SPEED_ATTR,  # RPM setpoint when SELECT=RPM
+        GPM_ATTR,  # GPM setpoint when SELECT=GPM
     },
     SENSE_TYPE: {SNAME_ATTR, SOURCE_ATTR},
     SCHED_TYPE: {SNAME_ATTR, ACT_ATTR, VACFLO_ATTR},

--- a/custom_components/intellicenter/number.py
+++ b/custom_components/intellicenter/number.py
@@ -31,16 +31,27 @@ from pyintellicenter import (
     BODY_TYPE,
     CALC_ATTR,
     CHEM_TYPE,
+    CIRCUIT_ATTR,
     CYACID_ATTR,
+    GPM_ATTR,
     HITMP_ATTR,
+    MAX_ATTR,
+    MAXF_ATTR,
+    MIN_ATTR,
+    MINF_ATTR,
     ORPSET_ATTR,
+    PARENT_ATTR,
     PHSET_ATTR,
+    PMPCIRC_TYPE,
     PRIM_ATTR,
     SEC_ATTR,
+    SPEED_ATTR,
+    SUBTYP_ATTR,
     PoolObject,
 )
 
 from . import IntelliCenterConfigEntry, PoolEntity
+from .const import CONST_GPM, CONST_RPM
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,6 +85,15 @@ CYACID_STEP = 1
 TEMP_SETPOINT_MIN = 40
 TEMP_SETPOINT_MAX = 104
 TEMP_SETPOINT_STEP = 1
+
+# Pump speed/flow ranges (defaults, actual limits come from pump MIN/MAX attributes)
+PUMP_RPM_MIN_DEFAULT = 450
+PUMP_RPM_MAX_DEFAULT = 3450
+PUMP_RPM_STEP = 50
+
+PUMP_GPM_MIN_DEFAULT = 15
+PUMP_GPM_MAX_DEFAULT = 140
+PUMP_GPM_STEP = 5
 
 # -------------------------------------------------------------------------------------
 
@@ -229,6 +249,102 @@ async def async_setup_entry(
                     integer_only=True,
                 )
             )
+
+    # Add pump circuit speed/flow setpoints (PMPCIRC) - CONFIG category
+    # These allow control of variable speed pump settings per circuit
+    for pool_obj in coordinator.model:
+        if pool_obj.objtype == PMPCIRC_TYPE:
+            # Get the parent pump to determine limits and type
+            parent_objnam = pool_obj[PARENT_ATTR]
+            parent_pump = coordinator.model[parent_objnam] if parent_objnam else None
+
+            # Get the associated circuit for naming
+            circuit_objnam = pool_obj[CIRCUIT_ATTR]
+            circuit = coordinator.model[circuit_objnam] if circuit_objnam else None
+            circuit_name = circuit.sname if circuit else circuit_objnam
+
+            # Determine pump type (SPEED=RPM only, FLOW=GPM only, VSF=both)
+            pump_subtype = parent_pump[SUBTYP_ATTR] if parent_pump else None
+
+            # Get limits from parent pump, with defaults
+            rpm_min = PUMP_RPM_MIN_DEFAULT
+            rpm_max = PUMP_RPM_MAX_DEFAULT
+            gpm_min = PUMP_GPM_MIN_DEFAULT
+            gpm_max = PUMP_GPM_MAX_DEFAULT
+
+            if parent_pump:
+                if MIN_ATTR in parent_pump.attribute_keys and parent_pump[MIN_ATTR]:
+                    try:
+                        rpm_min = int(parent_pump[MIN_ATTR])
+                    except (ValueError, TypeError):
+                        pass
+                if MAX_ATTR in parent_pump.attribute_keys and parent_pump[MAX_ATTR]:
+                    try:
+                        rpm_max = int(parent_pump[MAX_ATTR])
+                    except (ValueError, TypeError):
+                        pass
+                if MINF_ATTR in parent_pump.attribute_keys and parent_pump[MINF_ATTR]:
+                    try:
+                        val = int(parent_pump[MINF_ATTR])
+                        if val > 0:
+                            gpm_min = val
+                    except (ValueError, TypeError):
+                        pass
+                if MAXF_ATTR in parent_pump.attribute_keys and parent_pump[MAXF_ATTR]:
+                    try:
+                        val = int(parent_pump[MAXF_ATTR])
+                        if val > 0:
+                            gpm_max = val
+                    except (ValueError, TypeError):
+                        pass
+
+            # Create RPM setpoint entity if pump supports speed control
+            if SPEED_ATTR in pool_obj.attribute_keys and pump_subtype in (
+                "SPEED",
+                "VSF",
+                "VS",
+                None,  # Default to showing if unknown
+            ):
+                numbers.append(
+                    PoolNumber(
+                        coordinator,
+                        pool_obj,
+                        min_value=rpm_min,
+                        max_value=rpm_max,
+                        step=PUMP_RPM_STEP,
+                        attribute_key=SPEED_ATTR,
+                        name=f"+ RPM ({circuit_name})",
+                        icon="mdi:speedometer",
+                        unit_of_measurement=CONST_RPM,
+                        mode=NumberMode.BOX,
+                        entity_category=EntityCategory.CONFIG,
+                        integer_only=True,
+                    )
+                )
+
+            # Create GPM setpoint entity if pump supports flow control
+            if GPM_ATTR in pool_obj.attribute_keys and pump_subtype in (
+                "FLOW",
+                "VSF",
+                "VF",
+                None,  # Default to showing if unknown
+            ):
+                numbers.append(
+                    PoolNumber(
+                        coordinator,
+                        pool_obj,
+                        min_value=gpm_min,
+                        max_value=gpm_max,
+                        step=PUMP_GPM_STEP,
+                        attribute_key=GPM_ATTR,
+                        name=f"+ GPM ({circuit_name})",
+                        icon="mdi:water-pump",
+                        unit_of_measurement=CONST_GPM,
+                        mode=NumberMode.BOX,
+                        entity_category=EntityCategory.CONFIG,
+                        integer_only=True,
+                    )
+                )
 
     async_add_entities(numbers)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from pyintellicenter import (
     CHEM_TYPE,
     CIRCUIT_TYPE,
     HEATER_TYPE,
+    PMPCIRC_TYPE,
     PUMP_TYPE,
     SCHED_TYPE,
     SENSE_TYPE,
@@ -161,17 +162,34 @@ def pool_model_data() -> list[dict[str, Any]]:
                 "FEATR": "OFF",
             },
         },
-        # Pump
+        # Pump (variable speed/flow with limits)
         {
             "objnam": "PUMP1",
             "params": {
                 "OBJTYP": PUMP_TYPE,
-                "SUBTYP": "VS",
+                "SUBTYP": "VSF",
                 "SNAME": "Pool Pump",
                 "STATUS": "10",
                 "PWR": "1200",
                 "RPM": "2000",
                 "GPM": "55",
+                "MIN": "450",
+                "MAX": "3450",
+                "MINF": "15",
+                "MAXF": "140",
+            },
+        },
+        # Pump circuit settings (PMPCIRC)
+        {
+            "objnam": "PMPCIRC01",
+            "params": {
+                "OBJTYP": PMPCIRC_TYPE,
+                "SNAME": "Pool Pump Circuit 1",
+                "PARENT": "PUMP1",
+                "CIRCUIT": "POOL1",
+                "SELECT": "GPM",
+                "SPEED": "2400",
+                "GPM": "80",
             },
         },
         # Heater
@@ -263,17 +281,38 @@ def pool_object_switch() -> PoolObject:
 
 @pytest.fixture
 def pool_object_pump() -> PoolObject:
-    """Return a PoolObject representing a variable speed pump."""
+    """Return a PoolObject representing a variable speed/flow pump."""
     return PoolObject(
         "PUMP1",
         {
             "OBJTYP": PUMP_TYPE,
-            "SUBTYP": "VS",
+            "SUBTYP": "VSF",
             "SNAME": "Pool Pump",
             "STATUS": "10",
             "PWR": "1200",
             "RPM": "2000",
             "GPM": "55",
+            "MIN": "450",
+            "MAX": "3450",
+            "MINF": "15",
+            "MAXF": "140",
+        },
+    )
+
+
+@pytest.fixture
+def pool_object_pmpcirc() -> PoolObject:
+    """Return a PoolObject representing a pump circuit setting."""
+    return PoolObject(
+        "PMPCIRC01",
+        {
+            "OBJTYP": PMPCIRC_TYPE,
+            "SNAME": "Pool Pump Circuit 1",
+            "PARENT": "PUMP1",
+            "CIRCUIT": "POOL1",
+            "SELECT": "GPM",
+            "SPEED": "2400",
+            "GPM": "80",
         },
     )
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -7,8 +7,13 @@ from homeassistant.core import HomeAssistant
 from pyintellicenter import (
     BODY_TYPE,
     CHEM_TYPE,
+    CIRCUIT_TYPE,
+    GPM_ATTR,
+    PMPCIRC_TYPE,
     PRIM_ATTR,
+    PUMP_TYPE,
     SEC_ATTR,
+    SPEED_ATTR,
     PoolModel,
     PoolObject,
 )
@@ -400,3 +405,250 @@ async def test_number_no_bodies_configured(
 
     # Should create no entities when no bodies configured
     assert len(entities_added) == 0
+
+
+# --- Pump Speed Control Tests ---
+
+
+@pytest.fixture
+def pool_model_with_pmpcirc() -> PoolModel:
+    """Return a PoolModel with a variable speed/flow pump and circuit settings."""
+    model = PoolModel()
+    model.add_objects(
+        [
+            {
+                "objnam": "POOL1",
+                "params": {
+                    "OBJTYP": BODY_TYPE,
+                    "SUBTYP": "POOL",
+                    "SNAME": "Pool",
+                },
+            },
+            {
+                "objnam": "CIRC01",
+                "params": {
+                    "OBJTYP": CIRCUIT_TYPE,
+                    "SUBTYP": "GENERIC",
+                    "SNAME": "Pool Circuit",
+                },
+            },
+            {
+                "objnam": "PUMP1",
+                "params": {
+                    "OBJTYP": PUMP_TYPE,
+                    "SUBTYP": "VSF",
+                    "SNAME": "Pool Pump",
+                    "STATUS": "10",
+                    "MIN": "450",
+                    "MAX": "3450",
+                    "MINF": "15",
+                    "MAXF": "140",
+                },
+            },
+            {
+                "objnam": "PMPCIRC01",
+                "params": {
+                    "OBJTYP": PMPCIRC_TYPE,
+                    "SNAME": "Pool Pump Circuit 1",
+                    "PARENT": "PUMP1",
+                    "CIRCUIT": "CIRC01",
+                    "SELECT": "GPM",
+                    "SPEED": "2400",
+                    "GPM": "80",
+                },
+            },
+        ]
+    )
+    return model
+
+
+@pytest.fixture
+def pool_object_pmpcirc() -> PoolObject:
+    """Return a PoolObject representing a pump circuit setting."""
+    return PoolObject(
+        "PMPCIRC01",
+        {
+            "OBJTYP": PMPCIRC_TYPE,
+            "SNAME": "Pool Pump Circuit 1",
+            "PARENT": "PUMP1",
+            "CIRCUIT": "CIRC01",
+            "SELECT": "GPM",
+            "SPEED": "2400",
+            "GPM": "80",
+        },
+    )
+
+
+async def test_number_setup_creates_pmpcirc_entities(
+    hass: HomeAssistant,
+    pool_model_with_pmpcirc: PoolModel,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test number platform creates entities for pump circuit settings."""
+    mock_coordinator.model = pool_model_with_pmpcirc
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.number import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    # Should create 2 number entities (RPM and GPM for VSF pump)
+    pmpcirc_entities = [e for e in entities_added if "RPM" in e.name or "GPM" in e.name]
+    assert len(pmpcirc_entities) == 2
+
+
+async def test_number_pmpcirc_rpm_properties(
+    hass: HomeAssistant,
+    pool_object_pmpcirc: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test PoolNumber entity properties for pump RPM setpoint."""
+    from custom_components.intellicenter.const import CONST_RPM
+
+    number = PoolNumber(
+        mock_coordinator,
+        pool_object_pmpcirc,
+        min_value=450,
+        max_value=3450,
+        step=50,
+        attribute_key=SPEED_ATTR,
+        name="+ RPM (Pool Circuit)",
+        unit_of_measurement=CONST_RPM,
+        integer_only=True,
+    )
+
+    assert number.native_value == 2400
+    assert number._attr_native_unit_of_measurement == CONST_RPM
+    assert number._attr_native_min_value == 450
+    assert number._attr_native_max_value == 3450
+    assert number._attr_native_step == 50
+
+
+async def test_number_pmpcirc_gpm_properties(
+    hass: HomeAssistant,
+    pool_object_pmpcirc: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test PoolNumber entity properties for pump GPM setpoint."""
+    from custom_components.intellicenter.const import CONST_GPM
+
+    number = PoolNumber(
+        mock_coordinator,
+        pool_object_pmpcirc,
+        min_value=15,
+        max_value=140,
+        step=5,
+        attribute_key=GPM_ATTR,
+        name="+ GPM (Pool Circuit)",
+        unit_of_measurement=CONST_GPM,
+        integer_only=True,
+    )
+
+    assert number.native_value == 80
+    assert number._attr_native_unit_of_measurement == CONST_GPM
+    assert number._attr_native_min_value == 15
+    assert number._attr_native_max_value == 140
+    assert number._attr_native_step == 5
+
+
+async def test_number_pmpcirc_set_rpm(
+    hass: HomeAssistant,
+    pool_object_pmpcirc: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting pump RPM value."""
+    number = PoolNumber(
+        mock_coordinator,
+        pool_object_pmpcirc,
+        attribute_key=SPEED_ATTR,
+        integer_only=True,
+    )
+    number.hass = hass
+
+    await number.async_set_native_value(2800)
+
+    # Should use request_changes fallback with SPEED attribute
+    mock_coordinator.controller.request_changes.assert_called_once()
+    call_args = mock_coordinator.controller.request_changes.call_args
+    assert call_args[0][0] == "PMPCIRC01"
+    assert call_args[0][1] == {SPEED_ATTR: "2800"}
+
+
+async def test_number_pmpcirc_set_gpm(
+    hass: HomeAssistant,
+    pool_object_pmpcirc: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting pump GPM value."""
+    number = PoolNumber(
+        mock_coordinator,
+        pool_object_pmpcirc,
+        attribute_key=GPM_ATTR,
+        integer_only=True,
+    )
+    number.hass = hass
+
+    await number.async_set_native_value(60)
+
+    # Should use request_changes fallback with GPM attribute
+    mock_coordinator.controller.request_changes.assert_called_once()
+    call_args = mock_coordinator.controller.request_changes.call_args
+    assert call_args[0][0] == "PMPCIRC01"
+    assert call_args[0][1] == {GPM_ATTR: "60"}
+
+
+async def test_number_pmpcirc_is_updated(
+    hass: HomeAssistant,
+    pool_object_pmpcirc: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test pump circuit number isUpdated method."""
+    number = PoolNumber(
+        mock_coordinator,
+        pool_object_pmpcirc,
+        attribute_key=GPM_ATTR,
+    )
+
+    # Should update on GPM change
+    assert number.isUpdated({"PMPCIRC01": {GPM_ATTR: "100"}}) is True
+
+    # Should not update on SPEED change
+    assert number.isUpdated({"PMPCIRC01": {SPEED_ATTR: "3000"}}) is False
+
+    # Should not update on other object
+    assert number.isUpdated({"OTHER": {GPM_ATTR: "100"}}) is False
+
+
+async def test_number_pmpcirc_state_updates(
+    hass: HomeAssistant,
+    pool_object_pmpcirc: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test pump circuit number state updates from IntelliCenter."""
+    number = PoolNumber(
+        mock_coordinator,
+        pool_object_pmpcirc,
+        attribute_key=GPM_ATTR,
+        integer_only=True,
+    )
+
+    # Initial value
+    assert number.native_value == 80
+
+    # Simulate update from IntelliCenter
+    updates = {"PMPCIRC01": {GPM_ATTR: "100"}}
+    assert number.isUpdated(updates) is True
+
+    # Apply the update
+    pool_object_pmpcirc.update(updates["PMPCIRC01"])
+
+    # Verify value changed
+    assert number.native_value == 100


### PR DESCRIPTION
## Summary

This PR adds support for controlling pump speed (RPM) and flow (GPM) on variable speed pumps via the PMPCIRC (Pump Circuit) objects.

- Added PMPCIRC_TYPE tracking to coordinator's DEFAULT_ATTRIBUTES_MAP
- Added number entities for pump RPM and GPM setpoints per circuit
- Limits are automatically read from parent pump's MIN/MAX/MINF/MAXF attributes
- Supports SPEED (RPM only), FLOW (GPM only), and VSF (both) pump types
- Added 7 new tests for pump speed control functionality (182 total tests passing)

## Related Issue

Fixes #19

## Test Plan

- [x] Unit tests for pump speed/GPM number entities
- [x] Tests for entity creation based on pump type
- [x] Tests for setting values via `request_changes()`
- [x] Tests for state updates from IntelliCenter
- [ ] Manual testing with physical VSF pump (requested from reporter)

## Sample Automation (for testing)

```yaml
automation:
  - alias: "Pool pump - morning high flow"
    trigger:
      - platform: time
        at: "10:00:00"
    action:
      - service: number.set_value
        target:
          entity_id: number.pool_pump_gpm_pool
        data:
          value: 80

  - alias: "Pool pump - afternoon medium flow"
    trigger:
      - platform: time
        at: "14:00:00"
    action:
      - service: number.set_value
        target:
          entity_id: number.pool_pump_gpm_pool
        data:
          value: 60

  - alias: "Pool pump - night low flow"
    trigger:
      - platform: time
        at: "19:00:00"
    action:
      - service: number.set_value
        target:
          entity_id: number.pool_pump_gpm_pool
        data:
          value: 20
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)