### PR TITLE
chore: bump version to 3.7.0 + consolidate changelog

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.15"],
-  "version": "3.6.6",
+  "version": "3.7.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to the Pentair IntelliCenter integration will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.0] - 2026-05-31
 
 ### Fixed
+- **Retry setup on transient connection errors** (#41) - When Home Assistant restarts while IntelliCenter (or its bridge) is briefly unreachable or still booting, setup now raises `ConfigEntryNotReady` so HA retries with exponential backoff instead of leaving the entry in a permanent error state requiring a manual reload. Only connection-level failures are retried; a rejected command or non-network error still fails loudly, and the partially started coordinator is always torn down (no leaked reconnect task).
 - **HCOMBO heater control** - Multi-mode heaters (e.g. Pentair UltraTemp ETi Hybrid, subtype `HCOMBO`) can now be turned on and off correctly. IntelliCenter ignores `HEATER` attribute changes for HCOMBO heaters; the fix routes all control through the body's `MODE` attribute instead.
 
 ### Added
-- **HCOMBO operation modes** - Water heater entities backed by an HCOMBO heater now expose all four sub-modes as selectable operation modes: Gas Only, Heat Pump Only, Hybrid, and Dual. The last-used mode is remembered and restored on turn-on.
+- **HCOMBO operation modes** - Water heater entities backed by an HCOMBO heater now expose all four sub-modes as selectable operation modes: Gas Only, Heat Pump Only, Hybrid, and Dual. The last-used operation is remembered and restored on turn-on. Bodies with both an HCOMBO and a standard heater are fully supported.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.6.6"
+version = "3.7.0"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 requires-python = ">=3.13.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1247,7 +1247,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.6.6"
+version = "3.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Release prep for the two features merged since 3.6.6.

## Changes (metadata only)
- `manifest.json` + `pyproject.toml`: `3.6.6` → `3.7.0`
- `docs/CHANGELOG.md`: `[Unreleased]` → `[3.7.0] - 2026-05-31`, adding the retry-on-connection-error entry alongside the existing HCOMBO entries.

## Included in 3.7.0
- **Retry setup on transient connection errors** (#41 → #49) — `ConfigEntryNotReady` so HA retries with backoff instead of a permanent setup error; cleanup always runs.
- **HCOMBO multi-mode heater support** (#50) — UltraTemp ETi Hybrid; pure-standard, pure-HCOMBO, and mixed bodies.

## pyintellicenter pin — deliberately left at `>=0.1.15`
Nothing in 3.7.0 consumes the new 0.1.16 helpers (the retry fix uses 0.1.15 exception types; HCOMBO uses `request_changes`/inline reads). Bumping the pin to `>=0.1.16` should land together with a `uv.lock` refresh as a small follow-up once 0.1.16 is published to PyPI — keeping manifest ↔ pyproject ↔ lock in sync (the drift guard from #48 enforces this).

## Test plan
- `tests/test_versions.py` drift guard passes (3.7.0 == 3.7.0; pins consistent).
- Full suite: **257 passed**; `ruff` + `mypy` clean.
- No code changes — version/changelog only.
