### PR TITLE
fix: Remove restrictive pump subtype checks for PMPCIRC entities

### DIFF
--- a/custom_components/intellicenter/number.py
+++ b/custom_components/intellicenter/number.py
@@ -46,7 +46,6 @@ from pyintellicenter import (
     PRIM_ATTR,
     SEC_ATTR,
     SPEED_ATTR,
-    SUBTYP_ATTR,
     PoolObject,
 )
 
@@ -263,9 +262,6 @@ async def async_setup_entry(
             circuit = coordinator.model[circuit_objnam] if circuit_objnam else None
             circuit_name = circuit.sname if circuit else circuit_objnam
 
-            # Determine pump type (SPEED=RPM only, FLOW=GPM only, VSF=both)
-            pump_subtype = parent_pump[SUBTYP_ATTR] if parent_pump else None
-
             # Get limits from parent pump, with defaults
             rpm_min = PUMP_RPM_MIN_DEFAULT
             rpm_max = PUMP_RPM_MAX_DEFAULT
@@ -298,13 +294,9 @@ async def async_setup_entry(
                     except (ValueError, TypeError):
                         pass
 
-            # Create RPM setpoint entity if pump supports speed control
-            if SPEED_ATTR in pool_obj.attribute_keys and pump_subtype in (
-                "SPEED",
-                "VSF",
-                "VS",
-                None,  # Default to showing if unknown
-            ):
+            # Create RPM setpoint entity if SPEED attribute exists on PMPCIRC
+            # The presence of the attribute indicates the pump circuit supports RPM control
+            if SPEED_ATTR in pool_obj.attribute_keys:
                 numbers.append(
                     PoolNumber(
                         coordinator,
@@ -322,13 +314,9 @@ async def async_setup_entry(
                     )
                 )
 
-            # Create GPM setpoint entity if pump supports flow control
-            if GPM_ATTR in pool_obj.attribute_keys and pump_subtype in (
-                "FLOW",
-                "VSF",
-                "VF",
-                None,  # Default to showing if unknown
-            ):
+            # Create GPM setpoint entity if GPM attribute exists on PMPCIRC
+            # The presence of the attribute indicates the pump circuit supports GPM control
+            if GPM_ATTR in pool_obj.attribute_keys:
                 numbers.append(
                     PoolNumber(
                         coordinator,


### PR DESCRIPTION
## Summary
- Removed restrictive pump subtype checks that prevented entity creation for pumps with unexpected subtypes
- Now creates RPM entity if SPEED_ATTR exists on PMPCIRC, GPM entity if GPM_ATTR exists
- This is more robust since attribute presence directly indicates the pump circuit's capabilities

## Problem
The previous implementation checked the parent pump's `SUBTYP` to determine whether to create RPM/GPM entities. This was too restrictive and failed for pumps with subtypes that weren't in the allowed lists (e.g., if the subtype was "3VSF" instead of "VSF").

## Solution
Trust the PMPCIRC object itself. If it has `SPEED_ATTR`, create an RPM entity. If it has `GPM_ATTR`, create a GPM entity. The limits are still correctly pulled from the parent pump's MIN/MAX (for RPM) and MINF/MAXF (for GPM) attributes.

## Test plan
- [x] All 182 tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [ ] Manual testing on reporter's Intelliflow 3 VSF pump (pending)

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)