### PR TITLE
chore: bump pyintellicenter pin to >=0.1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           pip install pytest pytest-asyncio pytest-cov \
             pytest-homeassistant-custom-component \
-            "pyintellicenter>=0.1.15"
+            "pyintellicenter>=0.1.16"
       - name: Run tests
         run: pytest tests/ -v --tb=short --cov=custom_components/intellicenter
       - name: Count tests

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.15"],
+  "requirements": ["pyintellicenter>=0.1.16"],
   "version": "3.7.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.1.15",
+    "pyintellicenter>=0.1.16",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1265,7 +1265,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.1.15" },
+    { name = "pyintellicenter", specifier = ">=0.1.16" },
 ]
 
 [package.metadata.requires-dev]
@@ -1968,16 +1968,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.15"
+version = "0.1.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/f3/b982e701aa24bf9c972dad3f46b1923371381daf868ef70134a76edb5949/pyintellicenter-0.1.15.tar.gz", hash = "sha256:7289cae45a13e9bb6e1d2f275bef0a717d1c5be37a803212200475489abf81b5", size = 45707, upload-time = "2026-02-26T14:32:14.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/5e/2c24032bff0c399e4d8a2ce8d98f29dee53117530ac60f2631b241e725f3/pyintellicenter-0.1.16.tar.gz", hash = "sha256:d854e43dc918954d5d97e26157c9bded746e1745830c1cc0b6bc08d4d7fba7f5", size = 50668, upload-time = "2026-06-01T02:41:09.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/a1/dc2d2e8f484cecc33b6e6a747d9af5783a5d76cd782a737f4f7925142b52/pyintellicenter-0.1.15-py3-none-any.whl", hash = "sha256:b8c3f41c30c2b6d72947b683ac08f945aac322edeb3d46a6233c5fe5f08407b9", size = 52404, upload-time = "2026-02-26T14:32:13.097Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b1/3abd93457c546d7689eb3abca1c9a454f4fb41865fd99920940a4cb07851/pyintellicenter-0.1.16-py3-none-any.whl", hash = "sha256:12983aab0915317a4395d6031468c6af4e73a7401c477f21638747b21b2bf5bc", size = 64314, upload-time = "2026-06-01T02:41:08.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Now that **pyintellicenter 0.1.16 is published to PyPI**, pin the integration to it. This was the deliberate follow-up split out of the 3.7.0 release (#51) — a pin can't be locked/installed until the library version exists on PyPI.

## Changes
Bumped `>=0.1.15` → `>=0.1.16` everywhere the drift guard (`tests/test_versions.py`) keeps in lockstep:
- `custom_components/intellicenter/manifest.json`
- `pyproject.toml`
- `uv.lock` (refreshed: `pyintellicenter 0.1.15 → 0.1.16`)
- `.github/workflows/ci.yml` (test install)

No code changes; the integration version stays `3.7.0`.

## Why
Makes the 0.1.16 helpers available to the integration and ensures HACS/HA install the library version 3.7.0 was validated against.

## Test plan
- Full suite **257 passed** against the real 0.1.16 (resolved from PyPI); `ruff` + `mypy` clean.
- `tests/test_versions.py` + `tests/test_library_contract.py` guards pass (manifest ↔ pyproject pins consistent; the API the integration calls exists in 0.1.16).