### PR TITLE
fix: Support HCOMBO multi-mode heaters (e.g. UltraTemp ETi Hybrid)

### DIFF
--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -98,6 +98,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         HTMODE_ATTR,
         LOTMP_ATTR,
         LSTTMP_ATTR,
+        MODE_ATTR,  # Heat mode (used by multi-mode heaters like HCOMBO)
         STATUS_ATTR,
         VOL_ATTR,
     },
@@ -142,7 +143,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         # IntelliChlor sensors
         SALT_ATTR,
     },
-    HEATER_TYPE: {SNAME_ATTR, BODY_ATTR, LISTORD_ATTR},
+    HEATER_TYPE: {SNAME_ATTR, BODY_ATTR, LISTORD_ATTR, SUBTYP_ATTR},
     PUMP_TYPE: {
         SNAME_ATTR,
         STATUS_ATTR,

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -3,6 +3,11 @@
 This module provides water heater entities for pool and spa heating control.
 Supports multiple heater types (gas, solar, heat pump) and remembers the
 last used heater for convenient turn-on operations.
+
+Multi-mode heaters (subtype HCOMBO, e.g. Pentair UltraTemp ETi Hybrid) require
+MODE-based control instead of HEATER assignment. IntelliCenter ignores HEATER
+attribute changes for HCOMBO heaters; the body's MODE attribute must be set to
+a HeaterType value (e.g. HYBRID_DUAL=10) to activate heating.
 """
 
 from __future__ import annotations
@@ -27,14 +32,19 @@ from pyintellicenter import (
     LISTORD_ATTR,
     LOTMP_ATTR,
     LSTTMP_ATTR,
+    MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
     STATUS_OFF,
+    HeaterType,
     PoolObject,
 )
 
 from . import IntelliCenterConfigEntry, PoolEntity
 from .coordinator import IntelliCenterCoordinator
+
+# IntelliCenter subtype for multi-mode combo heaters (e.g. UltraTemp ETi Hybrid)
+_HCOMBO_SUBTYPE = "HCOMBO"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,14 +110,27 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         )
         self._heater_list = heater_list
         self._last_heater: str | None = self._pool_object[HEATER_ATTR]
+        self._is_multimode: bool = self._detect_multimode()
+
+    def _detect_multimode(self) -> bool:
+        """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
+        for heater_id in self._heater_list:
+            heater_obj = self.coordinator.model[heater_id]
+            if heater_obj is not None and heater_obj.subtype == _HCOMBO_SUBTYPE:
+                return True
+        return False
 
     @property
     def _is_heater_active(self) -> bool:
-        """Return True if the body is on and a heater is assigned."""
-        return bool(
-            self._pool_object[STATUS_ATTR] != STATUS_OFF
-            and self._pool_object[HEATER_ATTR] != NULL_OBJNAM
-        )
+        """Return True if the body is on and a heater is assigned or mode is active."""
+        if self._pool_object[STATUS_ATTR] == STATUS_OFF:
+            return False
+        if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
+            return True
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            return bool(mode and mode not in ("0", "1"))
+        return False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -187,12 +210,21 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         a body even when it's off (e.g., setting the Spa heater while in Pool
         mode). The real-time heating activity is exposed via the heating_status
         extra state attribute.
+
+        For multi-mode (HCOMBO) heaters, operation is controlled via MODE_ATTR
+        on the body rather than HEATER_ATTR assignment.
         """
         heater = self._pool_object[HEATER_ATTR]
         if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
             if heater_obj is not None and heater_obj.sname is not None:
                 return str(heater_obj.sname)
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            if mode and mode not in ("0", "1"):
+                heater_obj = self.coordinator.model[self._heater_list[0]]
+                if heater_obj is not None and heater_obj.sname is not None:
+                    return str(heater_obj.sname)
         return str(STATE_OFF)
 
     @property
@@ -209,6 +241,8 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Set new target operation mode."""
         if operation_mode == STATE_OFF:
             self._turn_off()
+        elif self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
         else:
             for heater in self._heater_list:
                 heater_obj = self.coordinator.model[heater]
@@ -218,12 +252,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        heater = (
-            self._last_heater
-            if self._last_heater and self._last_heater != NULL_OBJNAM
-            else self._heater_list[0]
-        )
-        self.request_changes({HEATER_ATTR: heater})
+        if self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
+        else:
+            heater = (
+                self._last_heater
+                if self._last_heater and self._last_heater != NULL_OBJNAM
+                else self._heater_list[0]
+            )
+            self.request_changes({HEATER_ATTR: heater})
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
@@ -231,12 +268,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     def _turn_off(self) -> None:
         """Turn off the water heater."""
-        self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+        if self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.OFF.value)})
+        else:
+            self.request_changes({HEATER_ATTR: NULL_OBJNAM})
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
         updated = self._check_attributes_updated(
-            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR
+            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR, MODE_ATTR
         )
 
         if updated and self._pool_object[HEATER_ATTR] != NULL_OBJNAM:

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -7,7 +7,8 @@ last used heater for convenient turn-on operations.
 Multi-mode heaters (subtype HCOMBO, e.g. Pentair UltraTemp ETi Hybrid) require
 MODE-based control instead of HEATER assignment. IntelliCenter ignores HEATER
 attribute changes for HCOMBO heaters; the body's MODE attribute must be set to
-a HeaterType value (e.g. HYBRID_DUAL=10) to activate heating.
+a HeaterType value. HCOMBO heaters expose all four sub-modes (Gas Only, Heat
+Pump Only, Hybrid, Dual) as distinct operation modes in the HA dropdown.
 """
 
 from __future__ import annotations
@@ -45,6 +46,17 @@ from .coordinator import IntelliCenterCoordinator
 
 # IntelliCenter subtype for multi-mode combo heaters (e.g. UltraTemp ETi Hybrid)
 _HCOMBO_SUBTYPE = "HCOMBO"
+
+# Display labels for each HCOMBO mode shown in the operation dropdown
+_HCOMBO_MODE_LABELS: dict[int, str] = {
+    HeaterType.HYBRID_GAS.value: "Gas Only",
+    HeaterType.HYBRID_ULTRA_TEMP.value: "Heat Pump Only",
+    HeaterType.HYBRID_HYBRID.value: "Hybrid",
+    HeaterType.HYBRID_DUAL.value: "Dual",
+}
+_HCOMBO_LABEL_TO_MODE: dict[str, HeaterType] = {
+    v: HeaterType(k) for k, v in _HCOMBO_MODE_LABELS.items()
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,6 +106,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
     """Representation of a Pentair water heater."""
 
     LAST_HEATER_ATTR = "LAST_HEATER"
+    LAST_HCOMBO_MODE_ATTR = "LAST_HCOMBO_MODE"
     _attr_icon = "mdi:thermometer"
 
     def __init__(
@@ -111,6 +124,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         self._heater_list = heater_list
         self._last_heater: str | None = self._pool_object[HEATER_ATTR]
         self._is_multimode: bool = self._detect_multimode()
+        self._last_hcombo_mode: HeaterType | None = self._current_hcombo_mode()
 
     def _detect_multimode(self) -> bool:
         """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
@@ -120,16 +134,35 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
                 return True
         return False
 
+    def _current_hcombo_mode(self) -> HeaterType | None:
+        """Return the active HCOMBO HeaterType, or None if off or not applicable."""
+        if not self._is_multimode:
+            return None
+        mode = self._pool_object[MODE_ATTR]
+        if mode:
+            try:
+                ht = HeaterType(int(mode))
+                if ht.value in _HCOMBO_MODE_LABELS:
+                    return ht
+            except ValueError:
+                pass
+        return None
+
     @property
     def _is_heater_active(self) -> bool:
         """Return True if the body is on and a heater is assigned or mode is active."""
         if self._pool_object[STATUS_ATTR] == STATUS_OFF:
             return False
-        if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
-            return True
         if self._is_multimode:
             mode = self._pool_object[MODE_ATTR]
-            return bool(mode and mode not in ("0", "1"))
+            if mode and mode not in ("0", "1"):
+                return True
+        # Check for an active standard (non-HCOMBO) heater assignment
+        heater = self._pool_object[HEATER_ATTR]
+        if heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and heater_obj.subtype != _HCOMBO_SUBTYPE:
+                return True
         return False
 
     @property
@@ -137,8 +170,11 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Return the state attributes of the entity."""
         state_attributes = super().extra_state_attributes
 
-        if self._last_heater != NULL_OBJNAM:
+        if not self._is_multimode and self._last_heater != NULL_OBJNAM:
             state_attributes[self.LAST_HEATER_ATTR] = self._last_heater
+
+        if self._is_multimode and self._last_hcombo_mode is not None:
+            state_attributes[self.LAST_HCOMBO_MODE_ATTR] = str(self._last_hcombo_mode.value)
 
         if self._is_heater_active:
             htmode = self._pool_object[HTMODE_ATTR]
@@ -214,26 +250,41 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         For multi-mode (HCOMBO) heaters, operation is controlled via MODE_ATTR
         on the body rather than HEATER_ATTR assignment.
         """
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            if mode:
+                try:
+                    label = _HCOMBO_MODE_LABELS.get(int(mode))
+                    if label:
+                        return label
+                except ValueError:
+                    pass
+        # Fall through to standard heater check (handles pure standard and mixed bodies)
         heater = self._pool_object[HEATER_ATTR]
         if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
-            if heater_obj is not None and heater_obj.sname is not None:
+            if (
+                heater_obj is not None
+                and heater_obj.sname is not None
+                and heater_obj.subtype != _HCOMBO_SUBTYPE
+            ):
                 return str(heater_obj.sname)
-        if self._is_multimode:
-            mode = self._pool_object[MODE_ATTR]
-            if mode and mode not in ("0", "1"):
-                heater_obj = self.coordinator.model[self._heater_list[0]]
-                if heater_obj is not None and heater_obj.sname is not None:
-                    return str(heater_obj.sname)
         return str(STATE_OFF)
 
     @property
     def operation_list(self) -> list[str]:
         """Return the list of available operation modes."""
         operations: list[str] = [str(STATE_OFF)]
+        if self._is_multimode:
+            operations.extend(_HCOMBO_MODE_LABELS.values())
+        # Always include standard (non-HCOMBO) heaters — handles pure standard and mixed bodies
         for heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
-            if heater_obj is not None and heater_obj.sname is not None:
+            if (
+                heater_obj is not None
+                and heater_obj.sname is not None
+                and heater_obj.subtype != _HCOMBO_SUBTYPE
+            ):
                 operations.append(heater_obj.sname)
         return operations
 
@@ -241,19 +292,26 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Set new target operation mode."""
         if operation_mode == STATE_OFF:
             self._turn_off()
-        elif self._is_multimode:
-            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
-        else:
-            for heater in self._heater_list:
-                heater_obj = self.coordinator.model[heater]
-                if heater_obj is not None and operation_mode == heater_obj.sname:
-                    self.request_changes({HEATER_ATTR: heater})
-                    break
+            return
+        # HCOMBO mode label takes priority (handles pure HCOMBO and mixed bodies)
+        if self._is_multimode:
+            heater_type = _HCOMBO_LABEL_TO_MODE.get(operation_mode)
+            if heater_type is not None:
+                self.request_changes({MODE_ATTR: str(heater_type.value)})
+                return
+        # Standard heater by sname (handles pure standard and mixed bodies)
+        for heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and operation_mode == heater_obj.sname:
+                self.request_changes({HEATER_ATTR: heater})
+                return
+        _LOGGER.warning("Unknown operation mode: %s", operation_mode)
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         if self._is_multimode:
-            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
+            mode = self._last_hcombo_mode or HeaterType.HYBRID_DUAL
+            self.request_changes({MODE_ATTR: str(mode.value)})
         else:
             heater = (
                 self._last_heater
@@ -268,10 +326,10 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     def _turn_off(self) -> None:
         """Turn off the water heater."""
+        changes: dict[str, str] = {HEATER_ATTR: NULL_OBJNAM}
         if self._is_multimode:
-            self.request_changes({MODE_ATTR: str(HeaterType.OFF.value)})
-        else:
-            self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+            changes[MODE_ATTR] = str(HeaterType.OFF.value)
+        self.request_changes(changes)
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
@@ -279,8 +337,12 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
             updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR, MODE_ATTR
         )
 
-        if updated and self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
-            self._last_heater = self._pool_object[HEATER_ATTR]
+        if updated:
+            if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
+                self._last_heater = self._pool_object[HEATER_ATTR]
+            mode = self._current_hcombo_mode()
+            if mode is not None:
+                self._last_hcombo_mode = mode
 
         return updated
 
@@ -288,12 +350,20 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Entity is added to Home Assistant."""
         await super().async_added_to_hass()
 
-        if self._last_heater == NULL_OBJNAM:
-            # Our current state is OFF so
-            # let's see if we find a previous value stored in our state
-            last_state = await self.async_get_last_state()
+        last_state = await self.async_get_last_state()
 
-            if last_state:
+        if last_state:
+            if self._last_heater == NULL_OBJNAM:
                 value = last_state.attributes.get(self.LAST_HEATER_ATTR)
                 if value and value != NULL_OBJNAM:
                     self._last_heater = value
+
+            if self._is_multimode and self._last_hcombo_mode is None:
+                raw = last_state.attributes.get(self.LAST_HCOMBO_MODE_ATTR)
+                if raw:
+                    try:
+                        ht = HeaterType(int(raw))
+                        if ht.value in _HCOMBO_MODE_LABELS:
+                            self._last_hcombo_mode = ht
+                    except ValueError:
+                        pass

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Pentair IntelliCenter integration will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **HCOMBO heater control** - Multi-mode heaters (e.g. Pentair UltraTemp ETi Hybrid, subtype `HCOMBO`) can now be turned on and off correctly. IntelliCenter ignores `HEATER` attribute changes for HCOMBO heaters; the fix routes all control through the body's `MODE` attribute instead.
+
+### Added
+- **HCOMBO operation modes** - Water heater entities backed by an HCOMBO heater now expose all four sub-modes as selectable operation modes: Gas Only, Heat Pump Only, Hybrid, and Dual. The last-used mode is remembered and restored on turn-on.
+
+---
+
 ## [3.6.6] - 2026-03-10
 
 ### Added

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -16,8 +16,10 @@ from pyintellicenter import (
     HEATER_ATTR,
     HEATER_TYPE,
     HTMODE_ATTR,
+    HeaterType,
     LOTMP_ATTR,
     LSTTMP_ATTR,
+    MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
     PoolModel,
@@ -74,6 +76,21 @@ def pool_object_heater2() -> PoolObject:
             "SNAME": "Solar Heater",
             "BODY": "POOL1",
             "LISTORD": "2",
+        },
+    )
+
+
+@pytest.fixture
+def pool_object_hcombo_heater() -> PoolObject:
+    """Return a PoolObject representing a multi-mode (HCOMBO) heater."""
+    return PoolObject(
+        "HTR_COMBO",
+        {
+            "OBJTYP": HEATER_TYPE,
+            "SUBTYP": "HCOMBO",
+            "SNAME": "Hybrid",
+            "BODY": "POOL1 SPA01",
+            "LISTORD": "1",
         },
     )
 
@@ -596,3 +613,262 @@ async def test_water_heater_extra_state_attributes(
     assert attrs["OBJNAM"] == "POOL1"
     assert "LAST_HEATER" in attrs  # Should include last heater
     assert attrs["LAST_HEATER"] == "HTR01"
+
+
+# -------------------------------------------------------------------------------------
+# HCOMBO (multi-mode heater) tests
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_hcombo_turn_on_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that HCOMBO heaters use MODE_ATTR instead of HEATER_ATTR for turn on.
+
+    Pentair UltraTemp ETi Hybrid (and other HCOMBO heaters) require the body's
+    MODE attribute to be set rather than the HEATER attribute.
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+    assert HEATER_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_turn_off_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that HCOMBO heaters use MODE_ATTR for turn off."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HYBRID_DUAL (on)
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_off()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
+    assert HEATER_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_current_operation_from_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation reflects MODE_ATTR when HEATER_ATTR is null."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HYBRID_DUAL active
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == "Hybrid"
+
+
+async def test_water_heater_hcombo_current_operation_off_when_mode_off(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation is off when MODE_ATTR is 1 (OFF)."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == STATE_OFF
+
+
+async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO set_operation_mode uses MODE_ATTR for non-off modes."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_set_operation_mode("Hybrid")
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+
+
+async def test_water_heater_hcombo_is_heater_active_from_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO _is_heater_active uses MODE_ATTR when HEATER_ATTR is null."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater._is_heater_active is True
+    attrs = water_heater.extra_state_attributes
+    assert "heating_status" in attrs
+
+
+async def test_water_heater_non_hcombo_turn_on_unchanged(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that standard (non-HCOMBO) heaters still use HEATER_ATTR for turn on."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_on()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert HEATER_ATTR in args[1]
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_isUpdated_watches_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test isUpdated triggers on MODE_ATTR changes for HCOMBO heaters."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.isUpdated({"POOL1": {MODE_ATTR: "10"}}) is True
+    assert water_heater.isUpdated({"POOL1": {"UNRELATED": "x"}}) is False

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -693,7 +693,7 @@ async def test_water_heater_hcombo_turn_off_uses_mode_attr(
     assert args[0] == "POOL1"
     assert MODE_ATTR in args[1]
     assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
-    assert HEATER_ATTR not in args[1]
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
 
 
 async def test_water_heater_hcombo_current_operation_from_mode(
@@ -721,7 +721,40 @@ async def test_water_heater_hcombo_current_operation_from_mode(
 
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
 
-    assert water_heater.current_operation == "Hybrid"
+    assert water_heater.current_operation == "Dual"
+
+
+async def test_water_heater_hcombo_current_operation_ignores_heater_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation uses MODE even when HEATER_ATTR is set.
+
+    IntelliCenter sets HEATER=<objnam> on the body even for HCOMBO heaters when
+    they're active. Without this fix current_operation would return the heater's
+    sname ("Hybrid") regardless of which sub-mode is selected.
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": "HTR_COMBO",  # IntelliCenter sets this even for HCOMBO
+            "HTMODE": "1",
+            "MODE": "7",  # Gas Only
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == "Gas Only"
 
 
 async def test_water_heater_hcombo_current_operation_off_when_mode_off(
@@ -730,6 +763,7 @@ async def test_water_heater_hcombo_current_operation_off_when_mode_off(
     mock_coordinator: MagicMock,
 ) -> None:
     """Test HCOMBO current_operation is off when MODE_ATTR is 1 (OFF)."""
+    mock_coordinator.model = MagicMock()
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
 
     body = PoolObject(
@@ -777,12 +811,12 @@ async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
     water_heater.hass = hass
 
-    await water_heater.async_set_operation_mode("Hybrid")
+    await water_heater.async_set_operation_mode("Gas Only")
 
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert MODE_ATTR in args[1]
-    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_GAS.value)
 
 
 async def test_water_heater_hcombo_is_heater_active_from_mode(
@@ -852,6 +886,7 @@ async def test_water_heater_isUpdated_watches_mode_attr(
     mock_coordinator: MagicMock,
 ) -> None:
     """Test isUpdated triggers on MODE_ATTR changes for HCOMBO heaters."""
+    mock_coordinator.model = MagicMock()
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
 
     body = PoolObject(
@@ -872,3 +907,450 @@ async def test_water_heater_isUpdated_watches_mode_attr(
 
     assert water_heater.isUpdated({"POOL1": {MODE_ATTR: "10"}}) is True
     assert water_heater.isUpdated({"POOL1": {"UNRELATED": "x"}}) is False
+
+
+async def test_water_heater_hcombo_operation_list_has_all_modes(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO operation list contains all four sub-modes."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    ops = water_heater.operation_list
+    assert STATE_OFF in ops
+    assert "Gas Only" in ops
+    assert "Heat Pump Only" in ops
+    assert "Hybrid" in ops
+    assert "Dual" in ops
+    assert len(ops) == 5
+
+
+async def test_water_heater_hcombo_set_each_operation_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test each HCOMBO label maps to the correct HeaterType MODE value."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    expected = {
+        "Gas Only": HeaterType.HYBRID_GAS,
+        "Heat Pump Only": HeaterType.HYBRID_ULTRA_TEMP,
+        "Hybrid": HeaterType.HYBRID_HYBRID,
+        "Dual": HeaterType.HYBRID_DUAL,
+    }
+
+    for label, heater_type in expected.items():
+        mock_coordinator.controller.request_changes.reset_mock()
+        water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+        water_heater.hass = hass
+        await water_heater.async_set_operation_mode(label)
+        args = mock_coordinator.controller.request_changes.call_args[0]
+        assert args[1][MODE_ATTR] == str(heater_type.value), f"Wrong MODE for {label}"
+
+
+async def test_water_heater_hcombo_current_operation_each_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test current_operation returns correct label for each HCOMBO MODE value."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    mode_to_label = {
+        "7": "Gas Only",
+        "8": "Heat Pump Only",
+        "9": "Hybrid",
+        "10": "Dual",
+    }
+
+    for mode_val, expected_label in mode_to_label.items():
+        body = PoolObject(
+            "POOL1",
+            {
+                "OBJTYP": BODY_TYPE,
+                "SNAME": "Spa",
+                "STATUS": "ON",
+                "HEATER": NULL_OBJNAM,
+                "HTMODE": "1",
+                "MODE": mode_val,
+                "LOTMP": "98",
+                "LSTTMP": "95",
+            },
+        )
+        water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+        assert water_heater.current_operation == expected_label, f"Wrong label for MODE={mode_val}"
+
+
+async def test_water_heater_hcombo_turn_on_restores_last_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test turn_on uses the last active HCOMBO mode instead of defaulting to Dual."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "7",  # Gas Only was active
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    # Simulate update that records Gas Only as last mode
+    updates = {"POOL1": {MODE_ATTR: "7"}}
+    water_heater.isUpdated(updates)
+
+    # Turn off
+    body.update({MODE_ATTR: "1"})
+
+    # Turn back on — should restore Gas Only, not Dual
+    await water_heater.async_turn_on()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_GAS.value)
+
+
+# -------------------------------------------------------------------------------------
+# Backward-compatibility tests — standard (non-HCOMBO) heaters must be unaffected
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_standard_heater_unaffected(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Verify standard (gas/solar/heat-pump) heaters behave identically after HCOMBO changes.
+
+    This is a regression guard: none of the HCOMBO code paths should activate
+    for heaters whose subtype is not HCOMBO.
+    """
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    water_heater.hass = hass
+
+    # _is_multimode must be False for standard heaters
+    assert water_heater._is_multimode is False
+
+    # operation_list uses heater snames, not HCOMBO mode labels
+    ops = water_heater.operation_list
+    assert "Gas Heater" in ops
+    assert "Gas Only" not in ops
+    assert "Heat Pump Only" not in ops
+    assert "Dual" not in ops
+
+    # current_operation reflects HEATER_ATTR, not MODE_ATTR
+    assert water_heater.current_operation == "Gas Heater"
+
+    # turn_on sends HEATER_ATTR, not MODE_ATTR
+    body_off = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+    wh_off = PoolWaterHeater(mock_coordinator, body_off, ["HTR01"])
+    wh_off.hass = hass
+    await wh_off.async_turn_on()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert HEATER_ATTR in args[1]
+    assert MODE_ATTR not in args[1]
+
+    # turn_off sends HEATER_ATTR=NULL, not MODE_ATTR
+    mock_coordinator.controller.request_changes.reset_mock()
+    wh_on = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    wh_on.hass = hass
+    await wh_on.async_turn_off()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_last_heater_not_in_attributes(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test LAST_HEATER is not exposed in state attributes for HCOMBO entities."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": "HTR_COMBO",
+            "HTMODE": "0",
+            "MODE": "10",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    attrs = water_heater.extra_state_attributes
+    assert "LAST_HEATER" not in attrs
+    assert "LAST_HCOMBO_MODE" in attrs
+
+
+async def test_water_heater_hcombo_restore_invalid_mode_ignored(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that restoring an invalid/non-HCOMBO HeaterType value is ignored.
+
+    If LAST_HCOMBO_MODE is stored as HeaterType.OFF (1) or any value not in
+    _HCOMBO_MODE_LABELS, async_turn_on must not use it (would send MODE=1, turning off).
+    """
+    from unittest.mock import AsyncMock, patch
+
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    # Simulate restoring HeaterType.OFF (1) — an invalid HCOMBO mode
+    mock_last_state = MagicMock()
+    mock_last_state.attributes = {"LAST_HCOMBO_MODE": "1"}
+
+    with patch.object(water_heater, "async_get_last_state", AsyncMock(return_value=mock_last_state)):
+        await water_heater.async_added_to_hass()
+
+    # _last_hcombo_mode must remain None — OFF is not a valid HCOMBO mode to restore
+    assert water_heater._last_hcombo_mode is None
+
+    # turn_on should fall back to HYBRID_DUAL, not send MODE=1
+    water_heater.hass = hass
+    await water_heater.async_turn_on()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+
+
+# -------------------------------------------------------------------------------------
+# Mixed standard + HCOMBO heater tests
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_mixed_heaters_operation_list(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that a body with both standard and HCOMBO heaters exposes both in operation_list."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+
+    assert water_heater._is_multimode is True
+    ops = water_heater.operation_list
+    assert STATE_OFF in ops
+    assert "Gas Only" in ops
+    assert "Heat Pump Only" in ops
+    assert "Hybrid" in ops
+    assert "Dual" in ops
+    assert "Gas Heater" in ops  # Standard heater still accessible
+
+
+async def test_water_heater_mixed_heaters_set_standard_heater(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that selecting a standard heater mode on a mixed body sends HEATER_ATTR."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_set_operation_mode("Gas Heater")
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][HEATER_ATTR] == "HTR01"
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_mixed_heaters_turn_off_clears_both(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that turn_off on a mixed body clears both HEATER_ATTR and MODE_ATTR."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_off()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
+
+
+async def test_water_heater_mixed_heaters_current_operation_standard_heater(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test current_operation reflects standard heater when HEATER is set and MODE is off."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "MODE": "1",  # HCOMBO off
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+
+    assert water_heater.current_operation == "Gas Heater"


### PR DESCRIPTION
## Summary

- Pentair IntelliCenter silently ignores `HEATER` attribute changes for heaters with subtype `HCOMBO` (e.g. UltraTemp ETi Hybrid). The body's `MODE` attribute must be set instead to control heating.
- Detects HCOMBO heaters via `heater_obj.subtype` at entity init and routes all `turn_on`, `turn_off`, and `set_operation_mode` calls through `MODE_ATTR` for affected bodies.
- Exposes all four HCOMBO sub-modes as selectable operation modes: **Gas Only**, **Heat Pump Only**, **Hybrid**, **Dual**. The last-used mode is remembered and restored on `turn_on`.
- `current_operation` now correctly reflects the active `MODE` value rather than the heater's `sname` (which IntelliCenter sets on the body regardless of which sub-mode is active, causing the dropdown to always show the heater name).
- Standard (non-HCOMBO) heaters are entirely unaffected — all new code paths are guarded by `_is_multimode`.

Root cause is the same as this fix in the homebridge Pentair plugin: https://github.com/astrostl/homebridge-pentair-intellicenter-ai/pull/150

**Known limitation**: if a body has both a standard heater and an HCOMBO heater, the entity treats the whole body as HCOMBO. Mixed configs of this kind are not known to exist in practice.

## Test plan

- [x] 15 new tests covering HCOMBO turn on/off, all four operation modes, `current_operation`, `_is_heater_active`, last-mode restore, invalid mode restore guard, and `LAST_HEATER` suppression for HCOMBO entities
- [x] Backward-compatibility regression test confirming standard heaters are entirely unaffected
- [x] All 233 tests pass
- [x] `ruff check` clean
- [x] `mypy` strict clean
- [x] Manually verified on a live Pentair IntelliCenter system with a UltraTemp ETi Hybrid — all four modes selectable, dropdown reflects active mode correctly, mode survives HA restart

<img width="409" height="543" alt="Screenshot 2026-05-30 at 4 22 09 PM" src="https://github.com/user-attachments/assets/b299ef72-ea2d-46e9-8aa6-3784f5378cb0" />

https://github.com/user-attachments/assets/84c3dee2-6df6-4a04-8d5d-18421d9fe5a7



🤖 Generated with [Claude Code](https://claude.com/claude-code)