### PR TITLE
feat: Improve climate entity with preset modes and simplified HVAC modes (v3.6.3)

### DIFF
--- a/custom_components/intellicenter/climate.py
+++ b/custom_components/intellicenter/climate.py
@@ -6,7 +6,8 @@ with heating-only equipment (gas heaters, solar), use the water_heater entity.
 
 Climate entities support:
 - Dual setpoints (heating and cooling)
-- HVAC modes: heat, cool, heat_cool, off
+- HVAC modes: off and heat_cool (system auto-manages heating vs cooling)
+- Preset modes: Heater selection (e.g., "Heater", "UltraTemp Preferred", "UltraTemp Only")
 - Current temperature monitoring
 """
 
@@ -16,12 +17,13 @@ import logging
 from typing import Any
 
 from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
@@ -110,12 +112,7 @@ class PoolClimate(PoolEntity, ClimateEntity):
             extra_state_attributes=[HEATER_ATTR, HTMODE_ATTR],
         )
         self._heater_list = heater_list
-        self._attr_hvac_modes = [
-            HVACMode.OFF,
-            HVACMode.HEAT,
-            HVACMode.COOL,
-            HVACMode.HEAT_COOL,
-        ]
+        self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL]
 
     @property
     def unique_id(self) -> str:
@@ -130,6 +127,7 @@ class PoolClimate(PoolEntity, ClimateEntity):
             ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
             | ClimateEntityFeature.TURN_ON
             | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.PRESET_MODE
         )
 
     @property
@@ -167,21 +165,35 @@ class PoolClimate(PoolEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return the current HVAC mode."""
-        status = self._pool_object[STATUS_ATTR]
         heater = self._pool_object[HEATER_ATTR]
 
-        # If body is off or no heater assigned, mode is OFF
-        if status == STATUS_OFF or heater == NULL_OBJNAM:
+        # Mode is OFF when no heater is assigned
+        # Mode is HEAT_COOL when a heater is assigned (system decides heating vs cooling)
+        # Whether actively heating/cooling is shown via hvac_action property
+        if heater == NULL_OBJNAM:
             return HVACMode.OFF
 
-        # Check the heat mode to determine if heating/cooling is enabled
-        htmode = self._pool_object[HTMODE_ATTR]
-        if htmode == "0":
-            return HVACMode.OFF
-
-        # When heater is active, default to heat_cool mode
-        # IntelliCenter manages the actual heating vs cooling decision
         return HVACMode.HEAT_COOL
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode (selected heater)."""
+        heater = self._pool_object[HEATER_ATTR]
+        if heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and heater_obj.sname is not None:
+                return str(heater_obj.sname)
+        return None
+
+    @property
+    def preset_modes(self) -> list[str]:
+        """Return the list of available preset modes (heater options)."""
+        presets: list[str] = []
+        for heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and heater_obj.sname is not None:
+                presets.append(heater_obj.sname)
+        return presets
 
     @property
     def hvac_action(self) -> HVACAction:
@@ -212,14 +224,27 @@ class PoolClimate(PoolEntity, ClimateEntity):
         if hvac_mode == HVACMode.OFF:
             self.request_changes({HEATER_ATTR: NULL_OBJNAM})
         else:
-            # Turn on heating/cooling by selecting the first available heater
-            if self._heater_list:
+            # Turn on heating/cooling by selecting the current or first available heater
+            current_heater = self._pool_object[HEATER_ATTR]
+            if current_heater and current_heater in self._heater_list:
+                # Keep current heater selection
+                self.request_changes({HEATER_ATTR: current_heater})
+            elif self._heater_list:
+                # Select first heater if no current selection
                 self.request_changes({HEATER_ATTR: self._heater_list[0]})
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode (heater selection)."""
+        for heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and preset_mode == heater_obj.sname:
+                self.request_changes({HEATER_ATTR: heater})
+                break
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
-        low_temp = kwargs.get(ATTR_TEMPERATURE + "_low")
-        high_temp = kwargs.get(ATTR_TEMPERATURE + "_high")
+        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
         if low_temp is not None:
             try:

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,8 +8,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.13"],
-  "version": "3.6.2",
+  "requirements": ["pyintellicenter>=0.1.14"],
+  "version": "3.6.3",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -171,11 +171,10 @@ async def test_climate_hvac_modes(
         ["HTR01"],
     )
 
-    # Check available HVAC modes
+    # Check available HVAC modes (only OFF and HEAT_COOL - system manages heat vs cool)
     assert HVACMode.OFF in climate.hvac_modes
-    assert HVACMode.HEAT in climate.hvac_modes
-    assert HVACMode.COOL in climate.hvac_modes
     assert HVACMode.HEAT_COOL in climate.hvac_modes
+    assert len(climate.hvac_modes) == 2
 
 
 async def test_climate_hvac_mode_heat_cool_when_active(
@@ -199,11 +198,15 @@ async def test_climate_hvac_mode_heat_cool_when_active(
     assert climate.hvac_mode == HVACMode.HEAT_COOL
 
 
-async def test_climate_hvac_mode_off_when_body_off(
+async def test_climate_hvac_mode_heat_cool_when_heater_assigned(
     hass: HomeAssistant,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test HVAC mode is off when body is off."""
+    """Test HVAC mode is heat_cool when heater is assigned, even if body is off.
+
+    The hvac_mode reflects whether climate control is enabled (heater assigned),
+    while hvac_action reflects actual heating/cooling state.
+    """
     mock_coordinator.controller.system_info = MagicMock()
     type(mock_coordinator.controller.system_info).uses_metric = property(
         lambda self: False
@@ -225,7 +228,9 @@ async def test_climate_hvac_mode_off_when_body_off(
 
     climate = PoolClimate(mock_coordinator, body, ["HTR01"])
 
-    assert climate.hvac_mode == HVACMode.OFF
+    # Mode is HEAT_COOL when heater is assigned (system manages heat vs cool)
+    # hvac_action will show OFF since body is off
+    assert climate.hvac_mode == HVACMode.HEAT_COOL
 
 
 async def test_climate_hvac_mode_off_when_no_heater(
@@ -425,7 +430,7 @@ async def test_climate_set_temperature_heating(
     )
     climate.hass = hass
 
-    await climate.async_set_temperature(temperature_low=75)
+    await climate.async_set_temperature(target_temp_low=75)
 
     mock_coordinator.controller.set_heating_setpoint.assert_called_once_with(
         "POOL1", 75
@@ -453,7 +458,7 @@ async def test_climate_set_temperature_cooling(
     )
     climate.hass = hass
 
-    await climate.async_set_temperature(temperature_high=88)
+    await climate.async_set_temperature(target_temp_high=88)
 
     mock_coordinator.controller.set_cooling_setpoint.assert_called_once_with(
         "POOL1", 88
@@ -481,7 +486,7 @@ async def test_climate_set_temperature_both(
     )
     climate.hass = hass
 
-    await climate.async_set_temperature(temperature_low=75, temperature_high=88)
+    await climate.async_set_temperature(target_temp_low=75, target_temp_high=88)
 
     mock_coordinator.controller.set_heating_setpoint.assert_called_once_with(
         "POOL1", 75


### PR DESCRIPTION
## Summary

This PR incorporates @scottshanafelt's climate improvements (PR #28) along with the required pyintellicenter update (v0.1.14) that fixes the `body_supports_cooling()` method.

### Changes

**Climate Entity Improvements:**
- Simplify HVAC modes to just `OFF` and `HEAT_COOL` (system auto-manages heating vs cooling)
- Add **preset modes** for heater selection (e.g., "Heater", "UltraTemp Preferred", "UltraTemp Only")
- Fix `hvac_mode` to only consider heater assignment, not body status
  - `hvac_mode` = `HEAT_COOL` when a heater is assigned (system is enabled)
  - `hvac_action` reflects actual heating/cooling/idle/off state
- Update temperature kwargs to use `ATTR_TARGET_TEMP_LOW`/`ATTR_TARGET_TEMP_HIGH` constants

**Dependency Update:**
- Require `pyintellicenter>=0.1.14` which fixes `body_supports_cooling()` to check ALL heaters that support a body, not just the currently assigned one
- This ensures climate entities are created even when the system is off or using a different heater

### Test Plan
- [x] All 216 tests pass
- [x] Updated tests for new HVAC mode behavior
- [x] Updated tests for new temperature kwargs
- [ ] Manual testing on physical hardware (done by @scottshanafelt)

Closes #24
Supersedes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)