### PR TITLE
docs: update for v3.7.0 (HCOMBO, retry resilience, 257 tests, pyintellicenter>=0.1.16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This is a Home Assistant custom integration for Pentair IntelliCenter pool contr
 **Current Quality Scale**: **Platinum** ✅ (v3.1.0+)
 
 The integration meets **Platinum** quality scale requirements with:
-- 217 automated tests across all platforms
+- 257 automated tests across all platforms
 - Comprehensive type annotations (mypy strict mode)
 - Full code documentation
 - Production hardening (circuit breaker, metrics, health monitoring)
@@ -101,7 +101,7 @@ uv pip install -e /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter
 ```
 
 For normal test/CI runs the published release is used (per `manifest.json`:
-`pyintellicenter>=0.1.15`). Keep `pyproject.toml`'s pin and `uv.lock` in sync with
+`pyintellicenter>=0.1.16`). Keep `pyproject.toml`'s pin and `uv.lock` in sync with
 `manifest.json` — they have drifted in the past.
 
 ### Testing
@@ -188,7 +188,7 @@ The integration follows a layered architecture:
 
 2. **Protocol/Model Layer** (`pyintellicenter` - external package)
    - Separate repository: https://github.com/joyfulhouse/pyintellicenter (checked out at `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter`)
-   - Installed via `manifest.json` requirements: `pyintellicenter>=0.1.15`
+   - Installed via `manifest.json` requirements: `pyintellicenter>=0.1.16`
    - `controller.py` - Controller classes (all `IC`-prefixed):
      - `ICBaseController`: connection + command handling; exposes `ICSystemInfo` and `ICConnectionMetrics`
      - `ICModelController`: manages `PoolModel` state, tracks attribute changes, and provides domain control/query helpers (lights, pumps, heaters, bodies, chemistry). NOTE: this class is large (~1,200 lines / 130+ methods) and is the main refactor target
@@ -227,6 +227,7 @@ Entities are created based on equipment characteristics in the pool model:
 - **Light Shows**: Created for circuits with subtype `LITSHO`
 - **Switches**: Created for circuits marked as "Featured" (`FEATR_ATTR == "ON"`)
 - **Bodies of Water**: Create switch, temperature sensors, and water heater entities
+- **Heaters**: Standard heaters surface as a water_heater entity. HCOMBO (UltraTemp ETi Hybrid) heaters add multi-mode water_heater entities exposing Gas Only / Heat Pump Only / Hybrid / Dual operation modes (driven via the body `MODE` attribute, since IntelliCenter ignores `HEATER` writes for HCOMBO). The last-used operation is remembered and restored on turn-on; bodies with both an HCOMBO and a standard heater are supported.
 - **Pumps**: Create binary_sensor plus optional power/RPM/GPM sensors
 - **Schedules**: Create binary_sensors (disabled by default)
 - **IntelliChem**: Create pH, ORP, and tank level sensors
@@ -285,7 +286,7 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
   - Follows Home Assistant style guide
   - Type annotations present (ongoing improvements)
 - ✅ **Automated tests that verify integration can be configured correctly**
-  - ✅ Config flow tests (8 tests)
+  - ✅ Config flow tests (13 tests)
   - ✅ Platform setup tests
   - ✅ Entity tests (24+ tests)
 - ✅ Provides fundamental end-user documentation (README exists)
@@ -305,7 +306,7 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 - ✅ Supports translations (English in `strings.json`)
 - ✅ Extensive non-technical user documentation (README with troubleshooting, automation examples)
 - ⚠️ Firmware/software updates through HA - Not applicable (hardware doesn't support)
-- ✅ **Automated tests covering entire integration** - 217 tests across 11 test files
+- ✅ **Automated tests covering entire integration** - 257 tests across 13 test files
 - ✅ UI reconfiguration support (options flow for keepalive/reconnect settings)
 - ✅ Diagnostic capabilities (`diagnostics.py` with connection metrics)
 
@@ -346,18 +347,20 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 **Testing**: ✅ COMPLETE
 - ✅ **Comprehensive automated test suite** using `pytest-homeassistant-custom-component`:
   - **Config flow tests**: 13 tests
-  - **Integration tests**: 11 tests (includes PoolConnectionHandler)
+  - **Integration tests**: 21 tests (setup/unload, retry-on-transient-error, PoolConnectionHandler)
   - **Platform tests**:
     - Light: 47 tests (parameterized effect tests)
+    - Water Heater: 46 tests (incl. HCOMBO multi-mode operation)
     - Number: 33 tests (setpoint controls)
     - Climate: 22 tests (UltraTemp heat pump)
-    - Water Heater: 19 tests
     - Sensor: 18 tests (pH device class)
     - Cover: 17 tests (device class)
     - Binary Sensor: 15 tests
     - Switch: 11 tests (device class)
   - **Diagnostics tests**: 10 tests
-  - **Total**: 217 automated tests with TCP connection mocking
+  - **Library contract tests**: 2 tests
+  - **Version sync tests**: 2 tests
+  - **Total**: 257 automated tests across 13 test files with TCP connection mocking
   - Protocol, controller, and model tests are in the [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository
 - ✅ **Type checking**: mypy configuration (`mypy.ini`) with strict type checking enabled
 - ✅ **Code quality**: Pre-commit hooks configured with ruff, ruff-format, codespell, bandit
@@ -367,21 +370,21 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 **Platinum Quality Scale Status**: ✅ **ACHIEVED** (v3.1.0+)
 
 The integration now meets ALL Platinum quality requirements:
-1. ✅ **Bronze**: Automated test suite with 217 tests
+1. ✅ **Bronze**: Automated test suite with 257 tests
 2. ✅ **Silver**: Comprehensive troubleshooting documentation
 3. ✅ **Gold**: Extensive test coverage across all critical components
 4. ✅ **Platinum**: Complete implementation
    - ✅ Full type annotations in all critical modules
    - ✅ Comprehensive code comments explaining complex logic
    - ✅ Optimized async performance with orjson
-   - ✅ 217 automated tests covering protocol, controller, model, and platforms
+   - ✅ 257 automated tests covering config flow, setup/retry, and all platforms (protocol, controller, and model are tested in the pyintellicenter repository)
    - ✅ mypy type checking configured
    - ✅ All pre-commit hooks passing
 
 **Platinum Achievements Summary**:
 - **Type Safety**: Complete type annotations with mypy strict mode
 - **Code Documentation**: Detailed docstrings and comments throughout
-- **Test Coverage**: 217 tests across 11 test files
+- **Test Coverage**: 257 tests across 13 test files
 - **Performance**: Optimized async architecture with orjson and minimal network overhead
 - **Code Quality**: Automated linting and formatting with ruff
 - **Production Hardening**: Circuit breaker, connection metrics, health monitoring

--- a/README.md
+++ b/README.md
@@ -30,17 +30,12 @@ This integration connects your Pentair IntelliCenter pool control system to Home
 - **Multi-Language**: User interface available in 12 languages
 - **Easy Reconfiguration**: Change connection settings without removing the integration
 
-## What's New in v3.7
+## What's New in v3.7.0
 
-This release adds new equipment support and critical fixes:
+This release adds hybrid heater support and improves setup reliability:
 
-- **Climate Entity**: Full UltraTemp heat pump support with heating and cooling modes, preset detection, and real-time HVAC action tracking
-- **VSF Pump Control**: Variable Speed/Flow pump mode selection with unified speed/flow setpoint entities
-- **IntelliChem Dosing Sensors**: Monitor acid and chlorine dosing volumes
-- **Pump Speed/Flow Control**: Number entities for setting variable speed pump RPM/GPM targets
-- **Water Heater Fixes**: Resolved operation mode validation errors when changing heater modes
-- **Light Effect Fix**: Color effect control now works correctly with pyintellicenter 0.1.7+
-- **Broader Pump Support**: Removed restrictive subtype checks, supporting more pump configurations
+- **HCOMBO Multi-Mode Heaters**: UltraTemp ETi Hybrid (HCOMBO) heaters now expose Gas Only, Heat Pump Only, Hybrid, and Dual operation modes. The last-used operation is remembered and restored on turn-on, and bodies that combine an HCOMBO with a standard heater are fully supported.
+- **Resilient Setup**: Transient connection failures during startup now trigger Home Assistant's automatic retry with backoff instead of a permanent setup error, so the integration recovers on its own when the IntelliCenter is briefly unreachable.
 
 ## Architecture
 
@@ -137,14 +132,14 @@ After setup, configure connection settings:
 
 | Category | Entity Type | Features |
 |----------|-------------|----------|
-| **Pool/Spa** | Switch, Sensors, Water Heater | On/off, temperature, heater control |
+| **Pool/Spa** | Switch, Sensors, Water Heater | On/off, temperature, heater control (incl. HCOMBO hybrid modes) |
 | **Lights** | Light | On/off, color effects (IntelliBrite, MagicStream) |
 | **Light Shows** | Light | Coordinated multi-light effects |
 | **Circuits** | Switch | All "Featured" circuits (cleaner, blower, etc.) |
 | **Pumps** | Binary Sensor, Sensors | Running status, power (W), speed (RPM), flow (GPM) |
 | **Chemistry** | Sensors, Number | pH, ORP, tank levels, setpoints (IntelliChem) |
 | **Heat Pumps** | Climate | UltraTemp heating/cooling with presets |
-| **Heaters** | Binary Sensor | Running status |
+| **Heaters** | Binary Sensor, Water Heater | Running status; HCOMBO (UltraTemp ETi Hybrid) Gas/Heat Pump/Hybrid/Dual modes |
 | **Schedules** | Binary Sensor | Active status (disabled by default) |
 | **System** | Switch, Binary Sensor, Sensors | Vacation mode, freeze protection, temperatures |
 | **Covers** | Cover | Pool cover open/close control |
@@ -367,7 +362,7 @@ This integration meets the **Platinum tier** quality standards for Home Assistan
 **Gold Requirements:**
 - Full translation support (12 languages)
 - Easy reconfiguration through the UI
-- Comprehensive automated testing (217 tests)
+- Comprehensive automated testing (257 tests)
 - Extensive user-friendly documentation
 - Automatic Zeroconf discovery
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,11 @@ Technical documentation for developers working on the Pentair IntelliCenter Home
 
 | Metric | Value |
 |--------|-------|
-| **Current Version** | 3.6.6 |
+| **Current Version** | 3.7.0 |
 | **Quality Scale** | Platinum |
-| **Test Coverage** | 217 tests |
+| **Test Coverage** | 257 tests |
 | **Home Assistant** | 2025.11+ required |
-| **pyintellicenter** | 0.1.15+ required |
+| **pyintellicenter** | 0.1.16+ required |
 
 ## Documentation Index
 
@@ -40,7 +40,7 @@ intellicenter/
 │       ├── climate.py       # UltraTemp heat pump
 │       ├── number.py        # Setpoints
 │       └── cover.py         # Pool covers
-├── tests/                   # 216 automated tests
+├── tests/                   # 257 automated tests
 ├── docs/                    # This documentation
 └── README.md                # User guide
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,13 +4,15 @@ This document describes the automated testing infrastructure for the Pentair Int
 
 ## Test Framework
 
-This project uses `pytest` with the `pytest-homeassistant-custom-component` framework for automated testing. The test suite covers:
+This project uses `pytest` with the `pytest-homeassistant-custom-component` framework for automated testing. The integration test suite (257 tests across 13 files) covers:
 
 - **Config Flow Tests**: User setup, Zeroconf discovery, error handling
-- **Platform Tests**: Entity creation and behavior for all platforms (light, switch, sensor, etc.)
-- **Model Tests**: PoolModel and PoolObject state management
-- **Protocol Tests**: TCP communication and message handling (planned)
-- **Controller Tests**: Connection management and reconnection logic (planned)
+- **Integration/Setup Tests**: Entry setup and unload, retry on transient connection errors, connection handler behavior
+- **Platform Tests**: Entity creation and behavior for all platforms (light, switch, sensor, binary_sensor, water_heater, climate, number, cover)
+- **Diagnostics Tests**: Diagnostic data export
+- **Contract & Version Tests**: pyintellicenter library contract and version-sync guards
+
+**Protocol Tests**, **Controller Tests**, and **Model Tests** (TCP communication, connection management/reconnection, and PoolModel/PoolObject state) live in the standalone [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository, not here.
 
 ## Installation
 
@@ -120,26 +122,20 @@ Tests user-initiated setup and Zeroconf discovery:
 
 #### Integration Tests (`test_init.py`)
 
-Tests integration setup and lifecycle:
+Tests integration setup and lifecycle (21 tests):
 - ✅ Integration setup and entry loading
 - ✅ Entry unloading
-- ✅ Connection failure handling
+- ✅ Retry on transient connection errors (`ConfigEntryNotReady` so HA retries with backoff)
+- ✅ Loud failure on rejected-command / non-network errors
+- ✅ Clean teardown of the partially-started coordinator (no leaked reconnect task)
+- ✅ Connection handler behavior
 
-#### Model Tests (`test_model.py`)
-
-Tests PoolModel and PoolObject classes (24 tests):
-- ✅ PoolObject creation and properties
-- ✅ Light/switch/pump type detection
-- ✅ Status handling (on/off)
-- ✅ Attribute updates
-- ✅ PoolModel object management
-- ✅ Filtering by type/subtype
-- ✅ Parent-child relationships
-- ✅ Batch updates processing
+> **Model Tests**: PoolModel and PoolObject state-management tests live in the
+> [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository, not in this repo.
 
 #### Light Platform Tests (`test_light.py`)
 
-Comprehensive light entity tests (14 tests):
+Comprehensive light entity tests (47 tests, including parameterized effect tests):
 - ✅ Entity creation for IntelliBrite/regular lights/light shows
 - ✅ Turn on/off operations
 - ✅ Color effect support
@@ -149,67 +145,101 @@ Comprehensive light entity tests (14 tests):
 
 #### Switch Platform Tests (`test_switch.py`)
 
-Comprehensive switch entity tests (10 tests):
+Comprehensive switch entity tests (11 tests):
 - ✅ Entity creation for circuits and bodies
 - ✅ Turn on/off operations
 - ✅ Featured circuit filtering
 - ✅ Body (pool/spa) switch behavior
 - ✅ Vacation mode switch
 - ✅ State updates
+- ✅ Device class
 
 #### Sensor Platform Tests (`test_sensor.py`)
 
-Basic sensor tests (needs expansion):
-- ⚠️ Platform setup (stub only)
-- 🔄 Temperature sensors (planned)
-- 🔄 Power/RPM/GPM sensors (planned)
-- 🔄 Chemistry sensors (planned)
+Sensor entity tests (18 tests):
+- ✅ Temperature sensors
+- ✅ Power/RPM/GPM pump sensors
+- ✅ Chemistry sensors (pH device class, ORP, tank levels)
+- ✅ Platform setup and state updates
 
 #### Binary Sensor Tests (`test_binary_sensor.py`)
 
-Tests needed for:
-- 🔄 Pump status sensors
-- 🔄 Heater status sensors
-- 🔄 Schedule sensors
-- 🔄 Freeze protection sensor
+Binary sensor entity tests (15 tests):
+- ✅ Pump status sensors
+- ✅ Heater status sensors
+- ✅ Schedule sensors
+- ✅ Freeze protection sensor
 
-#### Water Heater Tests
+#### Water Heater Tests (`test_water_heater.py`)
 
-Tests needed for:
-- 🔄 Water heater entity creation
-- 🔄 Temperature setpoint changes
-- 🔄 Mode selection (heat/idle/off)
-- 🔄 Heater status tracking
+Water heater entity tests (46 tests):
+- ✅ Water heater entity creation
+- ✅ Temperature setpoint changes
+- ✅ Mode selection (heat/idle/off)
+- ✅ Heater status tracking
+- ✅ HCOMBO multi-mode operation (Gas Only / Heat Pump Only / Hybrid / Dual)
+- ✅ Last-used operation remembered and restored on turn-on
+- ✅ Bodies combining an HCOMBO with a standard heater
+
+#### Climate Tests (`test_climate.py`)
+
+UltraTemp heat pump climate tests (22 tests):
+- ✅ Heating/cooling modes and HVAC action
+- ✅ Setpoint changes and preset detection
+
+#### Number Platform Tests (`test_number.py`)
+
+Setpoint number entity tests (33 tests):
+- ✅ Chemistry setpoints and pump speed/flow targets
+
+#### Cover Platform Tests (`test_cover.py`)
+
+Pool cover entity tests (17 tests):
+- ✅ Open/close control and device class
+
+#### Diagnostics Tests (`test_diagnostics.py`)
+
+Diagnostic export tests (10 tests):
+- ✅ Connection metrics and config-entry diagnostics
+
+#### Contract & Version Tests
+
+- ✅ `test_library_contract.py` (2 tests): pyintellicenter API contract
+- ✅ `test_versions.py` (2 tests): manifest/pyproject version-sync guards
 
 ## Test Coverage Status
 
 ### Current Coverage
 
-**Total Tests**: 59 tests across 6 test files
+**Total Tests**: 257 tests across 13 test files
 
 | Component | Tests | Status |
 |-----------|-------|--------|
-| Config Flow | 8 tests | ✅ Complete |
-| Integration | 5 tests | ✅ Complete |
-| Model | 24 tests | ✅ Complete |
-| Light Platform | 14 tests | ✅ Complete |
-| Switch Platform | 10 tests | ✅ Complete |
-| Sensor Platform | 1 test | ⚠️ Needs expansion |
-| Binary Sensor | 0 tests | 🔄 Pending |
-| Water Heater | 0 tests | 🔄 Pending |
-| Number Platform | 0 tests | 🔄 Pending |
-| Cover Platform | 0 tests | 🔄 Pending |
-| Protocol Layer | 0 tests | 🔄 Pending |
-| Controller Layer | 0 tests | 🔄 Pending |
-| Diagnostics | 0 tests | 🔄 Pending |
+| Light Platform | 47 tests | ✅ Complete |
+| Water Heater | 46 tests | ✅ Complete |
+| Number Platform | 33 tests | ✅ Complete |
+| Climate Platform | 22 tests | ✅ Complete |
+| Integration / Setup | 21 tests | ✅ Complete |
+| Sensor Platform | 18 tests | ✅ Complete |
+| Cover Platform | 17 tests | ✅ Complete |
+| Binary Sensor | 15 tests | ✅ Complete |
+| Config Flow | 13 tests | ✅ Complete |
+| Switch Platform | 11 tests | ✅ Complete |
+| Diagnostics | 10 tests | ✅ Complete |
+| Library Contract | 2 tests | ✅ Complete |
+| Version Sync | 2 tests | ✅ Complete |
+| **Total** | **257 tests** | ✅ Complete |
+
+> Protocol, controller, and model tests are maintained in the standalone
+> [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository and are not counted here.
 
 ### Gold Quality Requirements Met
 
-✅ **Extensive automated test coverage** - 59 tests covering:
+✅ **Extensive automated test coverage** - 257 tests covering:
   - Config flow (user + Zeroconf)
-  - Platform entity creation
+  - Integration setup, unload, and retry-on-transient-error
+  - Platform entity creation across all platforms
   - Entity state management
-  - Model/object management
   - Turn on/off operations
   - State updates
 


### PR DESCRIPTION
Brings the docs in line with the v3.7.0 release (the CHANGELOG was already updated in #51 and is left untouched here).

## Updates
- **README.md** — new "What's New in v3.7.0" (HCOMBO multi-mode heaters + resilient setup); Supported Equipment notes HCOMBO hybrid modes on Pool/Spa + Heaters rows; test count 217 → **257**.
- **CLAUDE.md** — `217 → 257` tests + corrected per-platform breakdown (water_heater 46, init/integration 21, +library_contract 2, +versions 2; "11 → 13 test files"); pyintellicenter pin `0.1.15 → 0.1.16` (2 refs); added an HCOMBO entry to the entity-creation logic.
- **docs/README.md** — metadata table: Version `3.6.6 → 3.7.0`, Test Coverage `217 → 257`, pyintellicenter `0.1.15+ → 0.1.16+`.
- **docs/TESTING.md** — rebuilt the stale "59 tests / many platforms pending" summary to the real **257 across 13 files**, all platforms ✅, with protocol/controller/model noted as living in the pyintellicenter repo.

All test figures verified against `pytest --collect-only` (257 total; per-file counts in the commit). Docs-only — no code/manifest/pyproject/changelog changes.