### PR TITLE
fix: retry setup on transient connection errors (#41)

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -8,6 +8,7 @@ It supports Zeroconf discovery and local push updates for real-time responsivene
 from __future__ import annotations
 
 from collections.abc import Iterable
+import contextlib
 import logging
 import re
 from typing import TYPE_CHECKING, Any
@@ -23,6 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyintellicenter import (
     STATUS_ATTR,
+    ICCommandError,
     ICConnectionError,
     ICModelController,
     ICTimeoutError,
@@ -93,37 +95,45 @@ async def async_setup_entry(
         transport=transport,
     )
 
+    # Only the connection attempt belongs inside the retry try/except. Keeping
+    # async_forward_entry_setups() and the listener registration outside it means a
+    # genuine platform or programming error (e.g. an unrelated OSError) surfaces as a
+    # real setup_error instead of being misclassified as a transient connection
+    # failure and retried forever.
     try:
-        # Start the connection
         await coordinator.async_start()
-
-        # Store the coordinator in the entry's runtime_data
-        entry.runtime_data = coordinator
-
-        # Set up platforms
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-        # Register update listener for options changes
-        entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
-        return True
-
     except (
-        ConnectionRefusedError,
         ICConnectionError,
         ICTimeoutError,
+        ICCommandError,
         TimeoutError,
         OSError,
     ) as err:
-        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in
-        # (every 30s with exponential backoff) instead of leaving the entry
-        # in a permanent setup_error state requiring a manual reload.
-        # Fixes issue #41: integration fails to start when HA is restarted
-        # while the IntelliCenter / its bridge is temporarily unreachable
-        # (EHOSTUNREACH, timeout, refused, etc.).
+        # async_start() registers an EVENT_HOMEASSISTANT_STOP listener and kicks off
+        # pyintellicenter's background reconnect task *before* re-raising the
+        # first-attempt error. runtime_data isn't set yet, so async_unload_entry
+        # can't reach this coordinator to clean it up. Tear it down here, otherwise
+        # every HA retry during an outage leaks another listener + reconnect loop.
+        # Best-effort: never let teardown mask the ConfigEntryNotReady below.
+        with contextlib.suppress(Exception):
+            await coordinator.async_stop()
+        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in (with
+        # exponential backoff) instead of leaving the entry in a permanent
+        # setup_error state requiring a manual reload. Fixes issue #41: the
+        # integration fails to start when HA is restarted while IntelliCenter / its
+        # bridge is temporarily unreachable (refused, timeout, EHOSTUNREACH) or still
+        # booting (a not-ready panel rejects the initial handshake with an
+        # ICCommandError, which pyintellicenter itself treats as retryable).
         raise ConfigEntryNotReady(
             f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
         ) from err
+
+    # Connection established — store the coordinator and finish setup.
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    return True
 
 
 async def async_unload_entry(

--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import contextlib
+import errno
 import logging
 import re
 from typing import TYPE_CHECKING, Any
@@ -24,7 +25,6 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyintellicenter import (
     STATUS_ATTR,
-    ICCommandError,
     ICConnectionError,
     ICModelController,
     ICTimeoutError,
@@ -72,6 +72,48 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+# OSError errnos that indicate a transient network condition (the panel / bridge is
+# briefly unreachable or still booting) rather than a permanent local fault.
+# ConnectionError and TimeoutError subclasses are always transient and handled
+# separately in _is_transient_connection_error().
+_TRANSIENT_OS_ERRNOS = frozenset(
+    code
+    for code in (
+        getattr(errno, _name, None)
+        for _name in (
+            "EHOSTUNREACH",
+            "ENETUNREACH",
+            "ETIMEDOUT",
+            "EHOSTDOWN",
+            "ENETDOWN",
+            "ENETRESET",
+        )
+    )
+    if code is not None
+)
+
+
+def _is_transient_connection_error(err: Exception) -> bool:
+    """Return True if ``err`` is a transient connection failure worth retrying.
+
+    pyintellicenter raises ICConnectionError / ICTimeoutError for transport problems
+    (refused, reset, timeout, EHOSTUNREACH — issue #41). ICConnectionHandler.start()
+    can also re-raise a raw OSError / TimeoutError surfaced via the request future on
+    the first connection attempt, so builtin connection/timeout errors and
+    network-errno OSErrors are treated as transient too.
+
+    Everything else is treated as permanent so setup fails visibly instead of retrying
+    forever: ICCommandError (the panel actively rejected a command — a protocol or
+    firmware incompatibility, which per HA guidance is a permanent fault rather than an
+    outage) and non-network OSErrors such as PermissionError or ENOSPC.
+    """
+    if isinstance(err, (ICConnectionError, ICTimeoutError)):
+        return True
+    if isinstance(err, (ConnectionError, TimeoutError)):
+        return True
+    return isinstance(err, OSError) and err.errno in _TRANSIENT_OS_ERRNOS
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: IntelliCenterConfigEntry
 ) -> bool:
@@ -95,43 +137,43 @@ async def async_setup_entry(
         transport=transport,
     )
 
-    # Only the connection attempt belongs inside the retry try/except. Keeping
-    # async_forward_entry_setups() and the listener registration outside it means a
-    # genuine platform or programming error (e.g. an unrelated OSError) surfaces as a
-    # real setup_error instead of being misclassified as a transient connection
-    # failure and retried forever.
+    # Bring the connection up, then wire up platforms + the options listener. The whole
+    # sequence shares one cleanup contract via `setup_complete`: on ANY non-success exit
+    # the finally stops the coordinator, because async_start() starts a reconnect task +
+    # EVENT_HOMEASSISTANT_STOP listener and HA does not unload an entry whose setup
+    # raised — so this is the only place those can be torn down. The `connected` flag
+    # scopes transient/permanent classification to the connection attempt only; a
+    # post-connect failure (e.g. a platform setup error) propagates unchanged.
+    connected = False
+    setup_complete = False
     try:
         await coordinator.async_start()
-    except (
-        ICConnectionError,
-        ICTimeoutError,
-        ICCommandError,
-        TimeoutError,
-        OSError,
-    ) as err:
-        # async_start() registers an EVENT_HOMEASSISTANT_STOP listener and kicks off
-        # pyintellicenter's background reconnect task *before* re-raising the
-        # first-attempt error. runtime_data isn't set yet, so async_unload_entry
-        # can't reach this coordinator to clean it up. Tear it down here, otherwise
-        # every HA retry during an outage leaks another listener + reconnect loop.
-        # Best-effort: never let teardown mask the ConfigEntryNotReady below.
-        with contextlib.suppress(Exception):
-            await coordinator.async_stop()
-        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in (with
-        # exponential backoff) instead of leaving the entry in a permanent
-        # setup_error state requiring a manual reload. Fixes issue #41: the
-        # integration fails to start when HA is restarted while IntelliCenter / its
-        # bridge is temporarily unreachable (refused, timeout, EHOSTUNREACH) or still
-        # booting (a not-ready panel rejects the initial handshake with an
-        # ICCommandError, which pyintellicenter itself treats as retryable).
-        raise ConfigEntryNotReady(
-            f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
-        ) from err
-
-    # Connection established — store the coordinator and finish setup.
-    entry.runtime_data = coordinator
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+        connected = True
+        entry.runtime_data = coordinator
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+        setup_complete = True
+    except Exception as err:
+        if not connected and _is_transient_connection_error(err):
+            # Transient connection failure → HA's built-in exponential-backoff retry
+            # instead of a permanent setup_error needing a manual reload (issue #41).
+            # The message (host + cause) is shown to the user while HA retries.
+            raise ConfigEntryNotReady(
+                f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
+            ) from err
+        # Permanent / unexpected fault (rejected command, non-network OSError, a
+        # post-connect platform error, a programming error, ...): fail loudly as
+        # setup_error rather than retry forever or mask it as transient.
+        raise
+    finally:
+        # Runs on failure OR cancellation (CancelledError is a BaseException that
+        # bypasses `except Exception`). async_stop() is null-safe on a partial start;
+        # suppress so cleanup never masks the original exception. A coordinator left in
+        # runtime_data by a post-connect failure is now stopped (inert) and is replaced
+        # on the next setup attempt.
+        if not setup_complete:
+            with contextlib.suppress(Exception):
+                await coordinator.async_stop()
 
     return True
 

--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -23,7 +23,9 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyintellicenter import (
     STATUS_ATTR,
+    ICConnectionError,
     ICModelController,
+    ICTimeoutError,
     PoolObject,
 )
 
@@ -106,8 +108,22 @@ async def async_setup_entry(
 
         return True
 
-    except ConnectionRefusedError as err:
-        raise ConfigEntryNotReady from err
+    except (
+        ConnectionRefusedError,
+        ICConnectionError,
+        ICTimeoutError,
+        TimeoutError,
+        OSError,
+    ) as err:
+        # Raise ConfigEntryNotReady so HA's built-in retry loop kicks in
+        # (every 30s with exponential backoff) instead of leaving the entry
+        # in a permanent setup_error state requiring a manual reload.
+        # Fixes issue #41: integration fails to start when HA is restarted
+        # while the IntelliCenter / its bridge is temporarily unreachable
+        # (EHOSTUNREACH, timeout, refused, etc.).
+        raise ConfigEntryNotReady(
+            f"Could not connect to IntelliCenter at {entry.data[CONF_HOST]}: {err}"
+        ) from err
 
 
 async def async_unload_entry(

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.15"],
-  "version": "3.6.7-pr44",
+  "version": "3.6.6",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.15"],
-  "version": "3.6.6",
+  "version": "3.6.7-pr44",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from pyintellicenter import ICCommandError, ICConnectionError, ICTimeoutError
 import pytest
 
 from custom_components.intellicenter import (
@@ -62,21 +63,75 @@ async def test_async_setup_entry_success(
             mock_forward.assert_called_once_with(entry, PLATFORMS)
 
 
-async def test_async_setup_entry_connection_failed(hass: HomeAssistant) -> None:
-    """Test setup fails when connection is refused."""
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ConnectionRefusedError(),
+        OSError("EHOSTUNREACH"),
+        TimeoutError(),
+        ICConnectionError("connection lost"),
+        ICTimeoutError("request timed out"),
+        ICCommandError("404"),
+    ],
+)
+async def test_async_setup_entry_transient_error_retries(
+    hass: HomeAssistant, exc: Exception
+) -> None:
+    """Transient connection errors during start raise ConfigEntryNotReady.
+
+    Covers issue #41: each of these must trigger HA's retry loop instead of a
+    permanent setup_error. ICCommandError represents a reachable-but-not-ready
+    panel that rejects the initial handshake; pyintellicenter's own reconnect loop
+    treats it as retryable, so setup must too.
+    """
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     entry.data = {CONF_HOST: "192.168.1.100"}
     entry.options = {}  # No custom options, will use defaults
 
-    # Mock coordinator to raise ConnectionRefusedError on start
+    with (
+        patch.object(
+            IntelliCenterCoordinator,
+            "async_start",
+            new_callable=AsyncMock,
+            side_effect=exc,
+        ),
+        patch.object(
+            IntelliCenterCoordinator,
+            "async_stop",
+            new_callable=AsyncMock,
+        ) as mock_stop,
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, entry)
+
+    # The partially-started coordinator must be torn down on failure so its
+    # EVENT_HOMEASSISTANT_STOP listener and pyintellicenter reconnect task don't
+    # leak on every retry during an outage.
+    mock_stop.assert_awaited_once()
+
+
+async def test_async_setup_entry_unexpected_error_propagates(
+    hass: HomeAssistant,
+) -> None:
+    """A non-connection error during start is not reclassified as transient.
+
+    Only the connection attempt is inside the retry try/except, so an unrelated
+    error (here ValueError) propagates unchanged instead of being masked as
+    ConfigEntryNotReady and retried forever.
+    """
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry_id"
+    entry.data = {CONF_HOST: "192.168.1.100"}
+    entry.options = {}
+
     with patch.object(
         IntelliCenterCoordinator,
         "async_start",
         new_callable=AsyncMock,
-        side_effect=ConnectionRefusedError(),
+        side_effect=ValueError("boom"),
     ):
-        with pytest.raises(ConfigEntryNotReady):
+        with pytest.raises(ValueError):
             await async_setup_entry(hass, entry)
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,7 @@
 """Test the Pentair IntelliCenter integration initialization."""
 
+import asyncio
+import errno
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.config_entries import ConfigEntry
@@ -64,30 +66,59 @@ async def test_async_setup_entry_success(
 
 
 @pytest.mark.parametrize(
-    "exc",
+    ("exc", "expected_exc"),
     [
-        ConnectionRefusedError(),
-        OSError("EHOSTUNREACH"),
-        TimeoutError(),
-        ICConnectionError("connection lost"),
-        ICTimeoutError("request timed out"),
-        ICCommandError("404"),
+        # Transient connection failures -> ConfigEntryNotReady so HA retries with
+        # backoff (issue #41). pyintellicenter surfaces transport problems as
+        # ICConnectionError/ICTimeoutError, but ICConnectionHandler.start() can also
+        # re-raise a raw OSError/TimeoutError from the first attempt, so builtin
+        # connection/timeout errors and network-errno OSErrors are transient too.
+        (ICConnectionError("connection refused"), ConfigEntryNotReady),
+        (ICTimeoutError("request timed out"), ConfigEntryNotReady),
+        (OSError(errno.EHOSTUNREACH, "no route to host"), ConfigEntryNotReady),
+        (ConnectionResetError("connection reset by peer"), ConfigEntryNotReady),
+        (TimeoutError(), ConfigEntryNotReady),
+        # Permanent faults -> propagate as setup_error instead of retrying forever:
+        # a rejected command (protocol/firmware fault), a non-network OSError, or an
+        # unrelated programming error.
+        (ICCommandError("404"), ICCommandError),
+        (PermissionError(errno.EACCES, "permission denied"), PermissionError),
+        (OSError(errno.ENOSPC, "no space left on device"), OSError),
+        (ValueError("boom"), ValueError),
+        # Cancellation must clean up too: CancelledError is a BaseException that
+        # bypasses `except Exception`, so cleanup must live in the finally.
+        (asyncio.CancelledError(), asyncio.CancelledError),
+    ],
+    ids=[
+        "transient-ICConnectionError",
+        "transient-ICTimeoutError",
+        "transient-OSError-EHOSTUNREACH",
+        "transient-ConnectionResetError",
+        "transient-TimeoutError",
+        "permanent-ICCommandError",
+        "permanent-PermissionError",
+        "permanent-OSError-ENOSPC",
+        "permanent-ValueError",
+        "cancelled-CancelledError",
     ],
 )
-async def test_async_setup_entry_transient_error_retries(
-    hass: HomeAssistant, exc: Exception
+async def test_async_setup_entry_start_failure(
+    hass: HomeAssistant, exc: BaseException, expected_exc: type[BaseException]
 ) -> None:
-    """Transient connection errors during start raise ConfigEntryNotReady.
+    """A failing or cancelled async_start() is classified, and the partial coordinator
+    is always torn down (cleanup lives in a finally) with no entry state left.
 
-    Covers issue #41: each of these must trigger HA's retry loop instead of a
-    permanent setup_error. ICCommandError represents a reachable-but-not-ready
-    panel that rejects the initial handshake; pyintellicenter's own reconnect loop
-    treats it as retryable, so setup must too.
+    Transient connection failures raise ConfigEntryNotReady so HA retries with backoff
+    (issue #41); everything else propagates unchanged — a rejected command or
+    non-network OSError as a permanent setup_error, a programming error as-is, and
+    CancelledError preserved. Either way async_stop() must run, platforms must not be
+    forwarded, and runtime_data must be untouched.
     """
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     entry.data = {CONF_HOST: "192.168.1.100"}
     entry.options = {}  # No custom options, will use defaults
+    entry.runtime_data = "UNSET"  # sentinel: must remain unchanged on failure
 
     with (
         patch.object(
@@ -101,38 +132,59 @@ async def test_async_setup_entry_transient_error_retries(
             "async_stop",
             new_callable=AsyncMock,
         ) as mock_stop,
-        pytest.raises(ConfigEntryNotReady),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ) as mock_forward,
+        pytest.raises(expected_exc),
     ):
         await async_setup_entry(hass, entry)
 
-    # The partially-started coordinator must be torn down on failure so its
-    # EVENT_HOMEASSISTANT_STOP listener and pyintellicenter reconnect task don't
-    # leak on every retry during an outage.
+    # Cleanup is decoupled from classification: the partially started coordinator must
+    # be torn down on BOTH the transient and permanent paths so its
+    # EVENT_HOMEASSISTANT_STOP listener and pyintellicenter reconnect task don't leak.
     mock_stop.assert_awaited_once()
+    mock_forward.assert_not_called()
+    assert entry.runtime_data == "UNSET"
 
 
-async def test_async_setup_entry_unexpected_error_propagates(
+async def test_async_setup_entry_post_connect_failure_cleans_up(
     hass: HomeAssistant,
 ) -> None:
-    """A non-connection error during start is not reclassified as transient.
+    """A failure after the connection succeeds still stops the coordinator.
 
-    Only the connection attempt is inside the retry try/except, so an unrelated
-    error (here ValueError) propagates unchanged instead of being masked as
-    ConfigEntryNotReady and retried forever.
+    async_start() succeeds (so the reconnect task + HA-stop listener are running), then
+    platform forwarding raises. HA does not unload an entry whose setup raised, so
+    async_setup_entry itself must tear the coordinator down or the reconnect loop leaks.
     """
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = "test_entry_id"
     entry.data = {CONF_HOST: "192.168.1.100"}
     entry.options = {}
+    entry.async_on_unload = MagicMock()
+    entry.add_update_listener = MagicMock()
 
-    with patch.object(
-        IntelliCenterCoordinator,
-        "async_start",
-        new_callable=AsyncMock,
-        side_effect=ValueError("boom"),
+    with (
+        patch.object(IntelliCenterCoordinator, "async_start", new_callable=AsyncMock),
+        patch.object(
+            IntelliCenterCoordinator,
+            "async_stop",
+            new_callable=AsyncMock,
+        ) as mock_stop,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("platform setup failed"),
+        ),
+        pytest.raises(RuntimeError),
     ):
-        with pytest.raises(ValueError):
-            await async_setup_entry(hass, entry)
+        await async_setup_entry(hass, entry)
+
+    # Connection succeeded then forwarding failed -> the running coordinator must be
+    # stopped so its reconnect task + listener don't leak across HA's setup retries.
+    mock_stop.assert_awaited_once()
 
 
 async def test_async_unload_entry(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary
Fixes #41: when Home Assistant restarts while the IntelliCenter (or its bridge) is briefly unreachable or still booting, the integration left the entry in a permanent `setup_error` requiring a manual reload. Setup now classifies the failure and raises `ConfigEntryNotReady` for transient connection problems so HA retries with exponential backoff.

Builds on @merritt925's work in #44 (which this PR supersedes), with additional hardening from an adversarial review pass.

## Key decisions
- **One cleanup contract (`setup_complete` flag).** `async_setup_entry` stops the coordinator on *every* non-success exit of the connect → forward → listen sequence — connection failure, a post-connect platform/listener failure, **or** cancellation (`asyncio.CancelledError` is a `BaseException` that bypasses `except Exception`, so a `finally` is required). `coordinator.async_start()` starts a reconnect task + `EVENT_HOMEASSISTANT_STOP` listener, and HA never unloads an entry whose setup raised, so this is the only place those can be torn down. Closes latent leaks that existed on `main`/#44.
- **Classification scoped to the connection attempt (`connected` flag).** Retry (`ConfigEntryNotReady`) only connection-level failures: `ICConnectionError` / `ICTimeoutError`, builtin `ConnectionError` / `TimeoutError`, and network-errno `OSError` (EHOSTUNREACH/ENETUNREACH/ETIMEDOUT/…). `ICConnectionHandler.start()` can re-raise a raw `OSError`/`TimeoutError` from the first attempt (surfaced via the request future), so these are handled rather than assumed wrapped.
- **Fail loudly on the rest.** `ICCommandError` (the panel actively rejected a command → protocol/firmware fault, per HA guidance a permanent fault) and non-network `OSError` (`PermissionError`, `ENOSPC`) and any post-connect/programming error propagate as `setup_error` instead of retrying forever or being masked as transient.

## Test plan
- New parametrized `test_async_setup_entry_start_failure` covers transient (→ `ConfigEntryNotReady`), permanent (→ propagates), and cancelled paths; plus `test_async_setup_entry_post_connect_failure_cleans_up`. Each asserts the coordinator is torn down and no entry state is left behind.
- Full suite: **231 passed**; `ruff` + `ruff format` + `mypy` (strict `mypy.ini`) clean.
- Adversarial review: Codex (SHIP) + Gemini (approve) after iterating on cleanup-decoupling, `ICCommandError` classification, cancellation, and the post-connect leak.
- Validated against the production instance reference (56 entities healthy, unaffected by this setup-error-path change) and a read-only live-hardware connect.

Supersedes #44. Co-authored with @merritt925.