### PR TITLE
fix: Retry setup on transient connection errors (#41)

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -8,6 +8,7 @@ It supports Zeroconf discovery and local push updates for real-time responsivene
 from __future__ import annotations
 
 from collections.abc import Iterable
+import contextlib
 import logging
 import re
 from typing import TYPE_CHECKING, Any
@@ -23,6 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyintellicenter import (
     STATUS_ATTR,
+    ICCommandError,
     ICConnectionError,
     ICModelController,
     ICTimeoutError,
@@ -93,37 +95,45 @@ async def async_setup_entry(
         transport=transport,
     )
 
+    # Only the connection attempt belongs inside the retry try/except. Keeping
+    # async_forward_entry_setups() and the listener registration outside it means a
+    # genuine platform or programming error (e.g. an unrelated OSError) surfaces as a
+    # real setup_error instead of being misclassified as a transient connection
+    # failure and retried forever.
     try:
-        # Start the connection
         await coordinator.async_start()
-
-        # Store the coordinator in the entry's runtime_data
-        entry.runtime_data = coordinator
-
-        # Set up platforms
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-        # Register update listener for options changes
-        entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
-        return True
-
     except (
-        ConnectionRefusedError,
         ICConnectionError,
         ICTimeoutError,
+        ICCommandError,
         TimeoutError,
         OSError,
     ) as err:
-        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in
-        # (every 30s with exponential backoff) instead of leaving the entry
-        # in a permanent setup_error state requiring a manual reload.
-        # Fixes issue #41: integration fails to start when HA is restarted
-        # while the IntelliCenter / its bridge is temporarily unreachable
-        # (EHOSTUNREACH, timeout, refused, etc.).
+        # async_start() registers an EVENT_HOMEASSISTANT_STOP listener and kicks off
+        # pyintellicenter's background reconnect task *before* re-raising the
+        # first-attempt error. runtime_data isn't set yet, so async_unload_entry
+        # can't reach this coordinator to clean it up. Tear it down here, otherwise
+        # every HA retry during an outage leaks another listener + reconnect loop.
+        # Best-effort: never let teardown mask the ConfigEntryNotReady below.
+        with contextlib.suppress(Exception):
+            await coordinator.async_stop()
+        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in (with
+        # exponential backoff) instead of leaving the entry in a permanent
+        # setup_error state requiring a manual reload. Fixes issue #41: the
+        # integration fails to start when HA is restarted while IntelliCenter / its
+        # bridge is temporarily unreachable (refused, timeout, EHOSTUNREACH) or still
+        # booting (a not-ready panel rejects the initial handshake with an
+        # ICCommandError, which pyintellicenter itself treats as retryable).
         raise ConfigEntryNotReady(
             f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
         ) from err
+
+    # Connection established — store the coordinator and finish setup.
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    return True
 
 
 async def async_unload_entry(

--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -23,7 +23,9 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyintellicenter import (
     STATUS_ATTR,
+    ICConnectionError,
     ICModelController,
+    ICTimeoutError,
     PoolObject,
 )
 
@@ -106,8 +108,22 @@ async def async_setup_entry(
 
         return True
 
-    except ConnectionRefusedError as err:
-        raise ConfigEntryNotReady from err
+    except (
+        ConnectionRefusedError,
+        ICConnectionError,
+        ICTimeoutError,
+        TimeoutError,
+        OSError,
+    ) as err:
+        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in
+        # (every 30s with exponential backoff) instead of leaving the entry
+        # in a permanent setup_error state requiring a manual reload.
+        # Fixes issue #41: integration fails to start when HA is restarted
+        # while the IntelliCenter / its bridge is temporarily unreachable
+        # (EHOSTUNREACH, timeout, refused, etc.).
+        raise ConfigEntryNotReady(
+            f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
+        ) from err
 
 
 async def async_unload_entry(

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.15"],
-  "version": "3.6.7-pr44",
+  "version": "3.6.6",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.15"],
-  "version": "3.6.6",
+  "version": "3.6.7-pr44",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from pyintellicenter import ICCommandError, ICConnectionError, ICTimeoutError
 import pytest
 
 from custom_components.intellicenter import (
@@ -62,21 +63,75 @@ async def test_async_setup_entry_success(
             mock_forward.assert_called_once_with(entry, PLATFORMS)
 
 
-async def test_async_setup_entry_connection_failed(hass: HomeAssistant) -> None:
-    """Test setup fails when connection is refused."""
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ConnectionRefusedError(),
+        OSError("EHOSTUNREACH"),
+        TimeoutError(),
+        ICConnectionError("connection lost"),
+        ICTimeoutError("request timed out"),
+        ICCommandError("404"),
+    ],
+)
+async def test_async_setup_entry_transient_error_retries(
+    hass: HomeAssistant, exc: Exception
+) -> None:
+    """Transient connection errors during start raise ConfigEntryNotReady.
+
+    Covers issue #41: each of these must trigger HA's retry loop instead of a
+    permanent setup_error. ICCommandError represents a reachable-but-not-ready
+    panel that rejects the initial handshake; pyintellicenter's own reconnect loop
+    treats it as retryable, so setup must too.
+    """
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     entry.data = {CONF_HOST: "192.168.1.100"}
     entry.options = {}  # No custom options, will use defaults
 
-    # Mock coordinator to raise ConnectionRefusedError on start
+    with (
+        patch.object(
+            IntelliCenterCoordinator,
+            "async_start",
+            new_callable=AsyncMock,
+            side_effect=exc,
+        ),
+        patch.object(
+            IntelliCenterCoordinator,
+            "async_stop",
+            new_callable=AsyncMock,
+        ) as mock_stop,
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, entry)
+
+    # The partially-started coordinator must be torn down on failure so its
+    # EVENT_HOMEASSISTANT_STOP listener and pyintellicenter reconnect task don't
+    # leak on every retry during an outage.
+    mock_stop.assert_awaited_once()
+
+
+async def test_async_setup_entry_unexpected_error_propagates(
+    hass: HomeAssistant,
+) -> None:
+    """A non-connection error during start is not reclassified as transient.
+
+    Only the connection attempt is inside the retry try/except, so an unrelated
+    error (here ValueError) propagates unchanged instead of being masked as
+    ConfigEntryNotReady and retried forever.
+    """
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.data = {CONF_HOST: "192.168.1.100"}
+    entry.options = {}
+
     with patch.object(
         IntelliCenterCoordinator,
         "async_start",
         new_callable=AsyncMock,
-        side_effect=ConnectionRefusedError(),
+        side_effect=ValueError("boom"),
     ):
-        with pytest.raises(ConfigEntryNotReady):
+        with pytest.raises(ValueError):
             await async_setup_entry(hass, entry)
 
 


### PR DESCRIPTION
## Summary

Closes #41.

`async_setup_entry` only caught `ConnectionRefusedError`. Any other connection failure — `EHOSTUNREACH` (Errno 113), asyncio `TimeoutError`, generic `OSError`, or pyintellicenter's own `ICConnectionError` / `ICTimeoutError` — fell through to the default handler. HA marks those entries as `setup_error`, and **HA never auto-retries `setup_error`**. So a transient network blip during HA startup (e.g. the Pentair Wireless Link bridge being briefly unreachable while HA is still booting) leaves the integration permanently broken until the user manually clicks **Reload**.

This is exactly the symptom in issue #41 and what I and others have been hitting consistently after every HA restart.

## The fix

Broaden the exception handler to also catch `ICConnectionError`, `ICTimeoutError`, `TimeoutError`, and `OSError`, and convert any of them to `ConfigEntryNotReady`. HA's built-in retry loop then kicks in (30s with exponential backoff, indefinitely), and the integration recovers on its own as soon as the network/bridge comes back.

Also includes a descriptive message containing the configured host so the **Failed to set up** tile in the UI tells the user *where* the connection is failing — not just that "something" failed.

```diff
-    except ConnectionRefusedError as err:
-        raise ConfigEntryNotReady from err
+    except (
+        ConnectionRefusedError,
+        ICConnectionError,
+        ICTimeoutError,
+        TimeoutError,
+        OSError,
+    ) as err:
+        raise ConfigEntryNotReady(
+            f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
+        ) from err
```

## Why these specific exceptions

`_connect_tcp` in pyintellicenter wraps both `TimeoutError` and `OSError` into `ICConnectionError` (connection.py L730-738), so under normal operation the exception leaking out of `coordinator.async_start()` is `ICConnectionError`. `ICTimeoutError` is the equivalent for the request layer (response timeout on an already-open session, which can happen during the initial discovery handshake). `TimeoutError` and `OSError` are kept as defensive catches in case future library changes let raw asyncio/OS exceptions leak through. `ConnectionRefusedError` is preserved for backward compatibility with the pre-existing behavior.

## Test plan

- [x] Lint: `ruff check custom_components/intellicenter/__init__.py` — passes
- [x] Format: `ruff format --check custom_components/intellicenter/__init__.py` — already formatted
- [ ] In-cluster: install fork on HA via HACS custom repository, restart HA while bridge is unreachable, observe entry enters `setup_retry` rather than `setup_error` and recovers automatically once the bridge is reachable again.