### PR TITLE
chore: maintainability hardening — version sync, strict mypy, CI drift guards, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           pip install pytest pytest-asyncio pytest-cov \
             pytest-homeassistant-custom-component \
-            "pyintellicenter>=0.1.1"
+            "pyintellicenter>=0.1.15"
       - name: Run tests
         run: pytest tests/ -v --tb=short --cov=custom_components/intellicenter
       - name: Count tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports, --no-strict-optional]
+        args: [--ignore-missing-imports]
         additional_dependencies: []
         files: ^custom_components/intellicenter/
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ This integration consists of two repositories that work together:
 | Project | Path | Repository |
 |---------|------|------------|
 | **intellicenter** (HA Integration) | `/Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter` | `joyfulhouse/intellicenter` |
-| **pyintellicenter** (Protocol Library) | `/Users/bryanli/Projects/joyfulhouse/homeassistant-dev/pyintellicenter` | `joyfulhouse/pyintellicenter` |
+| **pyintellicenter** (Protocol Library) | `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter` | `joyfulhouse/pyintellicenter` |
 
 ### When to Edit Each Project
 
@@ -51,7 +51,7 @@ When changes are made to pyintellicenter:
 3. Commit and push pyintellicenter changes
 4. Create a GitHub release to trigger the publish workflow:
    ```bash
-   cd /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/pyintellicenter
+   cd /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter
    gh release create v0.0.X --title "v0.0.X" --notes "Release notes here"
    ```
 5. Wait for publish workflow to complete (~60s)
@@ -91,17 +91,18 @@ pre-commit run --all-files
 
 ### Development Setup
 
-The protocol layer is in a separate package (`pyintellicenter`). For development:
+The protocol layer is in a separate package (`pyintellicenter`), checked out locally at
+`/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter` (repo `joyfulhouse/pyintellicenter`).
+For development against a local copy of the library:
 
 ```bash
-# Clone both repositories
-git clone https://github.com/joyfulhouse/intellicenter.git
-git clone https://github.com/joyfulhouse/pyintellicenter.git
-
-# Install pyintellicenter in development mode
-cd intellicenter
-uv pip install -e ../pyintellicenter
+# From the intellicenter repo root, install the local library editable:
+uv pip install -e /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter
 ```
+
+For normal test/CI runs the published release is used (per `manifest.json`:
+`pyintellicenter>=0.1.15`). Keep `pyproject.toml`'s pin and `uv.lock` in sync with
+`manifest.json` — they have drifted in the past.
 
 ### Testing
 
@@ -178,41 +179,44 @@ Mock the protocol layer by patching `ModelController` or creating test `PoolMode
 The integration follows a layered architecture:
 
 1. **Home Assistant Layer** (`custom_components/intellicenter/`)
-   - Platform modules: `light.py`, `sensor.py`, `switch.py`, `binary_sensor.py`, `water_heater.py`, `climate.py`, `number.py`, `cover.py`
+   - Platform modules: `light.py`, `sensor.py`, `switch.py`, `binary_sensor.py`, `water_heater.py`, `climate.py`, `number.py`, `cover.py`, `select.py`
    - Entry point: `__init__.py` - Sets up integration, manages entity lifecycle
+   - Coordinator: `coordinator.py` - `IntelliCenterCoordinator` (a `DataUpdateCoordinator`) owns the connection and fans out push updates to entities
    - Config flow: `config_flow.py` - Handles UI setup, Zeroconf discovery, and options flow
-   - Base entity: `PoolEntity` class in `__init__.py` - Common functionality for all entities
-   - `PoolConnectionHandler` - Home Assistant integration bridge for connection events
+   - Base entity: `PoolEntity` class in `__init__.py` (subclass of `CoordinatorEntity`) - common functionality for all entities
    - `OnOffControlMixin` - Mixin for simple on/off entities
 
 2. **Protocol/Model Layer** (`pyintellicenter` - external package)
-   - Separate repository: https://github.com/joyfulhouse/pyintellicenter
+   - Separate repository: https://github.com/joyfulhouse/pyintellicenter (checked out at `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter`)
    - Installed via `manifest.json` requirements: `pyintellicenter>=0.1.15`
-   - `controller.py` - Controller classes:
-     - `BaseController`: Basic TCP connection and command handling
-     - `ModelController`: Manages PoolModel state and tracks attribute changes
-     - `ConnectionHandler`: Reconnection logic with exponential backoff and circuit breaker
-     - `ConnectionMetrics`: Tracks response times, reconnect attempts, and health
-   - `protocol.py` - `ICProtocol`: Low-level asyncio protocol using orjson, handles message framing, request queuing (one-at-a-time), and keepalive queries
-   - `model.py` - `PoolModel` and `PoolObject`: Object model representing pool equipment
-   - `attributes.py` - Attribute definitions and type mappings
+   - `controller.py` - Controller classes (all `IC`-prefixed):
+     - `ICBaseController`: connection + command handling; exposes `ICSystemInfo` and `ICConnectionMetrics`
+     - `ICModelController`: manages `PoolModel` state, tracks attribute changes, and provides domain control/query helpers (lights, pumps, heaters, bodies, chemistry). NOTE: this class is large (~1,200 lines / 130+ methods) and is the main refactor target
+     - `ICConnectionHandler`: reconnection with exponential backoff + circuit breaker; emits events via the `ICConnectionHandlerCallbacks` protocol
+     - `ICConnectionMetrics`: tracks response times, reconnect attempts, and health
+   - `connection.py` - Transport layer: `ICProtocol` (TCP, port 6681) and `ICWebSocketTransport` (port 6680) share `ICRequestMixin`/`ICNotificationMixin`, wrapped by `ICConnection`. Uses orjson; handles framing, one-request-at-a-time flow control, and keepalive queries
+   - `model.py` - `PoolModel` and `PoolObject`: object model representing pool equipment
+   - `attributes/` - Attribute definitions and type mappings (package: `constants.py`, `body.py`, `circuit.py`, `equipment.py`, `system.py`, `schedule.py`, `misc.py`)
+   - `discovery.py` - Zeroconf discovery (`ICUnit`, `discover_intellicenter_units()`)
 
 ### Key Architectural Patterns
 
 **Connection Management**: The integration uses a layered approach to handle unreliable network connections:
-- `ICProtocol` handles transport-level concerns (message framing, flow control, keepalive queries)
-- `ModelController` manages state synchronization
-- `ConnectionHandler` implements automatic reconnection with exponential backoff (configurable, default 30s)
+- `ICProtocol` / `ICWebSocketTransport` (in `connection.py`) handle transport-level concerns (message framing, flow control, keepalive queries)
+- `ICModelController` manages state synchronization
+- `ICConnectionHandler` implements automatic reconnection with exponential backoff (configurable, default 30s)
 - Circuit breaker pattern prevents hammering dead servers (opens after 5 failures)
-- `ConnectionMetrics` tracks response times and reconnect attempts for observability
+- `ICConnectionMetrics` tracks response times and reconnect attempts for observability
 
-**State Updates**: Real-time updates flow through the system via:
+**State Updates**: Real-time updates flow through a `DataUpdateCoordinator` (no polling; `local_push`):
 1. IntelliCenter sends `NotifyList` messages when equipment state changes
-2. `ModelController.receivedNotifyList()` updates the `PoolModel`
-3. Dispatcher signals (`DOMAIN_UPDATE_{entry_id}`) notify Home Assistant entities
-4. Entities call `async_write_ha_state()` to update HA
+2. `ICModelController` applies them to the `PoolModel` and invokes the handler's `on_updated(controller, updates)` callback
+3. `_CoordinatorConnectionHandler.on_updated()` (in `coordinator.py`) calls `IntelliCenterCoordinator.async_set_updated_data(updates)`, which calls `async_update_listeners()`
+4. Each `PoolEntity` (a `CoordinatorEntity`) runs `_handle_coordinator_update()`; if its tracked attribute changed it calls `async_write_ha_state()`
 
-**Request Flow Control**: IntelliCenter struggles with concurrent requests, so `ICProtocol` enforces one request on the wire at a time using `_out_pending` counter and `_out_queue`.
+Connection up/down propagates the same way via `on_reconnected` / `on_disconnected` → `async_set_connection_state()`, which drives each entity's `available`.
+
+**Request Flow Control**: IntelliCenter struggles with concurrent requests, so the transport (`connection.py`) keeps a single in-flight request (`_response_future`) and queues the rest.
 
 ### Entity Creation Logic
 
@@ -247,8 +251,8 @@ Entities are created based on equipment characteristics in the pool model:
 ## Common Modifications
 
 When adding support for new equipment types:
-1. Add type/subtype constants to `attributes.py` if needed
-2. Add to `attributes_map` in `__init__.py:async_setup_entry()` to specify tracked attributes
+1. Add type/subtype constants to the `attributes/` package (in pyintellicenter) if needed
+2. Add to `DEFAULT_ATTRIBUTES_MAP` in `coordinator.py` to specify tracked attributes
 3. Create new platform module (e.g., `cover.py`) or extend existing one
 4. Add platform to `PLATFORMS` list in `__init__.py`
 5. Update `manifest.json` domains list and version
@@ -256,7 +260,7 @@ When adding support for new equipment types:
 
 When modifying protocol handling:
 - Be careful with request/response correlation - message IDs can mismatch on errors (IntelliCenter bug)
-- Maintain one-request-at-a-time flow control in `ICProtocol`
+- Maintain one-request-at-a-time flow control in `connection.py` (`ICProtocol` / `ICWebSocketTransport`)
 - Handle both responses (with `response` field) and notifications (without `response` field)
 
 ## Configuration Files
@@ -310,12 +314,12 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 **Code Quality & Standards**: ✅ COMPLETE
 - ✅ Follows Home Assistant integration standards
 - ✅ **Comprehensive type annotations** throughout codebase:
-  - `pyintellicenter/protocol.py`: Full type annotations with proper imports (TYPE_CHECKING)
+  - `pyintellicenter/connection.py`: Full type annotations with proper imports (TYPE_CHECKING)
   - `pyintellicenter/controller.py`: Complete type annotations for all classes
   - All methods have typed parameters and return values
   - Proper use of Optional, Union, and generic types
 - ✅ **Detailed code comments** explaining complex logic:
-  - `pyintellicenter/protocol.py`:
+  - `pyintellicenter/connection.py`:
     - Comprehensive module docstring explaining architecture
     - Detailed explanations of flow control mechanism
     - Documentation of message handling and buffering

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ format-check:
 	ruff format --check custom_components/
 
 type-check:
-	mypy custom_components/intellicenter/ --ignore-missing-imports --no-strict-optional || true
+	mypy custom_components/intellicenter/ --ignore-missing-imports
 
 pytest:
 	pytest tests/ -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "intellicenter"
-version = "3.6.0"
+version = "3.6.6"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.1.7",
+    "pyintellicenter>=0.1.15",
 ]
 
 [tool.ruff]
@@ -54,20 +54,9 @@ ignore-words-list = "hass,timout"
 skip = ".git,*.json,*.csv"
 quiet-level = 2
 
-[tool.mypy]
-python_version = "3.13"
-ignore_missing_imports = true
-no_strict_optional = true
-warn_redundant_casts = true
-warn_unused_configs = true
-disallow_untyped_defs = false
-check_untyped_defs = true
-warn_return_any = false
-show_error_codes = true
-
-[[tool.mypy.overrides]]
-module = "custom_components.intellicenter.*"
-ignore_errors = false
+# mypy configuration is centralized in mypy.ini (strict mode).
+# Do not add a [tool.mypy] block here: mypy.ini takes precedence over
+# pyproject.toml, so a second config would silently diverge.
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_library_contract.py
+++ b/tests/test_library_contract.py
@@ -1,0 +1,92 @@
+"""Contract tests against the REAL pyintellicenter library.
+
+The rest of the suite mocks ``ICModelController``, so a ``MagicMock`` answers to
+*any* attribute access. That means a rename or removal of a controller method the
+integration actually calls would pass the mocked tests and only break in
+production. These tests import the actually-installed library and assert that the
+API surface the integration depends on still exists, catching library/integration
+drift across ``pyintellicenter`` version bumps (the kind of drift that let
+manifest ``>=0.1.15`` ship while tests ran against 0.1.8).
+
+To regenerate ``CONTROLLER_METHODS`` after the integration changes::
+
+    grep -rhoE "(controller|_controller)\\.[a-zA-Z_]+\\(" \\
+        custom_components/intellicenter/ \\
+        | sed -E 's/.*\\.([a-zA-Z_]+)\\(/\\1/' | sort -u
+"""
+
+from __future__ import annotations
+
+import pyintellicenter
+
+# Methods the integration invokes on the controller (ICModelController, which
+# inherits ICBaseController). Existence + callability is asserted, not the exact
+# signature: that catches the real drift risk (rename/removal) without coupling
+# the test to internal parameter changes.
+#
+# NOTE: ``number.py`` dispatches several controller setters dynamically via a
+# ``getattr(controller, method_name)`` table keyed on string literals (the
+# IntelliChem setpoint methods below). The regenerate-grep in the module
+# docstring matches ``controller.<name>(`` call syntax, so it structurally
+# cannot find those string-literal method names -- they must be listed here
+# manually:
+#   set_alkalinity, set_calcium_hardness, set_cyanuric_acid,
+#   set_orp_setpoint, set_ph_setpoint
+CONTROLLER_METHODS = (
+    "body_supports_cooling",
+    "get_chlorinator_output",
+    "get_pump_circuit_speed",
+    "is_body_cooling",
+    "is_body_heating",
+    "is_vacation_mode",
+    "refresh_pump_circuit_speed",
+    "request_changes",
+    "set_alkalinity",
+    "set_calcium_hardness",
+    "set_chlorinator_output",
+    "set_cooling_setpoint",
+    "set_cyanuric_acid",
+    "set_heating_setpoint",
+    "set_light_effect",
+    "set_orp_setpoint",
+    "set_ph_setpoint",
+    "set_setpoint",
+    "set_vacation_mode",
+    "start",
+    "stop",
+)
+
+# Top-level symbols (classes/functions) the integration imports from the library.
+REQUIRED_SYMBOLS = (
+    "ICBaseController",
+    "ICModelController",
+    "ICConnectionHandler",
+    "ICConnectionError",
+    "ICTimeoutError",
+    "ICSystemInfo",
+    "PoolModel",
+    "PoolObject",
+    "discover_intellicenter_units",
+    "ICUnit",
+)
+
+
+def test_required_symbols_exist() -> None:
+    """Every top-level symbol the integration imports must still be exported."""
+    missing = [name for name in REQUIRED_SYMBOLS if not hasattr(pyintellicenter, name)]
+    assert not missing, (
+        f"pyintellicenter no longer exports {missing}; the integration imports these. "
+        "Update the integration or pin a compatible library version."
+    )
+
+
+def test_controller_methods_exist_and_callable() -> None:
+    """Every controller method the integration calls must still exist."""
+    controller = pyintellicenter.ICModelController
+    missing = [
+        name for name in CONTROLLER_METHODS if not callable(getattr(controller, name, None))
+    ]
+    assert not missing, (
+        f"ICModelController is missing methods the integration calls: {missing}. "
+        "This is library/integration contract drift that mocked tests cannot catch."
+    )

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,55 @@
+"""Guard against version/dependency drift between manifest.json and pyproject.toml.
+
+These are two independent sources of truth that have silently drifted before
+(manifest ``3.6.6`` vs pyproject ``3.6.0``; ``pyintellicenter>=0.1.15`` vs
+``>=0.1.7``). HACS/Home Assistant read ``manifest.json``; packaging/tests read
+``pyproject.toml``. This test fails loudly when they disagree so a release cannot
+ship mismatched metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_MANIFEST = _ROOT / "custom_components" / "intellicenter" / "manifest.json"
+_PYPROJECT = _ROOT / "pyproject.toml"
+
+
+def _manifest() -> dict:
+    return json.loads(_MANIFEST.read_text(encoding="utf-8"))
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _pyintellicenter_spec(requirements: list[str]) -> str | None:
+    """Return the pyintellicenter requirement string with whitespace removed."""
+    for req in requirements:
+        normalized = req.replace(" ", "")
+        if normalized.replace("_", "-").lower().startswith("pyintellicenter"):
+            return normalized
+    return None
+
+
+def test_version_matches() -> None:
+    manifest_version = _manifest()["version"]
+    pyproject_version = _pyproject()["project"]["version"]
+    assert manifest_version == pyproject_version, (
+        f"Version drift: manifest.json={manifest_version!r} != "
+        f"pyproject.toml={pyproject_version!r}. Keep them in sync on every release."
+    )
+
+
+def test_pyintellicenter_pin_matches() -> None:
+    manifest_spec = _pyintellicenter_spec(_manifest()["requirements"])
+    pyproject_spec = _pyintellicenter_spec(_pyproject()["project"]["dependencies"])
+    assert manifest_spec is not None, "manifest.json is missing a pyintellicenter requirement"
+    assert pyproject_spec is not None, "pyproject.toml is missing a pyintellicenter dependency"
+    assert manifest_spec == pyproject_spec, (
+        f"pyintellicenter pin drift: manifest.json={manifest_spec!r} != "
+        f"pyproject.toml={pyproject_spec!r}. Keep them in sync."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1247,7 +1247,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.6.0"
+version = "3.6.6"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },
@@ -1265,7 +1265,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.1.7" },
+    { name = "pyintellicenter", specifier = ">=0.1.15" },
 ]
 
 [package.metadata.requires-dev]
@@ -1968,16 +1968,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.8"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/a8/8b7cd67e41c1e1ae967044bea608e442a7ae5b23a829b8e94176f3a078fa/pyintellicenter-0.1.8.tar.gz", hash = "sha256:8206d676ca8499f39f32d7fc361d0093e8235d87548305b8874dc73afae07e6e", size = 43128, upload-time = "2025-12-31T20:00:44.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f3/b982e701aa24bf9c972dad3f46b1923371381daf868ef70134a76edb5949/pyintellicenter-0.1.15.tar.gz", hash = "sha256:7289cae45a13e9bb6e1d2f275bef0a717d1c5be37a803212200475489abf81b5", size = 45707, upload-time = "2026-02-26T14:32:14.754Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/d9/569e0782e76c13badef00f5f9a5b4a6bfbdf04f421d64e4290f50b3d851d/pyintellicenter-0.1.8-py3-none-any.whl", hash = "sha256:9e2ee41334a4c28528d047688875edae319251648f004092571b3f0702ac5f5b", size = 49777, upload-time = "2025-12-31T20:00:43.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/dc2d2e8f484cecc33b6e6a747d9af5783a5d76cd782a737f4f7925142b52/pyintellicenter-0.1.15-py3-none-any.whl", hash = "sha256:b8c3f41c30c2b6d72947b683ac08f945aac322edeb3d46a6233c5fe5f08407b9", size = 52404, upload-time = "2026-02-26T14:32:13.097Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Maintainability fixes surfaced during a repo-health review. **No runtime/behavior change** to the integration — changes are metadata, tooling, tests, and docs.

- **Version/dependency drift fixed:** align `pyproject.toml` version `3.6.0`→`3.6.6` and the `pyintellicenter` pin `>=0.1.7`→`>=0.1.15` with `manifest.json`; refresh `uv.lock` (`pyintellicenter` `0.1.8`→`0.1.15`). The suite now runs against the *shipped* library version instead of a stale one.
- **Unify mypy on strict:** remove the dead `[tool.mypy]` block from `pyproject.toml` (mypy.ini takes precedence over it anyway), drop `--no-strict-optional` from the pre-commit hook, and remove `--no-strict-optional || true` from the Makefile so type errors actually fail the build. `mypy.ini` (strict) is now the single source of truth; the code already passes it.
- **Drift guards (new tests):**
  - `tests/test_versions.py` — fails if `manifest.json` and `pyproject.toml` version/pin ever diverge again.
  - `tests/test_library_contract.py` — asserts the controller methods + symbols the integration actually calls still exist on the **real** `pyintellicenter` (the mocked suite cannot catch a renamed/removed library method).
- **CI:** bump the test-install pin to `pyintellicenter>=0.1.15`.
- **Docs:** correct `CLAUDE.md` — real library path, current class/file names (`ICBaseController`, `connection.py`, `attributes/`), and the actual `DataUpdateCoordinator`-based state-update flow (the prior dispatcher description no longer matched the code).

## Test plan

- `mypy custom_components/intellicenter/ --ignore-missing-imports` → clean (strict via `mypy.ini`)
- `ruff check custom_components/` → clean
- `pytest` → **221 passed** (217 + 4 new guards), against `pyintellicenter 0.1.15`
- Reviewed by Codex — no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
