### PR TITLE
feat: Add climate entity for UltraTemp heat pump cooling support

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -45,6 +45,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 # Platforms supported by this integration
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
     Platform.COVER,
     Platform.LIGHT,
     Platform.NUMBER,

--- a/custom_components/intellicenter/climate.py
+++ b/custom_components/intellicenter/climate.py
@@ -1,0 +1,262 @@
+"""Pentair IntelliCenter climate entities for pool/spa temperature control.
+
+This module provides climate entities for bodies of water (pool/spa) that have
+heat pumps capable of both heating AND cooling (UltraTemp systems). For bodies
+with heating-only equipment (gas heaters, solar), use the water_heater entity.
+
+Climate entities support:
+- Dual setpoints (heating and cooling)
+- HVAC modes: heat, cool, heat_cool, off
+- Current temperature monitoring
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pyintellicenter import (
+    BODY_ATTR,
+    BODY_TYPE,
+    HEATER_ATTR,
+    HEATER_TYPE,
+    HITMP_ATTR,
+    HTMODE_ATTR,
+    LISTORD_ATTR,
+    LOTMP_ATTR,
+    LSTTMP_ATTR,
+    NULL_OBJNAM,
+    STATUS_ATTR,
+    STATUS_OFF,
+    PoolObject,
+)
+
+from . import IntelliCenterConfigEntry, PoolEntity
+from .coordinator import IntelliCenterCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Coordinator handles updates via push, so no parallel update limit needed
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up climate entities for bodies with cooling support."""
+    coordinator = entry.runtime_data
+
+    # Find all heaters sorted by UI order
+    heaters = sorted(
+        coordinator.model.get_by_type(HEATER_TYPE),
+        key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
+    )
+
+    bodies = coordinator.model.get_by_type(BODY_TYPE)
+
+    climate_entities = []
+    body: PoolObject
+    for body in bodies:
+        # Check if this body supports cooling (has UltraTemp heat pump)
+        if not coordinator.controller.body_supports_cooling(body.objnam):
+            continue
+
+        # Build list of heaters that support this body
+        heater_list = []
+        heater: PoolObject
+        for heater in heaters:
+            if body.objnam in heater[BODY_ATTR].split(" "):
+                heater_list.append(heater.objnam)
+
+        if heater_list:
+            climate_entities.append(PoolClimate(coordinator, body, heater_list))
+
+    async_add_entities(climate_entities)
+
+
+class PoolClimate(PoolEntity, ClimateEntity):
+    """Climate entity for pool/spa with heating and cooling support.
+
+    This entity is created for bodies of water that have UltraTemp heat pumps,
+    which can both heat and cool water. It exposes dual setpoints:
+    - target_temperature_low: Heating setpoint (LOTMP) - heat UP to this temp
+    - target_temperature_high: Cooling setpoint (HITMP) - cool DOWN to this temp
+    """
+
+    _attr_icon = "mdi:thermometer-water"
+    _enable_turn_on_off_backwards_compat = False
+
+    def __init__(
+        self,
+        coordinator: IntelliCenterCoordinator,
+        pool_object: PoolObject,
+        heater_list: list[str],
+    ) -> None:
+        """Initialize the climate entity."""
+        super().__init__(
+            coordinator,
+            pool_object,
+            extra_state_attributes=[HEATER_ATTR, HTMODE_ATTR],
+        )
+        self._heater_list = heater_list
+        self._attr_hvac_modes = [
+            HVACMode.OFF,
+            HVACMode.HEAT,
+            HVACMode.COOL,
+            HVACMode.HEAT_COOL,
+        ]
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        base_id = super().unique_id
+        return f"{base_id}_climate"
+
+    @property
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return the list of supported features."""
+        return (
+            ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement."""
+        return self.pentairTemperatureSettings()
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum temperature."""
+        system_info = self.coordinator.system_info
+        return 5.0 if system_info and system_info.uses_metric else 40.0
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum temperature."""
+        system_info = self.coordinator.system_info
+        return 40.0 if system_info and system_info.uses_metric else 104.0
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current water temperature."""
+        return self._safe_float_conversion(self._pool_object[LSTTMP_ATTR])
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the heating setpoint (temperature to heat UP to)."""
+        return self._safe_float_conversion(self._pool_object[LOTMP_ATTR])
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the cooling setpoint (temperature to cool DOWN to)."""
+        return self._safe_float_conversion(self._pool_object[HITMP_ATTR])
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the current HVAC mode."""
+        status = self._pool_object[STATUS_ATTR]
+        heater = self._pool_object[HEATER_ATTR]
+
+        # If body is off or no heater assigned, mode is OFF
+        if status == STATUS_OFF or heater == NULL_OBJNAM:
+            return HVACMode.OFF
+
+        # Check the heat mode to determine if heating/cooling is enabled
+        htmode = self._pool_object[HTMODE_ATTR]
+        if htmode == "0":
+            return HVACMode.OFF
+
+        # When heater is active, default to heat_cool mode
+        # IntelliCenter manages the actual heating vs cooling decision
+        return HVACMode.HEAT_COOL
+
+    @property
+    def hvac_action(self) -> HVACAction:
+        """Return the current HVAC action."""
+        status = self._pool_object[STATUS_ATTR]
+        heater = self._pool_object[HEATER_ATTR]
+
+        if status == STATUS_OFF or heater == NULL_OBJNAM:
+            return HVACAction.OFF
+
+        htmode = self._pool_object[HTMODE_ATTR]
+        if htmode == "0":
+            return HVACAction.IDLE
+
+        # Check if actively heating
+        if self._controller.is_body_heating(self._pool_object.objnam):
+            return HVACAction.HEATING
+
+        # Could add cooling detection here if IntelliCenter exposes it
+        # For now, return IDLE when heater is enabled but not actively heating
+        return HVACAction.IDLE
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set the HVAC mode."""
+        if hvac_mode == HVACMode.OFF:
+            self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+        else:
+            # Turn on heating/cooling by selecting the first available heater
+            if self._heater_list:
+                self.request_changes({HEATER_ATTR: self._heater_list[0]})
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperatures."""
+        low_temp = kwargs.get(ATTR_TEMPERATURE + "_low")
+        high_temp = kwargs.get(ATTR_TEMPERATURE + "_high")
+
+        if low_temp is not None:
+            try:
+                temp_value = int(low_temp)
+                await self._controller.set_heating_setpoint(
+                    self._pool_object.objnam, temp_value
+                )
+            except (ValueError, TypeError):
+                _LOGGER.exception("Invalid heating setpoint value '%s'", low_temp)
+
+        if high_temp is not None:
+            try:
+                temp_value = int(high_temp)
+                await self._controller.set_cooling_setpoint(
+                    self._pool_object.objnam, temp_value
+                )
+            except (ValueError, TypeError):
+                _LOGGER.exception("Invalid cooling setpoint value '%s'", high_temp)
+
+    async def async_turn_on(self) -> None:
+        """Turn on the climate entity."""
+        if self._heater_list:
+            self.request_changes({HEATER_ATTR: self._heater_list[0]})
+
+    async def async_turn_off(self) -> None:
+        """Turn off the climate entity."""
+        self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+
+    def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
+        """Return true if the entity is updated."""
+        my_updates = updates.get(self._pool_object.objnam, {})
+        return bool(
+            my_updates
+            and {
+                STATUS_ATTR,
+                HEATER_ATTR,
+                HTMODE_ATTR,
+                LOTMP_ATTR,
+                HITMP_ATTR,
+                LSTTMP_ATTR,
+            }
+            & my_updates.keys()
+        )

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.10"],
-  "version": "3.6.1",
+  "requirements": ["pyintellicenter>=0.1.12"],
+  "version": "3.7.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,6 +413,13 @@ def mock_coordinator(
     mock_controller.get_cyanuric_acid = MagicMock(return_value=40)
     # Pump circuit speed helper - default to None, tests can override return_value
     mock_controller.get_pump_circuit_speed = MagicMock(return_value=None)
+    # Cooling support detection - default to False (no cooling support)
+    mock_controller.body_supports_cooling = MagicMock(return_value=False)
+    # Heating/cooling setpoint methods
+    mock_controller.set_heating_setpoint = AsyncMock()
+    mock_controller.set_cooling_setpoint = AsyncMock()
+    # Body heating detection
+    mock_controller.is_body_heating = MagicMock(return_value=False)
     mock_coord.controller = mock_controller
 
     # Configure system info

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,636 @@
+"""Test the Pentair IntelliCenter climate platform."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.climate import (
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from pyintellicenter import (
+    BODY_TYPE,
+    HEATER_ATTR,
+    HEATER_TYPE,
+    HITMP_ATTR,
+    HTMODE_ATTR,
+    LOTMP_ATTR,
+    LSTTMP_ATTR,
+    NULL_OBJNAM,
+    STATUS_ATTR,
+    PoolModel,
+    PoolObject,
+)
+import pytest
+
+from custom_components.intellicenter.climate import PoolClimate
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def pool_object_body_with_ultratemp() -> PoolObject:
+    """Return a PoolObject representing a pool body with UltraTemp heat pump."""
+    return PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SUBTYP": "POOL",
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "LSTTMP": "78",
+            "LOTMP": "72",
+            "HITMP": "85",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+        },
+    )
+
+
+@pytest.fixture
+def pool_object_ultratemp_heater() -> PoolObject:
+    """Return a PoolObject representing an UltraTemp heat pump."""
+    return PoolObject(
+        "HTR01",
+        {
+            "OBJTYP": HEATER_TYPE,
+            "SUBTYP": "ULTRA",
+            "SNAME": "UltraTemp",
+            "BODY": "POOL1 SPA01",
+            "LISTORD": "1",
+        },
+    )
+
+
+async def test_climate_setup_creates_entities_only_for_cooling_capable(
+    hass: HomeAssistant,
+    pool_model: PoolModel,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test climate platform only creates entities for bodies with cooling support."""
+    mock_coordinator.model = pool_model
+
+    # Mock body_supports_cooling: Pool supports cooling, Spa does not
+    mock_coordinator.controller.body_supports_cooling = MagicMock(
+        side_effect=lambda objnam: objnam == "POOL1"
+    )
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.climate import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    # Should only create climate entity for Pool (has cooling support)
+    assert len(entities_added) == 1
+    assert entities_added[0]._pool_object.objnam == "POOL1"
+
+
+async def test_climate_setup_no_entities_when_no_cooling_support(
+    hass: HomeAssistant,
+    pool_model: PoolModel,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test climate platform creates no entities when no cooling support."""
+    mock_coordinator.model = pool_model
+
+    # Mock body_supports_cooling: No bodies support cooling
+    mock_coordinator.controller.body_supports_cooling = MagicMock(return_value=False)
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.climate import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    # Should create no climate entities
+    assert len(entities_added) == 0
+
+
+async def test_climate_entity_properties(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    pool_object_ultratemp_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test PoolClimate entity properties."""
+    mock_coordinator.controller.request_changes = AsyncMock()
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_ultratemp_heater
+    )
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    # Test properties
+    assert climate.name == "Pool"
+    assert climate.unique_id == "test_entry_POOL1_climate"
+    assert climate.current_temperature == 78.0
+    assert climate.target_temperature_low == 72.0  # Heating setpoint
+    assert climate.target_temperature_high == 85.0  # Cooling setpoint
+    assert climate.temperature_unit == str(UnitOfTemperature.FAHRENHEIT)
+
+
+async def test_climate_hvac_modes(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test climate HVAC modes."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    # Check available HVAC modes
+    assert HVACMode.OFF in climate.hvac_modes
+    assert HVACMode.HEAT in climate.hvac_modes
+    assert HVACMode.COOL in climate.hvac_modes
+    assert HVACMode.HEAT_COOL in climate.hvac_modes
+
+
+async def test_climate_hvac_mode_heat_cool_when_active(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC mode is heat_cool when heater is active."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    # Body is ON, heater is assigned, htmode is 1
+    assert climate.hvac_mode == HVACMode.HEAT_COOL
+
+
+async def test_climate_hvac_mode_off_when_body_off(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC mode is off when body is off."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "OFF",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "LOTMP": "72",
+            "HITMP": "85",
+            "LSTTMP": "78",
+        },
+    )
+
+    climate = PoolClimate(mock_coordinator, body, ["HTR01"])
+
+    assert climate.hvac_mode == HVACMode.OFF
+
+
+async def test_climate_hvac_mode_off_when_no_heater(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC mode is off when no heater assigned."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "HITMP": "85",
+            "LSTTMP": "78",
+        },
+    )
+
+    climate = PoolClimate(mock_coordinator, body, ["HTR01"])
+
+    assert climate.hvac_mode == HVACMode.OFF
+
+
+async def test_climate_hvac_action_heating(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC action is heating when actively heating."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+    mock_coordinator.controller.is_body_heating = MagicMock(return_value=True)
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    assert climate.hvac_action == HVACAction.HEATING
+
+
+async def test_climate_hvac_action_idle(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC action is idle when heater enabled but not heating."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+    mock_coordinator.controller.is_body_heating = MagicMock(return_value=False)
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    assert climate.hvac_action == HVACAction.IDLE
+
+
+async def test_climate_hvac_action_off(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC action is off when body is off."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "OFF",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "LOTMP": "72",
+            "HITMP": "85",
+            "LSTTMP": "78",
+        },
+    )
+
+    climate = PoolClimate(mock_coordinator, body, ["HTR01"])
+
+    assert climate.hvac_action == HVACAction.OFF
+
+
+async def test_climate_set_hvac_mode_off(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting HVAC mode to off."""
+    mock_coordinator.controller.request_changes = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+    climate.hass = hass
+
+    await climate.async_set_hvac_mode(HVACMode.OFF)
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+
+
+async def test_climate_set_hvac_mode_heat_cool(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting HVAC mode to heat_cool."""
+    mock_coordinator.controller.request_changes = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+    climate.hass = hass
+
+    await climate.async_set_hvac_mode(HVACMode.HEAT_COOL)
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert args[1][HEATER_ATTR] == "HTR01"
+
+
+async def test_climate_set_temperature_heating(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting heating setpoint."""
+    mock_coordinator.controller.set_heating_setpoint = AsyncMock()
+    mock_coordinator.controller.set_cooling_setpoint = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+    climate.hass = hass
+
+    await climate.async_set_temperature(temperature_low=75)
+
+    mock_coordinator.controller.set_heating_setpoint.assert_called_once_with(
+        "POOL1", 75
+    )
+    mock_coordinator.controller.set_cooling_setpoint.assert_not_called()
+
+
+async def test_climate_set_temperature_cooling(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting cooling setpoint."""
+    mock_coordinator.controller.set_heating_setpoint = AsyncMock()
+    mock_coordinator.controller.set_cooling_setpoint = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+    climate.hass = hass
+
+    await climate.async_set_temperature(temperature_high=88)
+
+    mock_coordinator.controller.set_cooling_setpoint.assert_called_once_with(
+        "POOL1", 88
+    )
+    mock_coordinator.controller.set_heating_setpoint.assert_not_called()
+
+
+async def test_climate_set_temperature_both(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setting both heating and cooling setpoints."""
+    mock_coordinator.controller.set_heating_setpoint = AsyncMock()
+    mock_coordinator.controller.set_cooling_setpoint = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+    climate.hass = hass
+
+    await climate.async_set_temperature(temperature_low=75, temperature_high=88)
+
+    mock_coordinator.controller.set_heating_setpoint.assert_called_once_with(
+        "POOL1", 75
+    )
+    mock_coordinator.controller.set_cooling_setpoint.assert_called_once_with(
+        "POOL1", 88
+    )
+
+
+async def test_climate_turn_on(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test turning on the climate entity."""
+    mock_coordinator.controller.request_changes = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "HITMP": "85",
+            "LSTTMP": "78",
+        },
+    )
+
+    climate = PoolClimate(mock_coordinator, body, ["HTR01"])
+    climate.hass = hass
+
+    await climate.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert args[1][HEATER_ATTR] == "HTR01"
+
+
+async def test_climate_turn_off(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test turning off the climate entity."""
+    mock_coordinator.controller.request_changes = AsyncMock()
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+    climate.hass = hass
+
+    await climate.async_turn_off()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+
+
+async def test_climate_supported_features(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test supported features."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    features = climate.supported_features
+
+    assert features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    assert features & ClimateEntityFeature.TURN_ON
+    assert features & ClimateEntityFeature.TURN_OFF
+
+
+async def test_climate_min_max_temp_fahrenheit(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test min/max temperature in Fahrenheit."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    assert climate.min_temp == 40.0
+    assert climate.max_temp == 104.0
+
+
+async def test_climate_min_max_temp_celsius(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test min/max temperature in Celsius."""
+    type(mock_coordinator.system_info).uses_metric = property(lambda self: True)
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    assert climate.min_temp == 5.0
+    assert climate.max_temp == 40.0
+
+
+async def test_climate_is_updated(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test isUpdated method for relevant attributes."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    # Should update on status change
+    assert climate.isUpdated({"POOL1": {STATUS_ATTR: "ON"}}) is True
+
+    # Should update on heater change
+    assert climate.isUpdated({"POOL1": {HEATER_ATTR: "HTR01"}}) is True
+
+    # Should update on htmode change
+    assert climate.isUpdated({"POOL1": {HTMODE_ATTR: "1"}}) is True
+
+    # Should update on heating setpoint change
+    assert climate.isUpdated({"POOL1": {LOTMP_ATTR: "75"}}) is True
+
+    # Should update on cooling setpoint change
+    assert climate.isUpdated({"POOL1": {HITMP_ATTR: "88"}}) is True
+
+    # Should update on current temperature change
+    assert climate.isUpdated({"POOL1": {LSTTMP_ATTR: "80"}}) is True
+
+    # Should not update on unrelated object
+    assert climate.isUpdated({"OTHER": {STATUS_ATTR: "ON"}}) is False
+
+    # Should not update on unrelated attribute
+    assert climate.isUpdated({"POOL1": {"UNRELATED": "value"}}) is False


### PR DESCRIPTION
## Summary
Add climate platform for bodies of water with UltraTemp heat pumps that support both heating AND cooling. Bodies with heating-only equipment (gas heaters, solar) continue to use the water_heater entity.

## New Climate Entity Features
- **Dual setpoints**: `target_temperature_low` (heating - LOTMP), `target_temperature_high` (cooling - HITMP)
- **HVAC modes**: off, heat, cool, heat_cool
- **HVAC actions**: off, idle, heating (based on actual heating state)
- **Turn on/off support**
- **Temperature range**: 40-104°F or 5-40°C

## Changes
- Add `climate.py` platform for UltraTemp-equipped bodies
- Add `Platform.CLIMATE` to PLATFORMS list in `__init__.py`
- Update `manifest.json` to require `pyintellicenter>=0.1.12`
- Bump version to 3.7.0
- Add 21 new tests for climate entity (`test_climate.py`)
- Update `conftest.py` with cooling-related mock methods

## Detection Logic
Climate entities are only created for bodies where `controller.body_supports_cooling(body_objnam)` returns True, which checks if the heater has `SUBTYP="ULTRA"` (UltraTemp heat pump).

## Dependencies
- Requires pyintellicenter v0.1.12+ which adds `body_supports_cooling()` method (see joyfulhouse/pyintellicenter#17)

## Test plan
- [x] All 215 tests pass (194 existing + 21 new climate tests)
- [x] mypy strict mode passes
- [x] ruff lint/format passes

Closes #24

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)