### PR TITLE
feat: HCOMBO multi-mode heater support (UltraTemp ETi Hybrid)

### DIFF
--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -98,6 +98,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         HTMODE_ATTR,
         LOTMP_ATTR,
         LSTTMP_ATTR,
+        MODE_ATTR,  # Heat mode (used by multi-mode heaters like HCOMBO)
         STATUS_ATTR,
         VOL_ATTR,
     },
@@ -142,7 +143,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         # IntelliChlor sensors
         SALT_ATTR,
     },
-    HEATER_TYPE: {SNAME_ATTR, BODY_ATTR, LISTORD_ATTR},
+    HEATER_TYPE: {SNAME_ATTR, BODY_ATTR, LISTORD_ATTR, SUBTYP_ATTR},
     PUMP_TYPE: {
         SNAME_ATTR,
         STATUS_ATTR,

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -3,6 +3,11 @@
 This module provides water heater entities for pool and spa heating control.
 Supports multiple heater types (gas, solar, heat pump) and remembers the
 last used heater for convenient turn-on operations.
+
+Multi-mode heaters (subtype HCOMBO, e.g. Pentair UltraTemp ETi Hybrid) require
+MODE-based control instead of HEATER assignment. IntelliCenter ignores HEATER
+attribute changes for HCOMBO heaters; the body's MODE attribute must be set to
+a HeaterType value (e.g. HYBRID_DUAL=10) to activate heating.
 """
 
 from __future__ import annotations
@@ -27,14 +32,19 @@ from pyintellicenter import (
     LISTORD_ATTR,
     LOTMP_ATTR,
     LSTTMP_ATTR,
+    MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
     STATUS_OFF,
+    HeaterType,
     PoolObject,
 )
 
 from . import IntelliCenterConfigEntry, PoolEntity
 from .coordinator import IntelliCenterCoordinator
+
+# IntelliCenter subtype for multi-mode combo heaters (e.g. UltraTemp ETi Hybrid)
+_HCOMBO_SUBTYPE = "HCOMBO"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,14 +110,27 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         )
         self._heater_list = heater_list
         self._last_heater: str | None = self._pool_object[HEATER_ATTR]
+        self._is_multimode: bool = self._detect_multimode()
+
+    def _detect_multimode(self) -> bool:
+        """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
+        for heater_id in self._heater_list:
+            heater_obj = self.coordinator.model[heater_id]
+            if heater_obj is not None and heater_obj.subtype == _HCOMBO_SUBTYPE:
+                return True
+        return False
 
     @property
     def _is_heater_active(self) -> bool:
-        """Return True if the body is on and a heater is assigned."""
-        return bool(
-            self._pool_object[STATUS_ATTR] != STATUS_OFF
-            and self._pool_object[HEATER_ATTR] != NULL_OBJNAM
-        )
+        """Return True if the body is on and a heater is assigned or mode is active."""
+        if self._pool_object[STATUS_ATTR] == STATUS_OFF:
+            return False
+        if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
+            return True
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            return bool(mode and mode not in ("0", "1"))
+        return False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -187,12 +210,21 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         a body even when it's off (e.g., setting the Spa heater while in Pool
         mode). The real-time heating activity is exposed via the heating_status
         extra state attribute.
+
+        For multi-mode (HCOMBO) heaters, operation is controlled via MODE_ATTR
+        on the body rather than HEATER_ATTR assignment.
         """
         heater = self._pool_object[HEATER_ATTR]
         if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
             if heater_obj is not None and heater_obj.sname is not None:
                 return str(heater_obj.sname)
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            if mode and mode not in ("0", "1"):
+                heater_obj = self.coordinator.model[self._heater_list[0]]
+                if heater_obj is not None and heater_obj.sname is not None:
+                    return str(heater_obj.sname)
         return str(STATE_OFF)
 
     @property
@@ -209,6 +241,8 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Set new target operation mode."""
         if operation_mode == STATE_OFF:
             self._turn_off()
+        elif self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
         else:
             for heater in self._heater_list:
                 heater_obj = self.coordinator.model[heater]
@@ -218,12 +252,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        heater = (
-            self._last_heater
-            if self._last_heater and self._last_heater != NULL_OBJNAM
-            else self._heater_list[0]
-        )
-        self.request_changes({HEATER_ATTR: heater})
+        if self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
+        else:
+            heater = (
+                self._last_heater
+                if self._last_heater and self._last_heater != NULL_OBJNAM
+                else self._heater_list[0]
+            )
+            self.request_changes({HEATER_ATTR: heater})
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
@@ -231,12 +268,15 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     def _turn_off(self) -> None:
         """Turn off the water heater."""
-        self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+        if self._is_multimode:
+            self.request_changes({MODE_ATTR: str(HeaterType.OFF.value)})
+        else:
+            self.request_changes({HEATER_ATTR: NULL_OBJNAM})
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
         updated = self._check_attributes_updated(
-            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR
+            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR, MODE_ATTR
         )
 
         if updated and self._pool_object[HEATER_ATTR] != NULL_OBJNAM:

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -1,14 +1,26 @@
 """Pentair Intellicenter water heaters.
 
 This module provides water heater entities for pool and spa heating control.
-Supports multiple heater types (gas, solar, heat pump) and remembers the
-last used heater for convenient turn-on operations.
+A single :class:`PoolWaterHeater` models three kinds of body uniformly:
 
-Multi-mode heaters (subtype HCOMBO, e.g. Pentair UltraTemp ETi Hybrid) require
-MODE-based control instead of HEATER assignment. IntelliCenter ignores HEATER
-attribute changes for HCOMBO heaters; the body's MODE attribute must be set to
-a HeaterType value. HCOMBO heaters expose all four sub-modes (Gas Only, Heat
-Pump Only, Hybrid, Dual) as distinct operation modes in the HA dropdown.
+* **pure-standard** — only standard heaters (gas/solar/heat pump) are wired to
+  the body. They are selected by assigning ``HEATER=<objnam>``; the panel derives
+  the body ``MODE``.
+* **pure-HCOMBO** — only a multi-mode combo heater (subtype HCOMBO, e.g. Pentair
+  UltraTemp ETi Hybrid) is wired. IntelliCenter ignores ``HEATER`` assignments for
+  HCOMBO heaters; instead the body ``MODE`` attribute must be written to a
+  :class:`HeaterType` value. HCOMBO heaters expose all four sub-modes (Gas Only,
+  Heat Pump Only, Hybrid, Dual) as distinct operation modes.
+* **mixed** — the body's heater list contains BOTH an HCOMBO heater AND one or
+  more standard heaters. Operations from both planes appear in the dropdown.
+
+Every operation label resolves to a single atomic body write via
+:meth:`PoolWaterHeater._operation_to_changes`, which sets the chosen control
+plane and clears the opposite plane where safe. ``current_operation`` gives an
+assigned standard heater precedence over the HCOMBO ``MODE`` so the reported
+state stays correct even if one plane is momentarily stale after a switch. The
+last non-off operation is remembered (and restored across restarts) so turn-on
+returns the body to its previous mode.
 """
 
 from __future__ import annotations
@@ -48,14 +60,14 @@ from .coordinator import IntelliCenterCoordinator
 _HCOMBO_SUBTYPE = "HCOMBO"
 
 # Display labels for each HCOMBO mode shown in the operation dropdown
-_HCOMBO_MODE_LABELS: dict[int, str] = {
-    HeaterType.HYBRID_GAS.value: "Gas Only",
-    HeaterType.HYBRID_ULTRA_TEMP.value: "Heat Pump Only",
-    HeaterType.HYBRID_HYBRID.value: "Hybrid",
-    HeaterType.HYBRID_DUAL.value: "Dual",
+_HCOMBO_MODE_LABELS: dict[HeaterType, str] = {
+    HeaterType.HYBRID_GAS: "Gas Only",
+    HeaterType.HYBRID_ULTRA_TEMP: "Heat Pump Only",
+    HeaterType.HYBRID_HYBRID: "Hybrid",
+    HeaterType.HYBRID_DUAL: "Dual",
 }
 _HCOMBO_LABEL_TO_MODE: dict[str, HeaterType] = {
-    v: HeaterType(k) for k, v in _HCOMBO_MODE_LABELS.items()
+    label: mode for mode, label in _HCOMBO_MODE_LABELS.items()
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -105,8 +117,7 @@ async def async_setup_entry(
 class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
     """Representation of a Pentair water heater."""
 
-    LAST_HEATER_ATTR = "LAST_HEATER"
-    LAST_HCOMBO_MODE_ATTR = "LAST_HCOMBO_MODE"
+    LAST_OPERATION_ATTR = "LAST_OPERATION"
     _attr_icon = "mdi:thermometer"
 
     def __init__(
@@ -122,9 +133,12 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
             extra_state_attributes=[HEATER_ATTR, HTMODE_ATTR],
         )
         self._heater_list = heater_list
-        self._last_heater: str | None = self._pool_object[HEATER_ATTR]
         self._is_multimode: bool = self._detect_multimode()
-        self._last_hcombo_mode: HeaterType | None = self._current_hcombo_mode()
+        # Remember the last non-off operation so turn-on can restore it. None
+        # means the body is currently off (nothing to restore yet).
+        self._last_operation: str | None = self.current_operation
+        if self._last_operation == STATE_OFF:
+            self._last_operation = None
 
     def _detect_multimode(self) -> bool:
         """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
@@ -142,39 +156,75 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         if mode:
             try:
                 ht = HeaterType(int(mode))
-                if ht.value in _HCOMBO_MODE_LABELS:
-                    return ht
             except ValueError:
-                pass
+                return None
+            if ht in _HCOMBO_MODE_LABELS:
+                return ht
         return None
+
+    def _operation_to_changes(self, operation: str) -> dict[str, str] | None:
+        """Resolve an operation label to the atomic body changes that select it.
+
+        Returns None if the label is not a known operation for this body. HCOMBO
+        sub-mode labels are only honoured on multimode bodies, so a standard heater
+        whose name happens to match an HCOMBO label is never misrouted to the MODE
+        plane on a non-multimode body. (On a multimode body an HCOMBO sub-mode label
+        takes precedence over an identically-named standard heater — a pathological
+        config; operation_list de-dupes so it is never shown twice.)
+        """
+        if operation == STATE_OFF:
+            return {HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: str(HeaterType.OFF.value)}
+        if self._is_multimode:
+            heater_type = _HCOMBO_LABEL_TO_MODE.get(operation)
+            if heater_type is not None:
+                # HCOMBO sub-mode: set the body MODE and clear any standard heater
+                # assignment so the standard-heater-precedence in current_operation
+                # reflects the HCOMBO mode. HEATER=NULL is safe (turn-off writes it too).
+                return {MODE_ATTR: str(heater_type.value), HEATER_ATTR: NULL_OBJNAM}
+        for heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and operation == heater_obj.sname:
+                # Standard heater: assign it. We intentionally do NOT write MODE here
+                # (MODE=OFF would disable heating; the correct MODE depends on the
+                # heater's type and the panel derives it). current_operation prefers an
+                # assigned standard heater over a possibly-stale HCOMBO MODE.
+                return {HEATER_ATTR: heater}
+        return None
+
+    def _default_on_operation(self) -> str:
+        """Return a safe default operation label for turn-on with no last operation."""
+        if self._is_multimode:
+            # Economical default: heat pump only (NOT Dual, which runs gas + heat
+            # pump together).
+            return _HCOMBO_MODE_LABELS[HeaterType.HYBRID_ULTRA_TEMP]
+        for heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if (
+                heater_obj is not None
+                and heater_obj.sname is not None
+                and heater_obj.subtype != _HCOMBO_SUBTYPE
+            ):
+                return str(heater_obj.sname)
+        # Fall back to the first heater's sname if no standard heater is found.
+        first = self.coordinator.model[self._heater_list[0]]
+        return str(first.sname) if first is not None else STATE_OFF
 
     @property
     def _is_heater_active(self) -> bool:
-        """Return True if the body is on and a heater is assigned or mode is active."""
+        """Return True if a heat mode/heater is selected and the body is on."""
         if self._pool_object[STATUS_ATTR] == STATUS_OFF:
             return False
-        if self._is_multimode:
-            mode = self._pool_object[MODE_ATTR]
-            if mode and mode not in ("0", "1"):
-                return True
-        # Check for an active standard (non-HCOMBO) heater assignment
-        heater = self._pool_object[HEATER_ATTR]
-        if heater in self._heater_list:
-            heater_obj = self.coordinator.model[heater]
-            if heater_obj is not None and heater_obj.subtype != _HCOMBO_SUBTYPE:
-                return True
-        return False
+        # str() pins the comparison operand to str so the result is a concrete
+        # bool (HA's STATE_OFF is loosely typed and would otherwise widen to Any).
+        return self.current_operation != str(STATE_OFF)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the entity."""
         state_attributes = super().extra_state_attributes
 
-        if not self._is_multimode and self._last_heater != NULL_OBJNAM:
-            state_attributes[self.LAST_HEATER_ATTR] = self._last_heater
-
-        if self._is_multimode and self._last_hcombo_mode is not None:
-            state_attributes[self.LAST_HCOMBO_MODE_ATTR] = str(self._last_hcombo_mode.value)
+        if self._last_operation is not None:
+            state_attributes[self.LAST_OPERATION_ATTR] = self._last_operation
 
         if self._is_heater_active:
             htmode = self._pool_object[HTMODE_ATTR]
@@ -250,16 +300,9 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         For multi-mode (HCOMBO) heaters, operation is controlled via MODE_ATTR
         on the body rather than HEATER_ATTR assignment.
         """
-        if self._is_multimode:
-            mode = self._pool_object[MODE_ATTR]
-            if mode:
-                try:
-                    label = _HCOMBO_MODE_LABELS.get(int(mode))
-                    if label:
-                        return label
-                except ValueError:
-                    pass
-        # Fall through to standard heater check (handles pure standard and mixed bodies)
+        # An assigned standard (non-HCOMBO) heater takes precedence. This also makes
+        # the state correct when a stale HCOMBO MODE remains after switching to a
+        # standard heater on a mixed body.
         heater = self._pool_object[HEATER_ATTR]
         if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
@@ -269,6 +312,10 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
                 and heater_obj.subtype != _HCOMBO_SUBTYPE
             ):
                 return str(heater_obj.sname)
+        if self._is_multimode:
+            mode = self._current_hcombo_mode()
+            if mode is not None:
+                return _HCOMBO_MODE_LABELS[mode]
         return str(STATE_OFF)
 
     @property
@@ -277,72 +324,58 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         operations: list[str] = [str(STATE_OFF)]
         if self._is_multimode:
             operations.extend(_HCOMBO_MODE_LABELS.values())
-        # Always include standard (non-HCOMBO) heaters — handles pure standard and mixed bodies
+        # Always include standard (non-HCOMBO) heaters — handles pure standard and
+        # mixed bodies. Skip a standard heater whose name collides with an HCOMBO
+        # label already listed (so the dropdown never shows a duplicate entry).
         for heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
             if (
                 heater_obj is not None
                 and heater_obj.sname is not None
                 and heater_obj.subtype != _HCOMBO_SUBTYPE
+                and heater_obj.sname not in operations
             ):
                 operations.append(heater_obj.sname)
         return operations
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
-        if operation_mode == STATE_OFF:
-            self._turn_off()
+        changes = self._operation_to_changes(operation_mode)
+        if changes is None:
+            _LOGGER.warning("Unknown operation mode: %s", operation_mode)
             return
-        # HCOMBO mode label takes priority (handles pure HCOMBO and mixed bodies)
-        if self._is_multimode:
-            heater_type = _HCOMBO_LABEL_TO_MODE.get(operation_mode)
-            if heater_type is not None:
-                self.request_changes({MODE_ATTR: str(heater_type.value)})
-                return
-        # Standard heater by sname (handles pure standard and mixed bodies)
-        for heater in self._heater_list:
-            heater_obj = self.coordinator.model[heater]
-            if heater_obj is not None and operation_mode == heater_obj.sname:
-                self.request_changes({HEATER_ATTR: heater})
-                return
-        _LOGGER.warning("Unknown operation mode: %s", operation_mode)
+        await self._controller.request_changes(self._pool_object.objnam, changes)
 
     async def async_turn_on(self) -> None:
-        """Turn the entity on."""
-        if self._is_multimode:
-            mode = self._last_hcombo_mode or HeaterType.HYBRID_DUAL
-            self.request_changes({MODE_ATTR: str(mode.value)})
-        else:
-            heater = (
-                self._last_heater
-                if self._last_heater and self._last_heater != NULL_OBJNAM
-                else self._heater_list[0]
-            )
-            self.request_changes({HEATER_ATTR: heater})
+        """Turn the entity on, restoring the last operation or a safe default."""
+        operation = self._last_operation
+        if operation is None or self._operation_to_changes(operation) is None:
+            operation = self._default_on_operation()
+        changes = self._operation_to_changes(operation)
+        if changes is not None:
+            await self._controller.request_changes(self._pool_object.objnam, changes)
 
     async def async_turn_off(self) -> None:
-        """Turn the entity off."""
-        self._turn_off()
-
-    def _turn_off(self) -> None:
-        """Turn off the water heater."""
-        changes: dict[str, str] = {HEATER_ATTR: NULL_OBJNAM}
-        if self._is_multimode:
-            changes[MODE_ATTR] = str(HeaterType.OFF.value)
-        self.request_changes(changes)
+        """Turn the entity off, clearing both control planes atomically."""
+        await self._controller.request_changes(
+            self._pool_object.objnam,
+            {HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: str(HeaterType.OFF.value)},
+        )
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
         updated = self._check_attributes_updated(
-            updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR, MODE_ATTR
+            updates,
+            STATUS_ATTR,
+            HEATER_ATTR,
+            HTMODE_ATTR,
+            LOTMP_ATTR,
+            LSTTMP_ATTR,
+            MODE_ATTR,
         )
 
-        if updated:
-            if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
-                self._last_heater = self._pool_object[HEATER_ATTR]
-            mode = self._current_hcombo_mode()
-            if mode is not None:
-                self._last_hcombo_mode = mode
+        if updated and self.current_operation != STATE_OFF:
+            self._last_operation = self.current_operation
 
         return updated
 
@@ -350,20 +383,17 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Entity is added to Home Assistant."""
         await super().async_added_to_hass()
 
+        if self._last_operation is not None:
+            return
+
         last_state = await self.async_get_last_state()
-
         if last_state:
-            if self._last_heater == NULL_OBJNAM:
-                value = last_state.attributes.get(self.LAST_HEATER_ATTR)
-                if value and value != NULL_OBJNAM:
-                    self._last_heater = value
-
-            if self._is_multimode and self._last_hcombo_mode is None:
-                raw = last_state.attributes.get(self.LAST_HCOMBO_MODE_ATTR)
-                if raw:
-                    try:
-                        ht = HeaterType(int(raw))
-                        if ht.value in _HCOMBO_MODE_LABELS:
-                            self._last_hcombo_mode = ht
-                    except ValueError:
-                        pass
+            saved = last_state.attributes.get(self.LAST_OPERATION_ATTR)
+            # Only restore a label that is still a valid (non-off) operation for
+            # this body's current configuration.
+            if (
+                saved is not None
+                and saved != STATE_OFF
+                and saved in self.operation_list
+            ):
+                self._last_operation = saved

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -7,7 +7,8 @@ last used heater for convenient turn-on operations.
 Multi-mode heaters (subtype HCOMBO, e.g. Pentair UltraTemp ETi Hybrid) require
 MODE-based control instead of HEATER assignment. IntelliCenter ignores HEATER
 attribute changes for HCOMBO heaters; the body's MODE attribute must be set to
-a HeaterType value (e.g. HYBRID_DUAL=10) to activate heating.
+a HeaterType value. HCOMBO heaters expose all four sub-modes (Gas Only, Heat
+Pump Only, Hybrid, Dual) as distinct operation modes in the HA dropdown.
 """
 
 from __future__ import annotations
@@ -45,6 +46,17 @@ from .coordinator import IntelliCenterCoordinator
 
 # IntelliCenter subtype for multi-mode combo heaters (e.g. UltraTemp ETi Hybrid)
 _HCOMBO_SUBTYPE = "HCOMBO"
+
+# Display labels for each HCOMBO mode shown in the operation dropdown
+_HCOMBO_MODE_LABELS: dict[int, str] = {
+    HeaterType.HYBRID_GAS.value: "Gas Only",
+    HeaterType.HYBRID_ULTRA_TEMP.value: "Heat Pump Only",
+    HeaterType.HYBRID_HYBRID.value: "Hybrid",
+    HeaterType.HYBRID_DUAL.value: "Dual",
+}
+_HCOMBO_LABEL_TO_MODE: dict[str, HeaterType] = {
+    v: HeaterType(k) for k, v in _HCOMBO_MODE_LABELS.items()
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,6 +106,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
     """Representation of a Pentair water heater."""
 
     LAST_HEATER_ATTR = "LAST_HEATER"
+    LAST_HCOMBO_MODE_ATTR = "LAST_HCOMBO_MODE"
     _attr_icon = "mdi:thermometer"
 
     def __init__(
@@ -111,6 +124,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         self._heater_list = heater_list
         self._last_heater: str | None = self._pool_object[HEATER_ATTR]
         self._is_multimode: bool = self._detect_multimode()
+        self._last_hcombo_mode: HeaterType | None = self._current_hcombo_mode()
 
     def _detect_multimode(self) -> bool:
         """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
@@ -120,16 +134,35 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
                 return True
         return False
 
+    def _current_hcombo_mode(self) -> HeaterType | None:
+        """Return the active HCOMBO HeaterType, or None if off or not applicable."""
+        if not self._is_multimode:
+            return None
+        mode = self._pool_object[MODE_ATTR]
+        if mode:
+            try:
+                ht = HeaterType(int(mode))
+                if ht.value in _HCOMBO_MODE_LABELS:
+                    return ht
+            except ValueError:
+                pass
+        return None
+
     @property
     def _is_heater_active(self) -> bool:
         """Return True if the body is on and a heater is assigned or mode is active."""
         if self._pool_object[STATUS_ATTR] == STATUS_OFF:
             return False
-        if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
-            return True
         if self._is_multimode:
             mode = self._pool_object[MODE_ATTR]
-            return bool(mode and mode not in ("0", "1"))
+            if mode and mode not in ("0", "1"):
+                return True
+        # Check for an active standard (non-HCOMBO) heater assignment
+        heater = self._pool_object[HEATER_ATTR]
+        if heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and heater_obj.subtype != _HCOMBO_SUBTYPE:
+                return True
         return False
 
     @property
@@ -137,8 +170,11 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Return the state attributes of the entity."""
         state_attributes = super().extra_state_attributes
 
-        if self._last_heater != NULL_OBJNAM:
+        if not self._is_multimode and self._last_heater != NULL_OBJNAM:
             state_attributes[self.LAST_HEATER_ATTR] = self._last_heater
+
+        if self._is_multimode and self._last_hcombo_mode is not None:
+            state_attributes[self.LAST_HCOMBO_MODE_ATTR] = str(self._last_hcombo_mode.value)
 
         if self._is_heater_active:
             htmode = self._pool_object[HTMODE_ATTR]
@@ -214,26 +250,41 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         For multi-mode (HCOMBO) heaters, operation is controlled via MODE_ATTR
         on the body rather than HEATER_ATTR assignment.
         """
+        if self._is_multimode:
+            mode = self._pool_object[MODE_ATTR]
+            if mode:
+                try:
+                    label = _HCOMBO_MODE_LABELS.get(int(mode))
+                    if label:
+                        return label
+                except ValueError:
+                    pass
+        # Fall through to standard heater check (handles pure standard and mixed bodies)
         heater = self._pool_object[HEATER_ATTR]
         if heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
-            if heater_obj is not None and heater_obj.sname is not None:
+            if (
+                heater_obj is not None
+                and heater_obj.sname is not None
+                and heater_obj.subtype != _HCOMBO_SUBTYPE
+            ):
                 return str(heater_obj.sname)
-        if self._is_multimode:
-            mode = self._pool_object[MODE_ATTR]
-            if mode and mode not in ("0", "1"):
-                heater_obj = self.coordinator.model[self._heater_list[0]]
-                if heater_obj is not None and heater_obj.sname is not None:
-                    return str(heater_obj.sname)
         return str(STATE_OFF)
 
     @property
     def operation_list(self) -> list[str]:
         """Return the list of available operation modes."""
         operations: list[str] = [str(STATE_OFF)]
+        if self._is_multimode:
+            operations.extend(_HCOMBO_MODE_LABELS.values())
+        # Always include standard (non-HCOMBO) heaters — handles pure standard and mixed bodies
         for heater in self._heater_list:
             heater_obj = self.coordinator.model[heater]
-            if heater_obj is not None and heater_obj.sname is not None:
+            if (
+                heater_obj is not None
+                and heater_obj.sname is not None
+                and heater_obj.subtype != _HCOMBO_SUBTYPE
+            ):
                 operations.append(heater_obj.sname)
         return operations
 
@@ -241,19 +292,26 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Set new target operation mode."""
         if operation_mode == STATE_OFF:
             self._turn_off()
-        elif self._is_multimode:
-            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
-        else:
-            for heater in self._heater_list:
-                heater_obj = self.coordinator.model[heater]
-                if heater_obj is not None and operation_mode == heater_obj.sname:
-                    self.request_changes({HEATER_ATTR: heater})
-                    break
+            return
+        # HCOMBO mode label takes priority (handles pure HCOMBO and mixed bodies)
+        if self._is_multimode:
+            heater_type = _HCOMBO_LABEL_TO_MODE.get(operation_mode)
+            if heater_type is not None:
+                self.request_changes({MODE_ATTR: str(heater_type.value)})
+                return
+        # Standard heater by sname (handles pure standard and mixed bodies)
+        for heater in self._heater_list:
+            heater_obj = self.coordinator.model[heater]
+            if heater_obj is not None and operation_mode == heater_obj.sname:
+                self.request_changes({HEATER_ATTR: heater})
+                return
+        _LOGGER.warning("Unknown operation mode: %s", operation_mode)
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         if self._is_multimode:
-            self.request_changes({MODE_ATTR: str(HeaterType.HYBRID_DUAL.value)})
+            mode = self._last_hcombo_mode or HeaterType.HYBRID_DUAL
+            self.request_changes({MODE_ATTR: str(mode.value)})
         else:
             heater = (
                 self._last_heater
@@ -268,10 +326,10 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
 
     def _turn_off(self) -> None:
         """Turn off the water heater."""
+        changes: dict[str, str] = {HEATER_ATTR: NULL_OBJNAM}
         if self._is_multimode:
-            self.request_changes({MODE_ATTR: str(HeaterType.OFF.value)})
-        else:
-            self.request_changes({HEATER_ATTR: NULL_OBJNAM})
+            changes[MODE_ATTR] = str(HeaterType.OFF.value)
+        self.request_changes(changes)
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
@@ -279,8 +337,12 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
             updates, STATUS_ATTR, HEATER_ATTR, HTMODE_ATTR, LOTMP_ATTR, LSTTMP_ATTR, MODE_ATTR
         )
 
-        if updated and self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
-            self._last_heater = self._pool_object[HEATER_ATTR]
+        if updated:
+            if self._pool_object[HEATER_ATTR] != NULL_OBJNAM:
+                self._last_heater = self._pool_object[HEATER_ATTR]
+            mode = self._current_hcombo_mode()
+            if mode is not None:
+                self._last_hcombo_mode = mode
 
         return updated
 
@@ -288,12 +350,20 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         """Entity is added to Home Assistant."""
         await super().async_added_to_hass()
 
-        if self._last_heater == NULL_OBJNAM:
-            # Our current state is OFF so
-            # let's see if we find a previous value stored in our state
-            last_state = await self.async_get_last_state()
+        last_state = await self.async_get_last_state()
 
-            if last_state:
+        if last_state:
+            if self._last_heater == NULL_OBJNAM:
                 value = last_state.attributes.get(self.LAST_HEATER_ATTR)
                 if value and value != NULL_OBJNAM:
                     self._last_heater = value
+
+            if self._is_multimode and self._last_hcombo_mode is None:
+                raw = last_state.attributes.get(self.LAST_HCOMBO_MODE_ATTR)
+                if raw:
+                    try:
+                        ht = HeaterType(int(raw))
+                        if ht.value in _HCOMBO_MODE_LABELS:
+                            self._last_hcombo_mode = ht
+                    except ValueError:
+                        pass

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Pentair IntelliCenter integration will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **HCOMBO heater control** - Multi-mode heaters (e.g. Pentair UltraTemp ETi Hybrid, subtype `HCOMBO`) can now be turned on and off correctly. IntelliCenter ignores `HEATER` attribute changes for HCOMBO heaters; the fix routes all control through the body's `MODE` attribute instead.
+
+### Added
+- **HCOMBO operation modes** - Water heater entities backed by an HCOMBO heater now expose all four sub-modes as selectable operation modes: Gas Only, Heat Pump Only, Hybrid, and Dual. The last-used mode is remembered and restored on turn-on.
+
+---
+
 ## [3.6.6] - 2026-03-10
 
 ### Added

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -16,8 +16,10 @@ from pyintellicenter import (
     HEATER_ATTR,
     HEATER_TYPE,
     HTMODE_ATTR,
+    HeaterType,
     LOTMP_ATTR,
     LSTTMP_ATTR,
+    MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
     PoolModel,
@@ -74,6 +76,21 @@ def pool_object_heater2() -> PoolObject:
             "SNAME": "Solar Heater",
             "BODY": "POOL1",
             "LISTORD": "2",
+        },
+    )
+
+
+@pytest.fixture
+def pool_object_hcombo_heater() -> PoolObject:
+    """Return a PoolObject representing a multi-mode (HCOMBO) heater."""
+    return PoolObject(
+        "HTR_COMBO",
+        {
+            "OBJTYP": HEATER_TYPE,
+            "SUBTYP": "HCOMBO",
+            "SNAME": "Hybrid",
+            "BODY": "POOL1 SPA01",
+            "LISTORD": "1",
         },
     )
 
@@ -596,3 +613,262 @@ async def test_water_heater_extra_state_attributes(
     assert attrs["OBJNAM"] == "POOL1"
     assert "LAST_HEATER" in attrs  # Should include last heater
     assert attrs["LAST_HEATER"] == "HTR01"
+
+
+# -------------------------------------------------------------------------------------
+# HCOMBO (multi-mode heater) tests
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_hcombo_turn_on_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that HCOMBO heaters use MODE_ATTR instead of HEATER_ATTR for turn on.
+
+    Pentair UltraTemp ETi Hybrid (and other HCOMBO heaters) require the body's
+    MODE attribute to be set rather than the HEATER attribute.
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+    assert HEATER_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_turn_off_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that HCOMBO heaters use MODE_ATTR for turn off."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HYBRID_DUAL (on)
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_off()
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[0] == "POOL1"
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
+    assert HEATER_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_current_operation_from_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation reflects MODE_ATTR when HEATER_ATTR is null."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HYBRID_DUAL active
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == "Hybrid"
+
+
+async def test_water_heater_hcombo_current_operation_off_when_mode_off(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation is off when MODE_ATTR is 1 (OFF)."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == STATE_OFF
+
+
+async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO set_operation_mode uses MODE_ATTR for non-off modes."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    await water_heater.async_set_operation_mode("Hybrid")
+
+    mock_coordinator.controller.request_changes.assert_called_once()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert MODE_ATTR in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+
+
+async def test_water_heater_hcombo_is_heater_active_from_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO _is_heater_active uses MODE_ATTR when HEATER_ATTR is null."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater._is_heater_active is True
+    attrs = water_heater.extra_state_attributes
+    assert "heating_status" in attrs
+
+
+async def test_water_heater_non_hcombo_turn_on_unchanged(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that standard (non-HCOMBO) heaters still use HEATER_ATTR for turn on."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_on()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert HEATER_ATTR in args[1]
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_isUpdated_watches_mode_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test isUpdated triggers on MODE_ATTR changes for HCOMBO heaters."""
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.isUpdated({"POOL1": {MODE_ATTR: "10"}}) is True
+    assert water_heater.isUpdated({"POOL1": {"UNRELATED": "x"}}) is False

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -1,6 +1,6 @@
 """Test the Pentair IntelliCenter water heater platform."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntityFeature,
@@ -16,12 +16,12 @@ from pyintellicenter import (
     HEATER_ATTR,
     HEATER_TYPE,
     HTMODE_ATTR,
-    HeaterType,
     LOTMP_ATTR,
     LSTTMP_ATTR,
     MODE_ATTR,
     NULL_OBJNAM,
     STATUS_ATTR,
+    HeaterType,
     PoolModel,
     PoolObject,
 )
@@ -93,6 +93,12 @@ def pool_object_hcombo_heater() -> PoolObject:
             "LISTORD": "1",
         },
     )
+
+
+def _mixed_model_getitem(standard: PoolObject, hcombo: PoolObject) -> MagicMock:
+    """Return a model __getitem__ that maps each objnam to its distinct object."""
+    lookup = {standard.objnam: standard, hcombo.objnam: hcombo}
+    return MagicMock(side_effect=lambda oid: lookup.get(oid))
 
 
 async def test_water_heater_setup_creates_entities(
@@ -334,9 +340,19 @@ async def test_water_heater_set_temperature_invalid(
 
 async def test_water_heater_turn_on(
     hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_heater2: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test turning on the water heater."""
+    """Test turning on the water heater defaults to the first standard heater."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda oid: {
+            "HTR01": pool_object_heater,
+            "HTR02": pool_object_heater2,
+        }.get(oid)
+    )
+
     body = PoolObject(
         "POOL1",
         {
@@ -355,11 +371,10 @@ async def test_water_heater_turn_on(
 
     await water_heater.async_turn_on()
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[0] == "POOL1"
-    assert HEATER_ATTR in args[1]
-    assert args[1][HEATER_ATTR] == "HTR01"  # Uses first heater in list
+    # No remembered operation -> default is the first standard heater (Gas Heater).
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR01"}
+    )
 
 
 async def test_water_heater_turn_on_remembers_last_heater(
@@ -392,7 +407,7 @@ async def test_water_heater_turn_on_remembers_last_heater(
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01", "HTR02"])
     water_heater.hass = hass  # Required for async_create_task
 
-    # Simulate update that tracks last heater
+    # Simulate update that tracks the last operation (Solar Heater)
     updates = {
         "POOL1": {
             STATUS_ATTR: "ON",
@@ -408,9 +423,10 @@ async def test_water_heater_turn_on_remembers_last_heater(
     # Turn back on
     await water_heater.async_turn_on()
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[1][HEATER_ATTR] == "HTR02"  # Uses remembered heater
+    # Restores the remembered Solar Heater operation.
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR02"}
+    )
 
 
 async def test_water_heater_turn_off(
@@ -418,7 +434,7 @@ async def test_water_heater_turn_off(
     pool_object_body_with_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test turning off the water heater."""
+    """Test turning off the water heater clears both control planes."""
     water_heater = PoolWaterHeater(
         mock_coordinator,
         pool_object_body_with_heater,
@@ -428,11 +444,10 @@ async def test_water_heater_turn_off(
 
     await water_heater.async_turn_off()
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[0] == "POOL1"
-    assert HEATER_ATTR in args[1]
-    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: str(HeaterType.OFF.value)},
+    )
 
 
 async def test_water_heater_operation_list(
@@ -469,7 +484,7 @@ async def test_water_heater_set_operation_mode(
     pool_object_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test setting operation mode."""
+    """Test setting operation mode to a standard heater assigns HEATER only."""
     mock_coordinator.model = MagicMock()
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
 
@@ -482,11 +497,9 @@ async def test_water_heater_set_operation_mode(
 
     await water_heater.async_set_operation_mode("Gas Heater")
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[0] == "POOL1"
-    assert HEATER_ATTR in args[1]
-    assert args[1][HEATER_ATTR] == "HTR01"
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR01"}
+    )
 
 
 async def test_water_heater_set_operation_mode_off(
@@ -494,7 +507,7 @@ async def test_water_heater_set_operation_mode_off(
     pool_object_body_with_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test setting operation mode to off."""
+    """Test setting operation mode to off clears both control planes."""
     water_heater = PoolWaterHeater(
         mock_coordinator,
         pool_object_body_with_heater,
@@ -504,9 +517,10 @@ async def test_water_heater_set_operation_mode_off(
 
     await water_heater.async_set_operation_mode(STATE_OFF)
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: str(HeaterType.OFF.value)},
+    )
 
 
 async def test_water_heater_supported_features(
@@ -566,9 +580,13 @@ async def test_water_heater_min_max_temp_celsius(
 async def test_water_heater_is_updated(
     hass: HomeAssistant,
     pool_object_body_with_heater: PoolObject,
+    pool_object_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
     """Test isUpdated method for relevant attributes."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
     water_heater = PoolWaterHeater(
         mock_coordinator,
         pool_object_body_with_heater,
@@ -598,9 +616,13 @@ async def test_water_heater_is_updated(
 async def test_water_heater_extra_state_attributes(
     hass: HomeAssistant,
     pool_object_body_with_heater: PoolObject,
+    pool_object_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test extra state attributes."""
+    """Test extra state attributes expose the last operation label."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
     water_heater = PoolWaterHeater(
         mock_coordinator,
         pool_object_body_with_heater,
@@ -611,8 +633,9 @@ async def test_water_heater_extra_state_attributes(
 
     assert "OBJNAM" in attrs
     assert attrs["OBJNAM"] == "POOL1"
-    assert "LAST_HEATER" in attrs  # Should include last heater
-    assert attrs["LAST_HEATER"] == "HTR01"
+    # The unified model remembers the last non-off operation label, not a heater id.
+    assert attrs["LAST_OPERATION"] == "Gas Heater"
+    assert "LAST_HEATER" not in attrs
 
 
 # -------------------------------------------------------------------------------------
@@ -625,13 +648,16 @@ async def test_water_heater_hcombo_turn_on_uses_mode_attr(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test that HCOMBO heaters use MODE_ATTR instead of HEATER_ATTR for turn on.
+    """Test that HCOMBO turn-on writes the body MODE (and clears HEATER) atomically.
 
     Pentair UltraTemp ETi Hybrid (and other HCOMBO heaters) require the body's
-    MODE attribute to be set rather than the HEATER attribute.
+    MODE attribute to be set rather than the HEATER attribute. With no remembered
+    operation the economical default (Heat Pump Only) is selected.
     """
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -652,12 +678,12 @@ async def test_water_heater_hcombo_turn_on_uses_mode_attr(
 
     await water_heater.async_turn_on()
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[0] == "POOL1"
-    assert MODE_ATTR in args[1]
-    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
-    assert HEATER_ATTR not in args[1]
+    # HCOMBO heaters are controlled via an atomic body write that sets MODE and
+    # clears the standard-heater plane. Default is Heat Pump Only (not Dual).
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_ULTRA_TEMP.value), HEATER_ATTR: NULL_OBJNAM},
+    )
 
 
 async def test_water_heater_hcombo_turn_off_uses_mode_attr(
@@ -665,9 +691,11 @@ async def test_water_heater_hcombo_turn_off_uses_mode_attr(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test that HCOMBO heaters use MODE_ATTR for turn off."""
+    """Test that HCOMBO turn-off clears MODE and HEATER atomically."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -688,12 +716,10 @@ async def test_water_heater_hcombo_turn_off_uses_mode_attr(
 
     await water_heater.async_turn_off()
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[0] == "POOL1"
-    assert MODE_ATTR in args[1]
-    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
-    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: str(HeaterType.OFF.value)},
+    )
 
 
 async def test_water_heater_hcombo_current_operation_from_mode(
@@ -703,7 +729,9 @@ async def test_water_heater_hcombo_current_operation_from_mode(
 ) -> None:
     """Test HCOMBO current_operation reflects MODE_ATTR when HEATER_ATTR is null."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -732,11 +760,15 @@ async def test_water_heater_hcombo_current_operation_ignores_heater_attr(
     """Test HCOMBO current_operation uses MODE even when HEATER_ATTR is set.
 
     IntelliCenter sets HEATER=<objnam> on the body even for HCOMBO heaters when
-    they're active. Without this fix current_operation would return the heater's
-    sname ("Hybrid") regardless of which sub-mode is selected.
+    they're active. Because the assigned heater is an HCOMBO heater (not a
+    standard one), the standard-heater precedence does not apply and the HCOMBO
+    MODE drives current_operation: it must reflect the selected sub-mode rather
+    than the heater's sname ("Hybrid").
     """
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -764,7 +796,9 @@ async def test_water_heater_hcombo_current_operation_off_when_mode_off(
 ) -> None:
     """Test HCOMBO current_operation is off when MODE_ATTR is 1 (OFF)."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -790,9 +824,11 @@ async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test HCOMBO set_operation_mode uses MODE_ATTR for non-off modes."""
+    """Test HCOMBO set_operation_mode writes MODE and clears HEATER for non-off."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -813,10 +849,10 @@ async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
 
     await water_heater.async_set_operation_mode("Gas Only")
 
-    mock_coordinator.controller.request_changes.assert_called_once()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert MODE_ATTR in args[1]
-    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_GAS.value)
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_GAS.value), HEATER_ATTR: NULL_OBJNAM},
+    )
 
 
 async def test_water_heater_hcombo_is_heater_active_from_mode(
@@ -826,7 +862,9 @@ async def test_water_heater_hcombo_is_heater_active_from_mode(
 ) -> None:
     """Test HCOMBO _is_heater_active uses MODE_ATTR when HEATER_ATTR is null."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -887,7 +925,9 @@ async def test_water_heater_isUpdated_watches_mode_attr(
 ) -> None:
     """Test isUpdated triggers on MODE_ATTR changes for HCOMBO heaters."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -916,7 +956,9 @@ async def test_water_heater_hcombo_operation_list_has_all_modes(
 ) -> None:
     """Test HCOMBO operation list contains all four sub-modes."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -948,9 +990,11 @@ async def test_water_heater_hcombo_set_each_operation_mode(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test each HCOMBO label maps to the correct HeaterType MODE value."""
+    """Test each HCOMBO label maps to the correct atomic MODE write."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -978,8 +1022,10 @@ async def test_water_heater_hcombo_set_each_operation_mode(
         water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
         water_heater.hass = hass
         await water_heater.async_set_operation_mode(label)
-        args = mock_coordinator.controller.request_changes.call_args[0]
-        assert args[1][MODE_ATTR] == str(heater_type.value), f"Wrong MODE for {label}"
+        mock_coordinator.controller.request_changes.assert_called_once_with(
+            "POOL1",
+            {MODE_ATTR: str(heater_type.value), HEATER_ATTR: NULL_OBJNAM},
+        )
 
 
 async def test_water_heater_hcombo_current_operation_each_mode(
@@ -989,7 +1035,9 @@ async def test_water_heater_hcombo_current_operation_each_mode(
 ) -> None:
     """Test current_operation returns correct label for each HCOMBO MODE value."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     mode_to_label = {
         "7": "Gas Only",
@@ -1013,7 +1061,9 @@ async def test_water_heater_hcombo_current_operation_each_mode(
             },
         )
         water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
-        assert water_heater.current_operation == expected_label, f"Wrong label for MODE={mode_val}"
+        assert water_heater.current_operation == expected_label, (
+            f"Wrong label for MODE={mode_val}"
+        )
 
 
 async def test_water_heater_hcombo_turn_on_restores_last_mode(
@@ -1021,9 +1071,11 @@ async def test_water_heater_hcombo_turn_on_restores_last_mode(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test turn_on uses the last active HCOMBO mode instead of defaulting to Dual."""
+    """Test turn_on uses the last active HCOMBO mode instead of the default."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -1042,18 +1094,123 @@ async def test_water_heater_hcombo_turn_on_restores_last_mode(
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
     water_heater.hass = hass
 
-    # Simulate update that records Gas Only as last mode
+    # Simulate update that records Gas Only as the last operation
     updates = {"POOL1": {MODE_ATTR: "7"}}
     water_heater.isUpdated(updates)
 
     # Turn off
     body.update({MODE_ATTR: "1"})
 
-    # Turn back on — should restore Gas Only, not Dual
+    # Turn back on — should restore Gas Only, not the Heat Pump Only default
     await water_heater.async_turn_on()
 
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_GAS.value)
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_GAS.value), HEATER_ATTR: NULL_OBJNAM},
+    )
+
+
+# -------------------------------------------------------------------------------------
+# LAST_OPERATION restore tests
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_restore_invalid_operation_ignored(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test restoring a LAST_OPERATION label that is no longer valid is ignored.
+
+    If the saved label is not in the current operation_list (or is STATE_OFF),
+    async_turn_on must not use it and instead falls back to the safe default.
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF -> _last_operation starts None
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    # Simulate restoring a label that is not a valid operation for this body.
+    mock_last_state = MagicMock()
+    mock_last_state.attributes = {"LAST_OPERATION": "No Longer Wired Heater"}
+
+    with patch.object(
+        water_heater, "async_get_last_state", AsyncMock(return_value=mock_last_state)
+    ):
+        await water_heater.async_added_to_hass()
+
+    # The invalid label must not be adopted.
+    assert water_heater._last_operation is None
+
+    # turn_on falls back to the economical default (Heat Pump Only), not MODE=OFF.
+    water_heater.hass = hass
+    await water_heater.async_turn_on()
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_ULTRA_TEMP.value), HEATER_ATTR: NULL_OBJNAM},
+    )
+
+
+async def test_water_heater_restore_valid_operation(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test a valid saved LAST_OPERATION label is restored and used by turn_on."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",  # OFF -> _last_operation starts None
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    mock_last_state = MagicMock()
+    mock_last_state.attributes = {"LAST_OPERATION": "Gas Only"}
+
+    with patch.object(
+        water_heater, "async_get_last_state", AsyncMock(return_value=mock_last_state)
+    ):
+        await water_heater.async_added_to_hass()
+
+    assert water_heater._last_operation == "Gas Only"
+
+    # turn_on restores the saved Gas Only operation, not the default.
+    water_heater.hass = hass
+    await water_heater.async_turn_on()
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_GAS.value), HEATER_ATTR: NULL_OBJNAM},
+    )
 
 
 # -------------------------------------------------------------------------------------
@@ -1066,10 +1223,11 @@ async def test_water_heater_standard_heater_unaffected(
     pool_object_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Verify standard (gas/solar/heat-pump) heaters behave identically after HCOMBO changes.
+    """Verify standard heaters behave correctly after the HCOMBO redesign.
 
     This is a regression guard: none of the HCOMBO code paths should activate
-    for heaters whose subtype is not HCOMBO.
+    for heaters whose subtype is not HCOMBO, and selecting/turning on a standard
+    heater must write HEATER only (no MODE key).
     """
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
 
@@ -1102,7 +1260,14 @@ async def test_water_heater_standard_heater_unaffected(
     # current_operation reflects HEATER_ATTR, not MODE_ATTR
     assert water_heater.current_operation == "Gas Heater"
 
+    # selecting a standard heater sends HEATER_ATTR only, with NO MODE key
+    await water_heater.async_set_operation_mode("Gas Heater")
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR01"}
+    )
+
     # turn_on sends HEATER_ATTR, not MODE_ATTR
+    mock_coordinator.controller.request_changes.reset_mock()
     body_off = PoolObject(
         "POOL1",
         {
@@ -1122,24 +1287,27 @@ async def test_water_heater_standard_heater_unaffected(
     assert HEATER_ATTR in args[1]
     assert MODE_ATTR not in args[1]
 
-    # turn_off sends HEATER_ATTR=NULL, not MODE_ATTR
+    # turn_off clears both planes atomically (HEATER=NULL + MODE=OFF). Writing
+    # MODE=OFF is harmless for a pure-standard body and keeps the off-path uniform.
     mock_coordinator.controller.request_changes.reset_mock()
     wh_on = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
     wh_on.hass = hass
     await wh_on.async_turn_off()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[1][HEATER_ATTR] == NULL_OBJNAM
-    assert MODE_ATTR not in args[1]
+    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
 
 
-async def test_water_heater_hcombo_last_heater_not_in_attributes(
+async def test_water_heater_hcombo_last_operation_in_attributes(
     hass: HomeAssistant,
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test LAST_HEATER is not exposed in state attributes for HCOMBO entities."""
+    """Test HCOMBO entities expose LAST_OPERATION (and no legacy heater attrs)."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+    mock_coordinator.model.__getitem__ = MagicMock(
+        return_value=pool_object_hcombo_heater
+    )
 
     body = PoolObject(
         "POOL1",
@@ -1158,56 +1326,9 @@ async def test_water_heater_hcombo_last_heater_not_in_attributes(
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
 
     attrs = water_heater.extra_state_attributes
+    assert attrs["LAST_OPERATION"] == "Dual"
     assert "LAST_HEATER" not in attrs
-    assert "LAST_HCOMBO_MODE" in attrs
-
-
-async def test_water_heater_hcombo_restore_invalid_mode_ignored(
-    hass: HomeAssistant,
-    pool_object_hcombo_heater: PoolObject,
-    mock_coordinator: MagicMock,
-) -> None:
-    """Test that restoring an invalid/non-HCOMBO HeaterType value is ignored.
-
-    If LAST_HCOMBO_MODE is stored as HeaterType.OFF (1) or any value not in
-    _HCOMBO_MODE_LABELS, async_turn_on must not use it (would send MODE=1, turning off).
-    """
-    from unittest.mock import AsyncMock, patch
-
-    mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
-
-    body = PoolObject(
-        "POOL1",
-        {
-            "OBJTYP": BODY_TYPE,
-            "SNAME": "Spa",
-            "STATUS": "ON",
-            "HEATER": NULL_OBJNAM,
-            "HTMODE": "0",
-            "MODE": "1",
-            "LOTMP": "98",
-            "LSTTMP": "98",
-        },
-    )
-
-    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
-
-    # Simulate restoring HeaterType.OFF (1) — an invalid HCOMBO mode
-    mock_last_state = MagicMock()
-    mock_last_state.attributes = {"LAST_HCOMBO_MODE": "1"}
-
-    with patch.object(water_heater, "async_get_last_state", AsyncMock(return_value=mock_last_state)):
-        await water_heater.async_added_to_hass()
-
-    # _last_hcombo_mode must remain None — OFF is not a valid HCOMBO mode to restore
-    assert water_heater._last_hcombo_mode is None
-
-    # turn_on should fall back to HYBRID_DUAL, not send MODE=1
-    water_heater.hass = hass
-    await water_heater.async_turn_on()
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+    assert "LAST_HCOMBO_MODE" not in attrs
 
 
 # -------------------------------------------------------------------------------------
@@ -1221,10 +1342,10 @@ async def test_water_heater_mixed_heaters_operation_list(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test that a body with both standard and HCOMBO heaters exposes both in operation_list."""
+    """Test a mixed body exposes both standard and HCOMBO modes in operation_list."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(
-        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
     )
 
     body = PoolObject(
@@ -1259,10 +1380,14 @@ async def test_water_heater_mixed_heaters_set_standard_heater(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test that selecting a standard heater mode on a mixed body sends HEATER_ATTR."""
+    """Test selecting a standard heater on a mixed body assigns HEATER only.
+
+    current_operation must then show the standard heater's sname even though the
+    body MODE still holds a stale HCOMBO value.
+    """
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(
-        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
     )
 
     body = PoolObject(
@@ -1273,7 +1398,7 @@ async def test_water_heater_mixed_heaters_set_standard_heater(
             "STATUS": "ON",
             "HEATER": NULL_OBJNAM,
             "HTMODE": "0",
-            "MODE": "1",
+            "MODE": "7",  # stale HCOMBO "Gas Only" value present
             "LOTMP": "80",
             "LSTTMP": "75",
         },
@@ -1284,9 +1409,57 @@ async def test_water_heater_mixed_heaters_set_standard_heater(
 
     await water_heater.async_set_operation_mode("Gas Heater")
 
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[1][HEATER_ATTR] == "HTR01"
-    assert MODE_ATTR not in args[1]
+    # Standard heater selection writes HEATER only (panel derives MODE).
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR01"}
+    )
+
+    # Apply the change; current_operation prefers the assigned standard heater
+    # over the still-stale HCOMBO MODE=7.
+    body.update({HEATER_ATTR: "HTR01"})
+    assert water_heater.current_operation == "Gas Heater"
+
+
+async def test_water_heater_mixed_set_hcombo_mode(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test selecting an HCOMBO mode on a mixed body sets MODE and clears HEATER."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",  # standard heater currently assigned
+            "HTMODE": "1",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_set_operation_mode("Hybrid")
+
+    # MODE is set to the HCOMBO value and the stale standard heater is cleared.
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_HYBRID.value), HEATER_ATTR: NULL_OBJNAM},
+    )
+
+    # Apply the change; current_operation now reflects the HCOMBO mode.
+    body.update({HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: "9"})
+    assert water_heater.current_operation == "Hybrid"
 
 
 async def test_water_heater_mixed_heaters_turn_off_clears_both(
@@ -1297,8 +1470,8 @@ async def test_water_heater_mixed_heaters_turn_off_clears_both(
 ) -> None:
     """Test that turn_off on a mixed body clears both HEATER_ATTR and MODE_ATTR."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(
-        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
     )
 
     body = PoolObject(
@@ -1320,9 +1493,10 @@ async def test_water_heater_mixed_heaters_turn_off_clears_both(
 
     await water_heater.async_turn_off()
 
-    args = mock_coordinator.controller.request_changes.call_args[0]
-    assert args[1][HEATER_ATTR] == NULL_OBJNAM
-    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {HEATER_ATTR: NULL_OBJNAM, MODE_ATTR: str(HeaterType.OFF.value)},
+    )
 
 
 async def test_water_heater_mixed_heaters_current_operation_standard_heater(
@@ -1331,10 +1505,10 @@ async def test_water_heater_mixed_heaters_current_operation_standard_heater(
     pool_object_hcombo_heater: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test current_operation reflects standard heater when HEATER is set and MODE is off."""
+    """Test current_operation reflects standard heater when HEATER set and MODE off."""
     mock_coordinator.model = MagicMock()
-    mock_coordinator.model.__getitem__ = MagicMock(
-        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
     )
 
     body = PoolObject(
@@ -1354,3 +1528,168 @@ async def test_water_heater_mixed_heaters_current_operation_standard_heater(
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
 
     assert water_heater.current_operation == "Gas Heater"
+
+
+async def test_water_heater_mixed_current_operation_standard_wins_over_stale_mode(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test an assigned standard heater wins even when MODE holds a stale HCOMBO value.
+
+    After switching from an HCOMBO mode to a standard heater on a mixed body, the
+    body MODE may still hold the old HCOMBO value momentarily. current_operation
+    must report the standard heater (its plane was selected last).
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",  # standard heater assigned
+            "HTMODE": "1",
+            "MODE": "7",  # stale HCOMBO "Gas Only" value still present
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+
+    assert water_heater.current_operation == "Gas Heater"
+
+
+async def test_water_heater_mixed_turn_on_restores_standard_heater(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test turn_on on a mixed body restores a last standard-heater operation."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",  # standard heater was last selected
+            "HTMODE": "1",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+    assert water_heater._last_operation == "Gas Heater"
+
+    # Body turned off, then turned back on.
+    body.update({HEATER_ATTR: NULL_OBJNAM})
+    await water_heater.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR01"}
+    )
+
+
+async def test_water_heater_mixed_turn_on_restores_hcombo_mode(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test turn_on on a mixed body restores a last HCOMBO-mode operation."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = _mixed_model_getitem(
+        pool_object_heater, pool_object_hcombo_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "10",  # HCOMBO "Dual" was last selected
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+    assert water_heater._last_operation == "Dual"
+
+    # Body turned off, then turned back on.
+    body.update({MODE_ATTR: "1"})
+    await water_heater.async_turn_on()
+
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1",
+        {MODE_ATTR: str(HeaterType.HYBRID_DUAL.value), HEATER_ATTR: NULL_OBJNAM},
+    )
+
+
+async def test_water_heater_standard_heater_named_like_hcombo_not_misrouted(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A standard heater whose name matches an HCOMBO label is not misrouted.
+
+    On a non-multimode body, selecting a standard heater named e.g. "Gas Only"
+    must assign HEATER (not write the HCOMBO MODE plane), and the dropdown must
+    list it exactly once.
+    """
+    standard = PoolObject(
+        "HTR01",
+        {
+            "OBJTYP": HEATER_TYPE,
+            "SUBTYP": "GAS",
+            "SNAME": "Gas Only",
+            "BODY": "POOL1",
+            "LISTORD": "1",
+        },
+    )
+    # Swap in a MagicMock model first: __getitem__ is a dunder resolved on the
+    # type, so setting it on the real PoolModel instance from the fixture would be
+    # silently ignored and lookups would return the fixture's heater instead.
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=standard)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "80",
+            "LSTTMP": "78",
+        },
+    )
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    water_heater.hass = hass
+
+    assert water_heater._is_multimode is False
+    assert water_heater.operation_list.count("Gas Only") == 1
+
+    await water_heater.async_set_operation_mode("Gas Only")
+    mock_coordinator.controller.request_changes.assert_called_once_with(
+        "POOL1", {HEATER_ATTR: "HTR01"}
+    )

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -693,7 +693,7 @@ async def test_water_heater_hcombo_turn_off_uses_mode_attr(
     assert args[0] == "POOL1"
     assert MODE_ATTR in args[1]
     assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
-    assert HEATER_ATTR not in args[1]
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
 
 
 async def test_water_heater_hcombo_current_operation_from_mode(
@@ -721,7 +721,40 @@ async def test_water_heater_hcombo_current_operation_from_mode(
 
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
 
-    assert water_heater.current_operation == "Hybrid"
+    assert water_heater.current_operation == "Dual"
+
+
+async def test_water_heater_hcombo_current_operation_ignores_heater_attr(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO current_operation uses MODE even when HEATER_ATTR is set.
+
+    IntelliCenter sets HEATER=<objnam> on the body even for HCOMBO heaters when
+    they're active. Without this fix current_operation would return the heater's
+    sname ("Hybrid") regardless of which sub-mode is selected.
+    """
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": "HTR_COMBO",  # IntelliCenter sets this even for HCOMBO
+            "HTMODE": "1",
+            "MODE": "7",  # Gas Only
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    assert water_heater.current_operation == "Gas Only"
 
 
 async def test_water_heater_hcombo_current_operation_off_when_mode_off(
@@ -730,6 +763,7 @@ async def test_water_heater_hcombo_current_operation_off_when_mode_off(
     mock_coordinator: MagicMock,
 ) -> None:
     """Test HCOMBO current_operation is off when MODE_ATTR is 1 (OFF)."""
+    mock_coordinator.model = MagicMock()
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
 
     body = PoolObject(
@@ -777,12 +811,12 @@ async def test_water_heater_hcombo_set_operation_mode_uses_mode_attr(
     water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
     water_heater.hass = hass
 
-    await water_heater.async_set_operation_mode("Hybrid")
+    await water_heater.async_set_operation_mode("Gas Only")
 
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert MODE_ATTR in args[1]
-    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_GAS.value)
 
 
 async def test_water_heater_hcombo_is_heater_active_from_mode(
@@ -852,6 +886,7 @@ async def test_water_heater_isUpdated_watches_mode_attr(
     mock_coordinator: MagicMock,
 ) -> None:
     """Test isUpdated triggers on MODE_ATTR changes for HCOMBO heaters."""
+    mock_coordinator.model = MagicMock()
     mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
 
     body = PoolObject(
@@ -872,3 +907,450 @@ async def test_water_heater_isUpdated_watches_mode_attr(
 
     assert water_heater.isUpdated({"POOL1": {MODE_ATTR: "10"}}) is True
     assert water_heater.isUpdated({"POOL1": {"UNRELATED": "x"}}) is False
+
+
+async def test_water_heater_hcombo_operation_list_has_all_modes(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test HCOMBO operation list contains all four sub-modes."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    ops = water_heater.operation_list
+    assert STATE_OFF in ops
+    assert "Gas Only" in ops
+    assert "Heat Pump Only" in ops
+    assert "Hybrid" in ops
+    assert "Dual" in ops
+    assert len(ops) == 5
+
+
+async def test_water_heater_hcombo_set_each_operation_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test each HCOMBO label maps to the correct HeaterType MODE value."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    expected = {
+        "Gas Only": HeaterType.HYBRID_GAS,
+        "Heat Pump Only": HeaterType.HYBRID_ULTRA_TEMP,
+        "Hybrid": HeaterType.HYBRID_HYBRID,
+        "Dual": HeaterType.HYBRID_DUAL,
+    }
+
+    for label, heater_type in expected.items():
+        mock_coordinator.controller.request_changes.reset_mock()
+        water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+        water_heater.hass = hass
+        await water_heater.async_set_operation_mode(label)
+        args = mock_coordinator.controller.request_changes.call_args[0]
+        assert args[1][MODE_ATTR] == str(heater_type.value), f"Wrong MODE for {label}"
+
+
+async def test_water_heater_hcombo_current_operation_each_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test current_operation returns correct label for each HCOMBO MODE value."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    mode_to_label = {
+        "7": "Gas Only",
+        "8": "Heat Pump Only",
+        "9": "Hybrid",
+        "10": "Dual",
+    }
+
+    for mode_val, expected_label in mode_to_label.items():
+        body = PoolObject(
+            "POOL1",
+            {
+                "OBJTYP": BODY_TYPE,
+                "SNAME": "Spa",
+                "STATUS": "ON",
+                "HEATER": NULL_OBJNAM,
+                "HTMODE": "1",
+                "MODE": mode_val,
+                "LOTMP": "98",
+                "LSTTMP": "95",
+            },
+        )
+        water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+        assert water_heater.current_operation == expected_label, f"Wrong label for MODE={mode_val}"
+
+
+async def test_water_heater_hcombo_turn_on_restores_last_mode(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test turn_on uses the last active HCOMBO mode instead of defaulting to Dual."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "1",
+            "MODE": "7",  # Gas Only was active
+            "LOTMP": "98",
+            "LSTTMP": "95",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+    water_heater.hass = hass
+
+    # Simulate update that records Gas Only as last mode
+    updates = {"POOL1": {MODE_ATTR: "7"}}
+    water_heater.isUpdated(updates)
+
+    # Turn off
+    body.update({MODE_ATTR: "1"})
+
+    # Turn back on — should restore Gas Only, not Dual
+    await water_heater.async_turn_on()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_GAS.value)
+
+
+# -------------------------------------------------------------------------------------
+# Backward-compatibility tests — standard (non-HCOMBO) heaters must be unaffected
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_standard_heater_unaffected(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Verify standard (gas/solar/heat-pump) heaters behave identically after HCOMBO changes.
+
+    This is a regression guard: none of the HCOMBO code paths should activate
+    for heaters whose subtype is not HCOMBO.
+    """
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    water_heater.hass = hass
+
+    # _is_multimode must be False for standard heaters
+    assert water_heater._is_multimode is False
+
+    # operation_list uses heater snames, not HCOMBO mode labels
+    ops = water_heater.operation_list
+    assert "Gas Heater" in ops
+    assert "Gas Only" not in ops
+    assert "Heat Pump Only" not in ops
+    assert "Dual" not in ops
+
+    # current_operation reflects HEATER_ATTR, not MODE_ATTR
+    assert water_heater.current_operation == "Gas Heater"
+
+    # turn_on sends HEATER_ATTR, not MODE_ATTR
+    body_off = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "LOTMP": "72",
+            "LSTTMP": "68",
+        },
+    )
+    wh_off = PoolWaterHeater(mock_coordinator, body_off, ["HTR01"])
+    wh_off.hass = hass
+    await wh_off.async_turn_on()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert HEATER_ATTR in args[1]
+    assert MODE_ATTR not in args[1]
+
+    # turn_off sends HEATER_ATTR=NULL, not MODE_ATTR
+    mock_coordinator.controller.request_changes.reset_mock()
+    wh_on = PoolWaterHeater(mock_coordinator, body, ["HTR01"])
+    wh_on.hass = hass
+    await wh_on.async_turn_off()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_hcombo_last_heater_not_in_attributes(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test LAST_HEATER is not exposed in state attributes for HCOMBO entities."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": "HTR_COMBO",
+            "HTMODE": "0",
+            "MODE": "10",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    attrs = water_heater.extra_state_attributes
+    assert "LAST_HEATER" not in attrs
+    assert "LAST_HCOMBO_MODE" in attrs
+
+
+async def test_water_heater_hcombo_restore_invalid_mode_ignored(
+    hass: HomeAssistant,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that restoring an invalid/non-HCOMBO HeaterType value is ignored.
+
+    If LAST_HCOMBO_MODE is stored as HeaterType.OFF (1) or any value not in
+    _HCOMBO_MODE_LABELS, async_turn_on must not use it (would send MODE=1, turning off).
+    """
+    from unittest.mock import AsyncMock, patch
+
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(return_value=pool_object_hcombo_heater)
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Spa",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "98",
+            "LSTTMP": "98",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO"])
+
+    # Simulate restoring HeaterType.OFF (1) — an invalid HCOMBO mode
+    mock_last_state = MagicMock()
+    mock_last_state.attributes = {"LAST_HCOMBO_MODE": "1"}
+
+    with patch.object(water_heater, "async_get_last_state", AsyncMock(return_value=mock_last_state)):
+        await water_heater.async_added_to_hass()
+
+    # _last_hcombo_mode must remain None — OFF is not a valid HCOMBO mode to restore
+    assert water_heater._last_hcombo_mode is None
+
+    # turn_on should fall back to HYBRID_DUAL, not send MODE=1
+    water_heater.hass = hass
+    await water_heater.async_turn_on()
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][MODE_ATTR] == str(HeaterType.HYBRID_DUAL.value)
+
+
+# -------------------------------------------------------------------------------------
+# Mixed standard + HCOMBO heater tests
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_mixed_heaters_operation_list(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that a body with both standard and HCOMBO heaters exposes both in operation_list."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+
+    assert water_heater._is_multimode is True
+    ops = water_heater.operation_list
+    assert STATE_OFF in ops
+    assert "Gas Only" in ops
+    assert "Heat Pump Only" in ops
+    assert "Hybrid" in ops
+    assert "Dual" in ops
+    assert "Gas Heater" in ops  # Standard heater still accessible
+
+
+async def test_water_heater_mixed_heaters_set_standard_heater(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that selecting a standard heater mode on a mixed body sends HEATER_ATTR."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": NULL_OBJNAM,
+            "HTMODE": "0",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_set_operation_mode("Gas Heater")
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][HEATER_ATTR] == "HTR01"
+    assert MODE_ATTR not in args[1]
+
+
+async def test_water_heater_mixed_heaters_turn_off_clears_both(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test that turn_off on a mixed body clears both HEATER_ATTR and MODE_ATTR."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "MODE": "1",
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+    water_heater.hass = hass
+
+    await water_heater.async_turn_off()
+
+    args = mock_coordinator.controller.request_changes.call_args[0]
+    assert args[1][HEATER_ATTR] == NULL_OBJNAM
+    assert args[1][MODE_ATTR] == str(HeaterType.OFF.value)
+
+
+async def test_water_heater_mixed_heaters_current_operation_standard_heater(
+    hass: HomeAssistant,
+    pool_object_heater: PoolObject,
+    pool_object_hcombo_heater: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test current_operation reflects standard heater when HEATER is set and MODE is off."""
+    mock_coordinator.model = MagicMock()
+    mock_coordinator.model.__getitem__ = MagicMock(
+        side_effect=lambda x: pool_object_hcombo_heater if x == "HTR_COMBO" else pool_object_heater
+    )
+
+    body = PoolObject(
+        "POOL1",
+        {
+            "OBJTYP": BODY_TYPE,
+            "SNAME": "Pool",
+            "STATUS": "ON",
+            "HEATER": "HTR01",
+            "HTMODE": "1",
+            "MODE": "1",  # HCOMBO off
+            "LOTMP": "80",
+            "LSTTMP": "75",
+        },
+    )
+
+    water_heater = PoolWaterHeater(mock_coordinator, body, ["HTR_COMBO", "HTR01"])
+
+    assert water_heater.current_operation == "Gas Heater"


### PR DESCRIPTION
## Summary
Adds support for Pentair HCOMBO multi-mode heaters (e.g. UltraTemp ETi Hybrid) to the `water_heater` platform. These hybrid units are controlled via the body **MODE** attribute (a `HeaterType`: `HYBRID_GAS=7` … `HYBRID_DUAL=10`), unlike standard heaters which are controlled via **HEATER** assignment — so previously they could not be turned on/off from the integration.

Builds on @jbonta's PR #46 (which this supersedes), reworked after an adversarial review pass (Codex + Gemini) to correctly support **pure-standard, pure-HCOMBO, and mixed (HCOMBO + standard on the same body)** configurations.

## Key decisions
- **Unified atomic control** via `_operation_to_changes()`: OFF → `{HEATER:NULL, MODE:OFF}`; an HCOMBO sub-mode → `{MODE:x, HEATER:NULL}` (clears the standard plane); a standard heater → `{HEATER:h}` (no `MODE` write — `MODE=OFF` would *disable* heating; the panel derives the mode from the assigned heater). All writes go through `controller.request_changes` atomically.
- **Standard-heater precedence** in `current_operation`: an assigned standard heater is shown over a (possibly stale) HCOMBO `MODE`, and selecting an HCOMBO mode clears `HEATER` — so neither control plane can mis-report after switching. `_is_heater_active` is consistent with `current_operation`.
- **Unified `_last_operation` tracking**: turn-on restores the exact last operation (standard heater *or* HCOMBO mode), not always HCOMBO. First-run default is **Heat Pump Only** (economical), not Dual.
- **Label-collision safe**: HCOMBO labels are only honoured on multimode bodies, and `operation_list` de-dupes, so a standard heater named like an HCOMBO label is never misrouted (a multimode body with a standard heater named exactly an HCOMBO label is a documented, pathological precedence).
- Coordinator tracks body `MODE` + heater `SUBTYP` for push updates.

## Validation
- **Live hardware (read-only)**: confirmed body `MODE` is a `HeaterType` (Pool `MODE=1`=OFF, Spa `MODE=2`=HEATER). The non-multimode (gas) path reproduces production entity states exactly (Pool → "off", Spa → "Gas Heater") — **no regression** to standard heaters.
- Production has **no HCOMBO heater** (gas only), so HCOMBO/mixed paths are validated by unit tests + adversarial review (Codex SHIP, Gemini approve), not hardware.
- **257 tests pass** (incl. mixed-body select/restore/stale-plane + collision coverage); `ruff` + `ruff format` + `mypy` clean.

Supersedes #46. Co-authored with @jbonta.
