### PR TITLE
fix: Support HCOMBO multi-mode heaters (UltraTemp ETi Hybrid) via MODE_ATTR

### DIFF
--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -98,6 +98,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         HTMODE_ATTR,
         LOTMP_ATTR,
         LSTTMP_ATTR,
+        MODE_ATTR,  # Heat mode (used by multi-mode heaters like HCOMBO)
         STATUS_ATTR,
         VOL_ATTR,
     },
@@ -142,7 +143,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         # IntelliChlor sensors
         SALT_ATTR,
     },
-    HEATER_TYPE: {SNAME_ATTR, BODY_ATTR, LISTORD_ATTR},
+    HEATER_TYPE: {SNAME_ATTR, BODY_ATTR, LISTORD_ATTR, SUBTYP_ATTR},
     PUMP_TYPE: {
         SNAME_ATTR,
         STATUS_ATTR,

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -3,6 +3,11 @@
 This module provides water heater entities for pool and spa heating control.
 Supports multiple heater types (gas, solar, heat pump) and remembers the
 last used heater for convenient turn-on operations.
+
+Multi-mode heaters (subtype HCOMBO, e.g. Pentair UltraTemp ETi Hybrid) require
+MODE-based control instead of HEATER assignment. IntelliCenter ignores HEATER
+attribute changes for HCOMBO heaters; the body's MODE attribute must be set to
+a HeaterType value (e.g. HYBRID_DUAL=10) to activate heating.
 """
 
 from __future__ import annotations
@@ -27,14 +32,19 @@ from pyintellicenter import (
     LISTORD_ATTR,
     LOTMP_ATTR,
     LSTTMP_ATTR,
+    MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
     STATUS_OFF,
+    HeaterType,
     PoolObject,
 )
 
 from . import IntelliCenterConfigEntry, PoolEntity
 from .coordinator import IntelliCenterCoordinator
+
+# IntelliCenter subtype for multi-mode combo heaters (e.g. UltraTemp ETi Hybrid)
+_HCOMBO_SUBTYPE = "HCOMBO"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,14 +110,27 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         )
         self._heater_list = heater_list
         self._last_heater: str | None = self._pool_object[HEATER_ATTR]
+        self._is_multimode: bool = self._detect_multimode()
+
+    def _detect_multimode(self) -> bool:
+        """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
+        for heater_id in self._heater_list:
+            heater_obj = self.coordinator.model[heater_id]
+            if heater_obj is not None and heater_obj.subtype == _HCOMBO_SUBTYPE:
+                return True
+        return False
 
     @property
     def _is_heater_active(self) -> bool:
-        """Return True if the body is on and a heater is assigned."""
-        return bool(
-            self._pool_object[STATUS_ATTR] != STATUS_OFF
-            and self._pool_object[HEATER_ATTR] != NULL_OBJNAM
-        )
+        """Return True if the body is on and a heater is assigned or mode is active."""
+        if self._pool_object[STATUS_ATTR] == STATUS_OFF:
+            return False
+        if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
+            return True
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            return bool(mode and mode not in ("0", "1"))
+        return False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -187,12 +210,21 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         a body even when it's off (e.g., setting the Spa heater while in Pool
         mode). The real-time heating activity is exposed via the heating_status
         extra state attribute.
+
+        For multi-mode (HCOMBO) heaters, operation is controlled via MODE_ATTR
+        on the body rather than HEATER_ATTR assignment.
         """
         heater = self._pool_object[HEATER_ATTR]
         if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
             if heater_obj is not None and heater_obj.sname is not None:
                 return str(heater_obj.sname)
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            if mode and mode not in ("0", "1"):
+                heater_obj = self.coordinator.model[self._heater_list[0]]
+                if heater_obj is not None and heater_obj.sname is not None:
+                    return str(heater_obj.sname)
         return str(STATE_OFF)
 
     @property
@@ -209,6 +241,8 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Set new target operation mode."""
         if operation_mode == STATE_OFF:
             self._turn_off()
+        elif self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
         else:
             for heater in self._heater_list:
                 heater_obj = self.coordinator.model[heater]
@@ -218,12 +252,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        heater = (
-            self._last_heater
-            if self._last_heater and self._last_heater != NULL_OBJNAM
-            else self._heater_list[0]
-        )
-        self.request_changes({HEATER_ATTR: heater})
+        if self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
+        else:
+            heater = (
+                self._last_heater
+                if self._last_heater and self._last_heater != NULL_OBJNAM
+                else self._heater_list[0]
+            )
+            self.request_changes({HEATER_ATTR: heater})
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
@@ -231,12 +268,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     def _turn_off(self) -> None:
         """Turn off the water heater."""
-        self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+        if self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.OFF.value)})
+        else:
+            self.request_changes({HEATER_ATTR: NULL_OBJNAM})
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
         updated = self._check_attributes_updated(
-            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR
+            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR, MODE_ATTR
         )
 
         if updated and self._pool_object[HEATER_ATTR] != NULL_OBJNAM:

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -16,8 +16,10 @@ from pyintellicenter import (
     HEATER_ATTR,
     HEATER_TYPE,
     HTMODE_ATTR,
+    HeaterType,
     LOTMP_ATTR,
     LSTTMP_ATTR,
+    MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
     PoolModel,
@@ -74,6 +76,21 @@ def pool_object_heater2() -> PoolObject:
             "SNAME": "Solar Heater",
             "BODY": "POOL1",
             "LISTORD": "2",
+        },
+    )
+
+
+@pytest.fixture
+def pool_object_hcombo_heater() -> PoolObject:
+    """Return a PoolObject representing a multi-mode (HCOMBO) heater."""
+    return PoolObject(
+        "HTR_COMBO",
+        {
+            "OBJTYP": HEATER_TYPE,
+            "SUBTYP": "HCOMBO",
+            "SNAME": "Hybrid",
+            "BODY": "POOL1 SPA01",
+            "LISTORD": "1",
         },
     )
 
@@ -596,3 +613,262 @@ async def test_water_heater_extra_state_attributes(
     assert attrs["OBJNAM"] == "POOL1"
     assert "LAST_HEATER" in attrs  # Should include last heater
     assert attrs["LAST_HEATER"] == "HTR01"
+
+
+# -------------------------------------------------------------------------------------
+# HCOMBO (multi-mode heater) tests
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_hcombo_turn_on_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that HCOMBO heaters use MODE_ATTR instead of HEATER_ATTR for turn on.
+
+    Pentair UltraTemp ETi Hybrid (and other HCOMBO heaters) require the body's
+    MODE attribute to be set rather than the HEATER attribute.
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+    assert HEATER_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_turn_off_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that HCOMBO heaters use MODE_ATTR for turn off."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HYBRID_DUAL (on)
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_off()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
+    assert HEATER_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_current_operation_from_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation reflects MODE_ATTR when HEATER_ATTR is null."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HYBRID_DUAL active
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == "Hybrid"
+
+
+async def test_water_heater_hcombo_current_operation_off_when_mode_off(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation is off when MODE_ATTR is 1 (OFF)."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == STATE_OFF
+
+
+async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO set_operation_mode uses MODE_ATTR for non-off modes."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_set_operation_mode("Hybrid")
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+
+
+async def test_water_heater_hcombo_is_heater_active_from_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO _is_heater_active uses MODE_ATTR when HEATER_ATTR is null."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater._is_heater_active is True
+    attrs = water_heater.extra_state_attributes
+    assert "heating_status" in attrs
+
+
+async def test_water_heater_non_hcombo_turn_on_unchanged(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that standard (non-HCOMBO) heaters still use HEATER_ATTR for turn on."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_on()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert HEATER_ATTR in args[1]
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_isUpdated_watches_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test isUpdated triggers on MODE_ATTR changes for HCOMBO heaters."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.isUpdated({"POOL1": {MODE_ATTR: "10"}}) is True
+    assert water_heater.isUpdated({"POOL1": {"UNRELATED": "x"}}) is False


### PR DESCRIPTION
## Summary

- Pentair IntelliCenter silently ignores `HEATER` attribute changes for heaters with subtype `HCOMBO` (e.g. UltraTemp ETi Hybrid). The body's `MODE` attribute must be set instead (`HYBRID_DUAL=10` to activate, `OFF=1` to deactivate).
- Detects HCOMBO heaters via `heater_obj.subtype == "HCOMBO"` and routes `turn_on`, `turn_off`, and `set_operation_mode` through `MODE_ATTR` for affected bodies.
- Tracks `MODE_ATTR` in the coordinator's attribute map and in `isUpdated()` so state changes from the controller propagate correctly to HA.

## Root cause

The same bug was found and fixed in the homebridge Pentair plugin: https://github.com/astrostl/homebridge-pentair-intellicenter-ai/pull/150

The IntelliCenter controller simply ignores writes to `HEATER` for combo heaters — it requires the body-level `MODE` attribute to select the heating mode.

## Test plan

- [x] 8 new tests covering HCOMBO turn on/off, `current_operation`, `set_operation_mode`, `_is_heater_active`, and regression tests confirming standard heaters are unaffected
- [x] All 225 existing tests pass
- [x] `ruff check` clean
- [x] `mypy` clean (no issues in 14 source files)
- [x] Manually verified on a live Pentair IntelliCenter system with a UltraTemp ETi Hybrid heater — turning the spa heater on now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)