### PR TITLE
feat: Add HVACAction.COOLING detection for climate entity

### DIFF
--- a/custom_components/intellicenter/climate.py
+++ b/custom_components/intellicenter/climate.py
@@ -200,8 +200,11 @@ class PoolClimate(PoolEntity, ClimateEntity):
         if self._controller.is_body_heating(self._pool_object.objnam):
             return HVACAction.HEATING
 
-        # Could add cooling detection here if IntelliCenter exposes it
-        # For now, return IDLE when heater is enabled but not actively heating
+        # Check if actively cooling (UltraTemp heat pump)
+        if self._controller.is_body_cooling(self._pool_object.objnam):
+            return HVACAction.COOLING
+
+        # Heater is enabled but not actively heating or cooling
         return HVACAction.IDLE
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.12"],
-  "version": "3.7.0",
+  "requirements": ["pyintellicenter>=0.1.13"],
+  "version": "3.7.1",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,6 +420,8 @@ def mock_coordinator(
     mock_controller.set_cooling_setpoint = AsyncMock()
     # Body heating detection
     mock_controller.is_body_heating = MagicMock(return_value=False)
+    # Body cooling detection
+    mock_controller.is_body_cooling = MagicMock(return_value=False)
     mock_coord.controller = mock_controller
 
     # Configure system info

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -278,17 +278,40 @@ async def test_climate_hvac_action_heating(
     assert climate.hvac_action == HVACAction.HEATING
 
 
-async def test_climate_hvac_action_idle(
+async def test_climate_hvac_action_cooling(
     hass: HomeAssistant,
     pool_object_body_with_ultratemp: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test HVAC action is idle when heater enabled but not heating."""
+    """Test HVAC action is cooling when actively cooling."""
     mock_coordinator.controller.system_info = MagicMock()
     type(mock_coordinator.controller.system_info).uses_metric = property(
         lambda self: False
     )
     mock_coordinator.controller.is_body_heating = MagicMock(return_value=False)
+    mock_coordinator.controller.is_body_cooling = MagicMock(return_value=True)
+
+    climate = PoolClimate(
+        mock_coordinator,
+        pool_object_body_with_ultratemp,
+        ["HTR01"],
+    )
+
+    assert climate.hvac_action == HVACAction.COOLING
+
+
+async def test_climate_hvac_action_idle(
+    hass: HomeAssistant,
+    pool_object_body_with_ultratemp: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HVAC action is idle when heater enabled but not heating or cooling."""
+    mock_coordinator.controller.system_info = MagicMock()
+    type(mock_coordinator.controller.system_info).uses_metric = property(
+        lambda self: False
+    )
+    mock_coordinator.controller.is_body_heating = MagicMock(return_value=False)
+    mock_coordinator.controller.is_body_cooling = MagicMock(return_value=False)
 
     climate = PoolClimate(
         mock_coordinator,


### PR DESCRIPTION
## Summary
- Adds `HVACAction.COOLING` detection to the climate entity using `is_body_cooling()` from pyintellicenter v0.1.13
- Updates pyintellicenter dependency to `>=0.1.13`
- Adds new test for cooling HVAC action
- Bumps integration version to 3.7.1

## What Changed
The climate entity now properly detects when an UltraTemp heat pump is actively cooling the pool/spa and displays `HVACAction.COOLING` instead of `HVACAction.IDLE`.

## Related PRs
- pyintellicenter PR #18: Added `is_body_cooling()` method

## Test Plan
- [x] All 216 tests pass
- [x] New test for `HVACAction.COOLING` added
- [x] mypy type checking passes
- [x] ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)