### PR TITLE
fix: Decouple water heater operation from body STATUS

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.15"],
-  "version": "3.6.4",
+  "version": "3.6.5",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -180,9 +180,16 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     @property
     def current_operation(self) -> str:
-        """Return current operation."""
+        """Return current operation.
+
+        This reflects the configured heater mode, independent of whether the
+        body is currently running (STATUS). A user can pre-select a heater for
+        a body even when it's off (e.g., setting the Spa heater while in Pool
+        mode). The real-time heating activity is exposed via the heating_status
+        extra state attribute.
+        """
         heater = self._pool_object[HEATER_ATTR]
-        if self._is_heater_active and heater in self._heater_list:
+        if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
             if heater_obj is not None and heater_obj.sname is not None:
                 return str(heater_obj.sname)

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -192,12 +192,17 @@ async def test_water_heater_state_idle(
     assert water_heater.extra_state_attributes["heating_status"] == "idle"
 
 
-async def test_water_heater_state_off(
+async def test_water_heater_state_body_off_heater_configured(
     hass: HomeAssistant,
     pool_object_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test water heater state when off."""
+    """Test water heater shows configured heater even when body is off.
+
+    This is the core of issue #34 bug 1: when the system is in Pool mode,
+    the Spa body STATUS is OFF, but the user can still configure a heater
+    for the Spa. The operation mode should reflect the configured heater.
+    """
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
 
     body = PoolObject(
@@ -205,8 +210,37 @@ async def test_water_heater_state_off(
         {
             "OBJTYP": BODY_TYPE,
             "SNAME": "Pool",
-            "STATUS": "OFF",  # Body off
-            "HEATER": "HTR01",
+            "STATUS": "OFF",  # Body off (e.g., Spa while in Pool mode)
+            "HEATER": "HTR01",  # But heater is configured
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+
+    # Operation should show the configured heater, not "off"
+    assert water_heater.current_operation == "Gas Heater"
+    # But heating_status should not be present since body isn't running
+    assert "heating_status" not in water_heater.extra_state_attributes
+
+
+async def test_water_heater_state_off_no_heater_configured(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test water heater state when body is off and no heater configured."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "OFF",
+            "HEATER": NULL_OBJNAM,  # No heater configured
             "HTMODE": "0",
             "LOTMP": "72",
             "LSTTMP": "68",


### PR DESCRIPTION
## Summary

- Decouples `current_operation` from body `STATUS` so the water heater shows the configured heater name regardless of whether the body pump is running
- When a heater is configured for an inactive body (e.g., Spa heater set while in Pool mode), the operation mode now correctly shows the heater name instead of "off"
- Real-time heating activity (`heating`/`idle`) remains correctly gated by body STATUS in `extra_state_attributes`

Fixes #34

## Test plan

- [x] All 217 existing tests pass
- [x] New test: `test_water_heater_state_body_off_heater_configured` — verifies operation shows heater name when body is OFF
- [x] New test: `test_water_heater_state_off_no_heater_configured` — verifies operation shows "off" when no heater is assigned
- [x] ruff check/format clean
- [x] mypy strict passes
- [ ] Manual test: Set Spa heater while in Pool mode, verify UI shows heater name
- [ ] Manual test: Heater configured + water at setpoint → verify shows heater name (not "off")

🤖 Generated with [Claude Code](https://claude.com/claude-code)