### PR TITLE
feat: consume pyintellicenter 0.1.17 — SAm effect (#47) + runtime equipment detection (#42)

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -7,7 +7,7 @@ It supports Zeroconf discovery and local push updates for real-time responsivene
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 import contextlib
 import errno
 import logging
@@ -21,9 +21,13 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyintellicenter import (
+    BODY_ATTR,
+    BODY_TYPE,
+    HEATER_TYPE,
     STATUS_ATTR,
     ICConnectionError,
     ICModelController,
@@ -208,6 +212,95 @@ async def async_migrate_entry(
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
     # Currently at version 1.1, no migration needed yet
     return True
+
+
+# -------------------------------------------------------------------------------------
+# Dynamic entity setup helper
+# -------------------------------------------------------------------------------------
+
+
+def async_setup_pool_entities(
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    build_entities: Callable[
+        [IntelliCenterCoordinator, Iterable[PoolObject]], list[Any]
+    ],
+) -> None:
+    """Create entities now and whenever new pool objects appear at runtime.
+
+    Every platform builds its entities by inspecting the objects in the pool
+    model. This helper runs that builder once for the objects present at setup,
+    then registers a coordinator listener so the same builder runs for any
+    equipment that is added later (issue #42) - for example a second IntelliChem
+    controller coming online - without requiring a Home Assistant restart.
+
+    Entities are de-duplicated by ``unique_id`` so an object can never produce a
+    duplicate entity, even though the coordinator already reports each new object
+    only once.
+
+    Args:
+        entry: The config entry whose ``runtime_data`` is the coordinator.
+        async_add_entities: The platform's add-entities callback.
+        build_entities: Builds the entity objects for a set of candidate pool
+            objects. Receives the coordinator (for cross-object lookups) and the
+            objects to consider; returns the list of entities to add.
+    """
+    coordinator = entry.runtime_data
+    created_unique_ids: set[str] = set()
+
+    @callback
+    def _add(candidates: Iterable[PoolObject]) -> None:
+        entities: list[Any] = []
+        for entity in build_entities(coordinator, candidates):
+            uid = entity.unique_id
+            if uid in created_unique_ids:
+                continue
+            created_unique_ids.add(uid)
+            entities.append(entity)
+        if entities:
+            async_add_entities(entities)
+
+    # Initial population from the objects discovered at setup.
+    _add(list(coordinator.model))
+
+    # Dynamic population for objects added after startup.
+    entry.async_on_unload(coordinator.async_add_new_objects_listener(_add))
+
+
+def bodies_affected_by(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolObject]:
+    """Return bodies of water touched by the candidate objects.
+
+    Heater-dependent platforms (water_heater, climate) create one entity per
+    body, but whether that entity exists depends on the heaters wired to the
+    body. A body is included when it is itself a candidate OR when a candidate
+    heater serves it, so adding a heater to an existing body re-evaluates that
+    body (issue #42). Duplicate entities for bodies that already have one are
+    filtered by ``async_setup_pool_entities`` via ``unique_id``.
+
+    Args:
+        coordinator: The coordinator providing the pool model.
+        candidates: The newly-considered pool objects.
+
+    Returns:
+        The list of body PoolObjects to (re)evaluate.
+    """
+    body_objnams: set[str] = set()
+    for obj in candidates:
+        if obj.objtype == BODY_TYPE:
+            body_objnams.add(obj.objnam)
+        elif obj.objtype == HEATER_TYPE:
+            served = obj[BODY_ATTR]
+            if served:
+                body_objnams.update(served.split(" "))
+
+    bodies: list[PoolObject] = []
+    for objnam in body_objnams:
+        body = coordinator.model[objnam]
+        if body is not None and body.objtype == BODY_TYPE:
+            bodies.append(body)
+    return bodies
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/binary_sensor.py
+++ b/custom_components/intellicenter/binary_sensor.py
@@ -55,7 +55,6 @@ def _build_entities(
     """Build binary sensor entities for the given candidate pool objects."""
     sensors: list[PoolBinarySensor | HeaterBinarySensor | ScheduleBinarySensor] = []
 
-    obj: PoolObject
     for obj in candidates:
         if obj.objtype == CIRCUIT_TYPE and obj.subtype == "FRZ":
             sensors.append(

--- a/custom_components/intellicenter/binary_sensor.py
+++ b/custom_components/intellicenter/binary_sensor.py
@@ -10,6 +10,7 @@ This module provides binary sensor entities for:
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -39,7 +40,7 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,18 +49,14 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Load pool binary sensors based on a config entry."""
-    coordinator = entry.runtime_data
-
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolBinarySensor | HeaterBinarySensor | ScheduleBinarySensor]:
+    """Build binary sensor entities for the given candidate pool objects."""
     sensors: list[PoolBinarySensor | HeaterBinarySensor | ScheduleBinarySensor] = []
 
     obj: PoolObject
-    for obj in coordinator.model:
+    for obj in candidates:
         if obj.objtype == CIRCUIT_TYPE and obj.subtype == "FRZ":
             sensors.append(
                 PoolBinarySensor(
@@ -143,7 +140,16 @@ async def async_setup_entry(
                         entity_category=EntityCategory.DIAGNOSTIC,
                     )
                 )
-    async_add_entities(sensors)
+    return sensors
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load pool binary sensors based on a config entry."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/climate.py
+++ b/custom_components/intellicenter/climate.py
@@ -13,6 +13,7 @@ Climate entities support:
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -28,7 +29,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     BODY_ATTR,
-    BODY_TYPE,
     HEATER_ATTR,
     HEATER_TYPE,
     HITMP_ATTR,
@@ -42,7 +42,12 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import (
+    IntelliCenterConfigEntry,
+    PoolEntity,
+    async_setup_pool_entities,
+    bodies_affected_by,
+)
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,40 +56,48 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up climate entities for bodies with cooling support."""
-    coordinator = entry.runtime_data
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolClimate]:
+    """Build climate entities for cooling-capable bodies affected by candidates.
 
+    Only bodies whose heat pump supports cooling get a climate entity. A body is
+    (re)evaluated when it is itself a candidate OR when a candidate heater serves
+    it (issue #42). Duplicate entities for already-known bodies are filtered by
+    the caller via ``unique_id``.
+    """
     # Find all heaters sorted by UI order
     heaters = sorted(
         coordinator.model.get_by_type(HEATER_TYPE),
         key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
     )
 
-    bodies = coordinator.model.get_by_type(BODY_TYPE)
-
-    climate_entities = []
-    body: PoolObject
-    for body in bodies:
+    climate_entities: list[PoolClimate] = []
+    for body in bodies_affected_by(coordinator, candidates):
         # Check if this body supports cooling (has UltraTemp heat pump)
         if not coordinator.controller.body_supports_cooling(body.objnam):
             continue
 
         # Build list of heaters that support this body
-        heater_list = []
-        heater: PoolObject
-        for heater in heaters:
-            if body.objnam in heater[BODY_ATTR].split(" "):
-                heater_list.append(heater.objnam)
+        heater_list = [
+            heater.objnam
+            for heater in heaters
+            if body.objnam in heater[BODY_ATTR].split(" ")
+        ]
 
         if heater_list:
             climate_entities.append(PoolClimate(coordinator, body, heater_list))
 
-    async_add_entities(climate_entities)
+    return climate_entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up climate entities for bodies with cooling support."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 class PoolClimate(PoolEntity, ClimateEntity):

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -358,6 +358,12 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         already know about. Any new objects are recorded and dispatched to the
         registered listeners so the platforms can create entities for them at
         runtime. Does nothing until the initial connection has completed.
+
+        Independent new objects (e.g. a newly-installed IntelliChem) are handled
+        fully. Objects whose entities depend on *another* object — a heater added
+        to an existing body, or a PMPCIRC arriving before its parent pump in a
+        separate update — may still require an integration reload (tracked in
+        issue #57).
         """
         if not self._started:
             return
@@ -369,7 +375,9 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
             return
 
         # Record before notifying so a listener cannot observe the objects as
-        # "new" a second time (e.g. via a re-entrant refresh).
+        # "new" a second time (e.g. via a re-entrant refresh); duplicate entity
+        # creation is additionally guarded by unique_id de-duplication in the
+        # platforms.
         self._known_objnams.update(obj.objnam for obj in new_objects)
 
         _LOGGER.debug(
@@ -377,8 +385,17 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
             len(new_objects),
             ", ".join(obj.objnam for obj in new_objects),
         )
+        # Dispatch to each platform independently: a failure in one platform's
+        # builder must not skip the rest. Builders are deterministic, so a logged
+        # error would recur rather than resolve on retry, which is why the objects
+        # stay recorded as known above.
         for listener in list(self._new_objects_listeners):
-            listener(new_objects)
+            try:
+                listener(new_objects)
+            except Exception:
+                _LOGGER.exception(
+                    "Error dispatching new pool objects to a platform listener"
+                )
 
     @callback
     def async_set_updated_data(self, data: dict[str, dict[str, Any]]) -> None:

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -8,6 +8,7 @@ notifications from the controller.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 from typing import Any
 
@@ -83,11 +84,17 @@ from pyintellicenter import (
     ICModelController,
     ICSystemInfo,
     PoolModel,
+    PoolObject,
 )
 
 from .const import DEFAULT_TRANSPORT, DOMAIN, TransportType
 
 _LOGGER = logging.getLogger(__name__)
+
+# Callback invoked when previously-unseen pool objects appear in the model at
+# runtime. Each platform registers one of these so it can create entities for
+# newly-added equipment without requiring a Home Assistant restart (issue #42).
+NewObjectsListener = Callable[[list[PoolObject]], None]
 
 # Default attribute tracking map - defines which attributes to monitor per object type
 DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
@@ -239,6 +246,18 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         self._stop_listener: CALLBACK_TYPE | None = None
         self._connected = False
 
+        # Dynamic-entity-addition state (issue #42).
+        # `_known_objnams` is the set of object identifiers the platforms have
+        # already created entities for. It is seeded once the initial connection
+        # completes (so the objects present at setup are not treated as "new"),
+        # then reconciled against the model whenever updates arrive or the
+        # connection is (re)established. `_started` gates detection so the burst
+        # of attribute updates emitted during the very first controller.start()
+        # is ignored - the seed captures that full initial object set instead.
+        self._known_objnams: set[str] = set()
+        self._started = False
+        self._new_objects_listeners: list[NewObjectsListener] = []
+
     @property
     def controller(self) -> ICModelController:
         """Return the ICModelController."""
@@ -275,6 +294,12 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         await self._handler.start()
         self._connected = True
 
+        # Snapshot the objects discovered during the initial connection. Anything
+        # that appears in the model after this point is treated as newly-added
+        # equipment and dispatched to the registered platform listeners.
+        self._known_objnams = {obj.objnam for obj in self._model}
+        self._started = True
+
     async def async_stop(self) -> None:
         """Stop the connection to the IntelliCenter."""
         # Cancel stop listener
@@ -300,6 +325,62 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         return {}
 
     @callback
+    def async_add_new_objects_listener(
+        self, listener: NewObjectsListener
+    ) -> CALLBACK_TYPE:
+        """Register a callback for newly-added pool objects.
+
+        Each platform registers a listener during setup so it can create
+        entities for equipment that appears after the integration has started
+        (issue #42), e.g. a second IntelliChem controller coming online. The
+        listener receives the list of new PoolObjects each time previously-unseen
+        objects are detected in the model.
+
+        Args:
+            listener: Callback invoked with the list of new PoolObjects.
+
+        Returns:
+            A callable that unregisters the listener.
+        """
+        self._new_objects_listeners.append(listener)
+
+        @callback
+        def _remove_listener() -> None:
+            self._new_objects_listeners.remove(listener)
+
+        return _remove_listener
+
+    @callback
+    def _async_detect_new_objects(self) -> None:
+        """Detect objects added to the model and notify platform listeners.
+
+        Compares the current model against the set of objects the platforms
+        already know about. Any new objects are recorded and dispatched to the
+        registered listeners so the platforms can create entities for them at
+        runtime. Does nothing until the initial connection has completed.
+        """
+        if not self._started:
+            return
+
+        new_objects = [
+            obj for obj in self._model if obj.objnam not in self._known_objnams
+        ]
+        if not new_objects:
+            return
+
+        # Record before notifying so a listener cannot observe the objects as
+        # "new" a second time (e.g. via a re-entrant refresh).
+        self._known_objnams.update(obj.objnam for obj in new_objects)
+
+        _LOGGER.debug(
+            "Detected %d new pool object(s): %s",
+            len(new_objects),
+            ", ".join(obj.objnam for obj in new_objects),
+        )
+        for listener in list(self._new_objects_listeners):
+            listener(new_objects)
+
+    @callback
     def async_set_updated_data(self, data: dict[str, dict[str, Any]]) -> None:
         """Handle push update from IntelliCenter.
 
@@ -310,6 +391,9 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
             data: Dictionary of object updates {objnam: {attr: value}}
         """
         self.data = data
+        # New equipment can enter the model on a reconnect (the controller
+        # re-fetches every object on start), so reconcile before fanning out.
+        self._async_detect_new_objects()
         self.async_update_listeners()
 
     @callback
@@ -320,6 +404,10 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
             connected: True if connected, False if disconnected
         """
         self._connected = connected
+        # A reconnect re-fetches the full object list into the model; surface any
+        # equipment that was added while the connection was down.
+        if connected:
+            self._async_detect_new_objects()
         # Notify all listeners of the connection state change
         self.async_update_listeners()
 

--- a/custom_components/intellicenter/cover.py
+++ b/custom_components/intellicenter/cover.py
@@ -5,6 +5,7 @@ This module provides cover entities for pool covers and other motorized covers.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -24,7 +25,7 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,22 +36,24 @@ PARALLEL_UPDATES = 0
 # -------------------------------------------------------------------------------------
 
 
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolCover]:
+    """Build cover entities for the given candidate pool objects."""
+    covers: list[PoolCover] = []
+    for pool_obj in candidates:
+        if pool_obj.objtype == EXTINSTR_TYPE and pool_obj.subtype == "COVER":
+            covers.append(PoolCover(coordinator, pool_obj))
+    return covers
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: IntelliCenterConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Load pool cover entities based on a config entry."""
-    coordinator = entry.runtime_data
-
-    covers: list[PoolCover] = []
-
-    pool_obj: PoolObject
-    for pool_obj in coordinator.model:
-        if pool_obj.objtype == EXTINSTR_TYPE and pool_obj.subtype == "COVER":
-            covers.append(PoolCover(coordinator, pool_obj))
-
-    async_add_entities(covers)
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/light.py
+++ b/custom_components/intellicenter/light.py
@@ -6,6 +6,7 @@ Supports color effects for IntelliBrite, MagicStream, and GloBrite lights.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any, ClassVar
 
@@ -26,7 +27,7 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,18 +36,12 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Load pool lights based on a config entry."""
-    coordinator = entry.runtime_data
-
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolLight]:
+    """Build light entities for the given candidate pool objects."""
     lights: list[PoolLight] = []
-
-    obj: PoolObject
-    for obj in coordinator.model:
+    for obj in candidates:
         if obj.is_a_light:
             lights.append(
                 PoolLight(
@@ -70,8 +65,16 @@ async def async_setup_entry(
                     LIGHT_EFFECTS if supports_color else None,
                 )
             )
+    return lights
 
-    async_add_entities(lights)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load pool lights based on a config entry."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 class PoolLight(PoolEntity, LightEntity):

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.16"],
+  "requirements": ["pyintellicenter>=0.1.17"],
   "version": "3.7.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}

--- a/custom_components/intellicenter/number.py
+++ b/custom_components/intellicenter/number.py
@@ -107,7 +107,6 @@ def _build_entities(
 
     numbers: list[PoolNumber | PumpSpeedNumber] = []
 
-    pool_obj: PoolObject
     for pool_obj in candidate_objects:
         if pool_obj.objtype == CHEM_TYPE:
             if pool_obj.subtype == "ICHLOR" and PRIM_ATTR in pool_obj.attribute_keys:

--- a/custom_components/intellicenter/number.py
+++ b/custom_components/intellicenter/number.py
@@ -9,7 +9,7 @@ This module provides number entities for:
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 import logging
 from typing import Any
 
@@ -50,7 +50,7 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
 from .const import CONST_GPM, CONST_RPM
 from .coordinator import IntelliCenterCoordinator
 
@@ -98,18 +98,17 @@ PUMP_GPM_STEP = 5
 # -------------------------------------------------------------------------------------
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Load pool number entities based on a config entry."""
-    coordinator = entry.runtime_data
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolNumber | PumpSpeedNumber]:
+    """Build number entities for the given candidate pool objects."""
+    # Materialize so the candidate objects can be iterated more than once below.
+    candidate_objects = list(candidates)
 
     numbers: list[PoolNumber | PumpSpeedNumber] = []
 
     pool_obj: PoolObject
-    for pool_obj in coordinator.model:
+    for pool_obj in candidate_objects:
         if pool_obj.objtype == CHEM_TYPE:
             if pool_obj.subtype == "ICHLOR" and PRIM_ATTR in pool_obj.attribute_keys:
                 # IntelliChlor output percentage controls (CONFIG category)
@@ -231,7 +230,7 @@ async def async_setup_entry(
                     )
 
     # Add body max temperature setpoints (HITMP) - CONFIG category
-    for pool_obj in coordinator.model:
+    for pool_obj in candidate_objects:
         if pool_obj.objtype == BODY_TYPE and HITMP_ATTR in pool_obj.attribute_keys:
             numbers.append(
                 PoolNumber(
@@ -252,7 +251,7 @@ async def async_setup_entry(
 
     # Add pump circuit speed/flow setpoints (PMPCIRC) - CONFIG category
     # These allow control of variable speed pump settings per circuit
-    for pool_obj in coordinator.model:
+    for pool_obj in candidate_objects:
         if pool_obj.objtype == PMPCIRC_TYPE:
             # Get the parent pump to determine limits and type
             parent_objnam = pool_obj[PARENT_ATTR]
@@ -361,7 +360,16 @@ async def async_setup_entry(
                     )
                 )
 
-    async_add_entities(numbers)
+    return numbers
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load pool number entities based on a config entry."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/select.py
+++ b/custom_components/intellicenter/select.py
@@ -44,7 +44,6 @@ def _build_entities(
     """Build pump-mode select entities for the given candidate pool objects."""
     selects: list[PumpModeSelect] = []
 
-    pool_obj: PoolObject
     for pool_obj in candidates:
         # Create pump mode selector only for PMPCIRC objects where the parent pump
         # supports BOTH RPM (MAX_ATTR > 0) and GPM (MAXF_ATTR > 0) modes

--- a/custom_components/intellicenter/select.py
+++ b/custom_components/intellicenter/select.py
@@ -6,6 +6,7 @@ This module provides select entities for pump circuit mode selection
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -23,7 +24,7 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,18 +38,14 @@ PUMP_MODE_GPM = "GPM"
 PUMP_MODES = [PUMP_MODE_RPM, PUMP_MODE_GPM]
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Load Pentair select entities based on a config entry."""
-    coordinator = entry.runtime_data
-
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PumpModeSelect]:
+    """Build pump-mode select entities for the given candidate pool objects."""
     selects: list[PumpModeSelect] = []
 
     pool_obj: PoolObject
-    for pool_obj in coordinator.model:
+    for pool_obj in candidates:
         # Create pump mode selector only for PMPCIRC objects where the parent pump
         # supports BOTH RPM (MAX_ATTR > 0) and GPM (MAXF_ATTR > 0) modes
         if pool_obj.objtype == PMPCIRC_TYPE and SELECT_ATTR in pool_obj.attribute_keys:
@@ -94,7 +91,16 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(selects)
+    return selects
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load Pentair select entities based on a config entry."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 class PumpModeSelect(PoolEntity, SelectEntity):

--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -12,6 +12,7 @@ as they are user-entered configuration, not sensor readings.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -52,7 +53,7 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
 from .const import CONST_GPM, CONST_RPM
 from .coordinator import IntelliCenterCoordinator
 
@@ -64,18 +65,14 @@ PARALLEL_UPDATES = 0
 # -------------------------------------------------------------------------------------
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Load pool sensors based on a config entry."""
-    coordinator = entry.runtime_data
-
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolSensor]:
+    """Build sensor entities for the given candidate pool objects."""
     sensors: list[PoolSensor] = []
 
     obj: PoolObject
-    for obj in coordinator.model:
+    for obj in candidates:
         if obj.objtype == SENSE_TYPE:
             sensors.append(
                 PoolSensor(
@@ -301,7 +298,16 @@ async def async_setup_entry(
                         state_class=None,  # Non-numeric value
                     )
                 )
-    async_add_entities(sensors)
+    return sensors
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load pool sensors based on a config entry."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -71,7 +71,6 @@ def _build_entities(
     """Build sensor entities for the given candidate pool objects."""
     sensors: list[PoolSensor] = []
 
-    obj: PoolObject
     for obj in candidates:
         if obj.objtype == SENSE_TYPE:
             sensors.append(

--- a/custom_components/intellicenter/switch.py
+++ b/custom_components/intellicenter/switch.py
@@ -6,6 +6,7 @@ superchlorinate mode, and vacation mode.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -27,7 +28,12 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, OnOffControlMixin, PoolEntity
+from . import (
+    IntelliCenterConfigEntry,
+    OnOffControlMixin,
+    PoolEntity,
+    async_setup_pool_entities,
+)
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,18 +42,12 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: IntelliCenterConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Load Pentair switch entities based on a config entry."""
-    coordinator = entry.runtime_data
-
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolCircuit]:
+    """Build switch entities for the given candidate pool objects."""
     switches: list[PoolCircuit] = []
-
-    pool_obj: PoolObject
-    for pool_obj in coordinator.model:
+    for pool_obj in candidates:
         if pool_obj.objtype == BODY_TYPE:
             switches.append(PoolBody(coordinator, pool_obj))
         elif (
@@ -79,8 +79,16 @@ async def async_setup_entry(
         elif pool_obj.objtype == SYSTEM_TYPE:
             # Vacation mode uses convenience method
             switches.append(PoolVacation(coordinator, pool_obj))
+    return switches
 
-    async_add_entities(switches)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load Pentair switch entities based on a config entry."""
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 class PoolCircuit(PoolEntity, OnOffControlMixin, SwitchEntity):

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -25,6 +25,7 @@ returns the body to its previous mode.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 from typing import Any
 
@@ -38,7 +39,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from pyintellicenter import (
     BODY_ATTR,
-    BODY_TYPE,
     HEATER_ATTR,
     HEATER_TYPE,
     HTMODE_ATTR,
@@ -53,7 +53,12 @@ from pyintellicenter import (
     PoolObject,
 )
 
-from . import IntelliCenterConfigEntry, PoolEntity
+from . import (
+    IntelliCenterConfigEntry,
+    PoolEntity,
+    async_setup_pool_entities,
+    bodies_affected_by,
+)
 from .coordinator import IntelliCenterCoordinator
 
 # IntelliCenter subtype for multi-mode combo heaters (e.g. UltraTemp ETi Hybrid)
@@ -76,39 +81,46 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
+def _build_entities(
+    coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
+) -> list[PoolWaterHeater]:
+    """Build water heater entities for bodies affected by the candidate objects.
+
+    A water heater belongs to a body of water but its existence depends on the
+    heaters wired to that body. A body is therefore (re)considered when the body
+    itself is a candidate OR when a candidate heater serves it, so that adding a
+    heater to an existing body surfaces a water heater entity too. Duplicate
+    entities for already-known bodies are filtered out by the caller via
+    ``unique_id``.
+    """
+    # All heaters, sorted by their UI order (objects without one go last).
+    heaters = sorted(
+        coordinator.model.get_by_type(HEATER_TYPE),
+        key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
+    )
+
+    bodies_to_consider = bodies_affected_by(coordinator, candidates)
+
+    water_heaters: list[PoolWaterHeater] = []
+    for body in bodies_to_consider:
+        heater_list = [
+            heater.objnam
+            for heater in heaters
+            if body.objnam in heater[BODY_ATTR].split(" ")
+        ]
+        if heater_list:
+            water_heaters.append(PoolWaterHeater(coordinator, body, heater_list))
+
+    return water_heaters
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: IntelliCenterConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Load pool water heater entities based on a config entry."""
-    coordinator = entry.runtime_data
-
-    # here we try to figure out which heater, if any, can be used for a given
-    # body of water
-
-    # first find all heaters
-    # and sort them by their UI order (if they don't have one, use 100 and place them last)
-    heaters = sorted(
-        coordinator.model.get_by_type(HEATER_TYPE),
-        key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
-    )
-
-    bodies = coordinator.model.get_by_type(BODY_TYPE)
-
-    water_heaters = []
-    body: PoolObject
-    for body in bodies:
-        heater_list = []
-        heater: PoolObject
-        for heater in heaters:
-            # if the heater supports this body, add it to the list
-            if body.objnam in heater[BODY_ATTR].split(" "):
-                heater_list.append(heater.objnam)
-        if heater_list:
-            water_heaters.append(PoolWaterHeater(coordinator, body, heater_list))
-
-    async_add_entities(water_heaters)
+    async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -99,10 +99,8 @@ def _build_entities(
         key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
     )
 
-    bodies_to_consider = bodies_affected_by(coordinator, candidates)
-
     water_heaters: list[PoolWaterHeater] = []
-    for body in bodies_to_consider:
+    for body in bodies_affected_by(coordinator, candidates):
         heater_list = [
             heater.objnam
             for heater in heaters

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Options flow 500 error** (#40) - Opening the integration options (the gear icon on the integration card) raised *"Config flow could not be loaded: 500 Internal Server Error"*. `OptionsFlowHandler` assigned `self.config_entry` in its `__init__`, but Home Assistant made `config_entry` a read-only property on the base `OptionsFlow` and removed the deprecated setter in 2025.12, so the assignment raised `AttributeError: property 'config_entry' ... has no setter` on current Home Assistant. The handler now relies on the `config_entry` that the base class provides. Thanks to @jeffstearns for the detailed report and traceback.
+- **SAm light show missing from effect list** (#47) - The SAm IntelliBrite light show (reported by IntelliCenter as `USE=SAMMOD`) was missing from the effect map, so selecting it from the controller or IntelliCenter web app left the Home Assistant light entity's effect showing null. Added the `SAMMOD` -> "SAm" mapping in pyintellicenter (>=0.1.17). Thanks to @CrewDawg72 for reporting.
 
 ### Changed
 - **Test/dev environment now tracks released Home Assistant** - Bumped the test stack to Home Assistant 2026.5.4 (Python 3.14.2+, `pytest-homeassistant-custom-component` 0.13.333) to match production. The previous pin (HA 2025.11.3) still shipped the deprecated options-flow `config_entry` setter (warn-only for custom integrations), which silently masked #40 in CI; tracking the shipped HA version ensures such removals are exercised before release.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Options flow 500 error** (#40) - Opening the integration options (the gear icon on the integration card) raised *"Config flow could not be loaded: 500 Internal Server Error"*. `OptionsFlowHandler` assigned `self.config_entry` in its `__init__`, but Home Assistant made `config_entry` a read-only property on the base `OptionsFlow` and removed the deprecated setter in 2025.12, so the assignment raised `AttributeError: property 'config_entry' ... has no setter` on current Home Assistant. The handler now relies on the `config_entry` that the base class provides. Thanks to @jeffstearns for the detailed report and traceback.
-- **SAm light show missing from effect list** (#47) - The SAm IntelliBrite light show (reported by IntelliCenter as `USE=SAMMOD`) was missing from the effect map, so selecting it from the controller or IntelliCenter web app left the Home Assistant light entity's effect showing null. Added the `SAMMOD` -> "SAm" mapping in pyintellicenter (>=0.1.17). Thanks to @CrewDawg72 for reporting.
+### Added
+- **Runtime detection of newly-added equipment** (#42) - Equipment added to the Pentair system after Home Assistant has started (for example a second IntelliChem controller coming online) now surfaces its sensors and controls automatically, without requiring a restart. The coordinator watches the pool model for previously-unseen objects and notifies each platform so it can create the matching entities at runtime. Thanks to @bhamiltoncx for the report.
 
 ### Changed
 - **Test/dev environment now tracks released Home Assistant** - Bumped the test stack to Home Assistant 2026.5.4 (Python 3.14.2+, `pytest-homeassistant-custom-component` 0.13.333) to match production. The previous pin (HA 2025.11.3) still shipped the deprecated options-flow `config_entry` setter (warn-only for custom integrations), which silently masked #40 in CI; tracking the shipped HA version ensures such removals are exercised before release.
+
+### Fixed
+- **Options flow 500 error** (#40) - Opening the integration options (the gear icon on the integration card) raised *"Config flow could not be loaded: 500 Internal Server Error"*. `OptionsFlowHandler` assigned `self.config_entry` in its `__init__`, but Home Assistant made `config_entry` a read-only property on the base `OptionsFlow` and removed the deprecated setter in 2025.12, so the assignment raised `AttributeError: property 'config_entry' ... has no setter` on current Home Assistant. The handler now relies on the `config_entry` that the base class provides. Thanks to @jeffstearns for the detailed report and traceback.
+- **SAm light show missing from effect list** (#47) - The SAm IntelliBrite light show (reported by IntelliCenter as `USE=SAMMOD`) was missing from the effect map, so selecting it from the controller or IntelliCenter web app left the Home Assistant light entity's effect showing null. Added the `SAMMOD` -> "SAm" mapping in pyintellicenter (>=0.1.17). Thanks to @CrewDawg72 for reporting.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.1.16",
+    "pyintellicenter>=0.1.17",
 ]
 
 [tool.ruff]

--- a/tests/test_dynamic_entities.py
+++ b/tests/test_dynamic_entities.py
@@ -1,0 +1,406 @@
+"""Tests for runtime dynamic entity addition (issue #42).
+
+When new equipment appears in the pool model after the integration has started
+(for example a second IntelliChem controller coming online), the platforms must
+create entities for it without requiring a Home Assistant restart. These tests
+cover both halves of the mechanism:
+
+* the coordinator detecting previously-unseen objects and notifying listeners,
+* the platforms creating the right entities for those objects while never
+  duplicating entities for objects that already have them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from pyintellicenter import CHEM_TYPE, SENSE_TYPE, PoolModel, PoolObject
+import pytest
+
+from custom_components.intellicenter import (
+    async_setup_pool_entities,
+    bodies_affected_by,
+)
+from custom_components.intellicenter.coordinator import IntelliCenterCoordinator
+
+# A second IntelliChem controller - the exact scenario reported in issue #42.
+# Includes both sensor readings (PHVAL/ORPVAL/tank levels) and the controllable
+# setpoints/config attributes so it exercises multiple platforms.
+CHEM2_OBJNAM = "CHEM2"
+CHEM2_PARAMS: dict[str, str] = {
+    "OBJTYP": CHEM_TYPE,
+    "SUBTYP": "ICHEM",
+    "SNAME": "IntelliChem 2",
+    "PHVAL": "7.5",
+    "ORPVAL": "700",
+    "PHTNK": "6",
+    "ORPTNK": "6",
+    "PHSET": "7.4",
+    "ORPSET": "700",
+    "ALK": "100",
+    "CALC": "300",
+    "CYACID": "40",
+}
+
+# A second temperature sensor.
+SENSE2_OBJNAM = "SENSE2"
+SENSE2_PARAMS: dict[str, str] = {
+    "OBJTYP": SENSE_TYPE,
+    "SUBTYP": "POOL",
+    "SNAME": "Water Temp",
+    "SOURCE": "80",
+}
+
+
+def _make_coordinator(
+    hass: HomeAssistant, model: PoolModel
+) -> IntelliCenterCoordinator:
+    """Build a real coordinator wired to a pre-populated model.
+
+    The coordinator is put in the "started" state with its known-object snapshot
+    seeded from ``model`` - mirroring the state right after async_start().
+    """
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "test_entry"
+    entry.data = {CONF_HOST: "192.168.1.100"}
+
+    coordinator = IntelliCenterCoordinator(hass, entry, host="192.168.1.100")
+    # Replace the controller's empty model with our populated test model.
+    coordinator._model = model
+    # Simulate the post-start seed: every current object is already known.
+    coordinator._known_objnams = {obj.objnam for obj in model}
+    coordinator._started = True
+    return coordinator
+
+
+# -------------------------------------------------------------------------------------
+# Coordinator detection
+# -------------------------------------------------------------------------------------
+
+
+class TestCoordinatorNewObjectDetection:
+    """Tests for IntelliCenterCoordinator new-object detection."""
+
+    async def test_listener_notified_for_new_object(
+        self, hass: HomeAssistant, pool_model: PoolModel
+    ) -> None:
+        """A newly-added object is dispatched to registered listeners."""
+        coordinator = _make_coordinator(hass, pool_model)
+
+        received: list[list[PoolObject]] = []
+        coordinator.async_add_new_objects_listener(received.append)
+
+        # New equipment enters the model (as it would after a reconnect re-fetch).
+        pool_model.add_object(CHEM2_OBJNAM, dict(CHEM2_PARAMS))
+        coordinator._async_detect_new_objects()
+
+        assert len(received) == 1
+        assert [obj.objnam for obj in received[0]] == ["CHEM2"]
+        # The new object is now tracked, so it is not reported again.
+        coordinator._async_detect_new_objects()
+        assert len(received) == 1
+
+    async def test_no_notification_for_known_objects(
+        self, hass: HomeAssistant, pool_model: PoolModel
+    ) -> None:
+        """Objects present at startup never trigger the new-object listeners."""
+        coordinator = _make_coordinator(hass, pool_model)
+
+        received: list[list[PoolObject]] = []
+        coordinator.async_add_new_objects_listener(received.append)
+
+        coordinator._async_detect_new_objects()
+
+        assert received == []
+
+    async def test_no_notification_before_started(
+        self, hass: HomeAssistant, pool_model: PoolModel
+    ) -> None:
+        """Detection is a no-op until the initial connection has completed.
+
+        This keeps the burst of attribute updates emitted during the very first
+        controller.start() from being misread as newly-added equipment.
+        """
+        coordinator = _make_coordinator(hass, pool_model)
+        coordinator._started = False
+        coordinator._known_objnams = set()
+
+        received: list[list[PoolObject]] = []
+        coordinator.async_add_new_objects_listener(received.append)
+
+        pool_model.add_object(CHEM2_OBJNAM, dict(CHEM2_PARAMS))
+        coordinator._async_detect_new_objects()
+
+        assert received == []
+
+    async def test_set_updated_data_detects_new_object(
+        self, hass: HomeAssistant, pool_model: PoolModel
+    ) -> None:
+        """A push update surfaces objects added to the model on reconnect."""
+        coordinator = _make_coordinator(hass, pool_model)
+
+        received: list[list[PoolObject]] = []
+        coordinator.async_add_new_objects_listener(received.append)
+
+        # The controller re-fetched every object on reconnect; the model now has
+        # the new one. The coordinator learns of it on the next push.
+        pool_model.add_object(CHEM2_OBJNAM, dict(CHEM2_PARAMS))
+        coordinator.async_set_updated_data({"CHEM2": {"PHVAL": "7.5"}})
+
+        assert len(received) == 1
+        assert received[0][0].objnam == "CHEM2"
+
+    async def test_reconnect_detects_new_object(
+        self, hass: HomeAssistant, pool_model: PoolModel
+    ) -> None:
+        """Becoming connected again surfaces equipment added while offline."""
+        coordinator = _make_coordinator(hass, pool_model)
+
+        received: list[list[PoolObject]] = []
+        coordinator.async_add_new_objects_listener(received.append)
+
+        pool_model.add_object(SENSE2_OBJNAM, dict(SENSE2_PARAMS))
+        coordinator.async_set_connection_state(True)
+
+        assert len(received) == 1
+        assert received[0][0].objnam == "SENSE2"
+
+        # Going offline must not re-run detection.
+        coordinator.async_set_connection_state(False)
+        assert len(received) == 1
+
+    async def test_listener_unregister(
+        self, hass: HomeAssistant, pool_model: PoolModel
+    ) -> None:
+        """The unregister callback stops further notifications."""
+        coordinator = _make_coordinator(hass, pool_model)
+
+        received: list[list[PoolObject]] = []
+        unregister = coordinator.async_add_new_objects_listener(received.append)
+        unregister()
+
+        pool_model.add_object(CHEM2_OBJNAM, dict(CHEM2_PARAMS))
+        coordinator._async_detect_new_objects()
+
+        assert received == []
+
+
+# -------------------------------------------------------------------------------------
+# Platform dynamic setup
+# -------------------------------------------------------------------------------------
+
+
+def _capture_listener(
+    mock_coordinator: MagicMock,
+) -> dict[str, Any]:
+    """Wire a mock coordinator so the registered new-objects listener is captured.
+
+    Returns a dict with the captured ``listener`` (populated once the platform
+    registers it) and the list of ``added`` entity batches.
+    """
+    state: dict[str, Any] = {"listener": None, "added": []}
+
+    def _register(listener: Any) -> Any:
+        state["listener"] = listener
+        return MagicMock()
+
+    mock_coordinator.async_add_new_objects_listener = MagicMock(side_effect=_register)
+    return state
+
+
+async def test_sensor_platform_adds_entities_for_new_intellichem(
+    hass: HomeAssistant, pool_model: PoolModel, mock_coordinator: MagicMock
+) -> None:
+    """A second IntelliChem added at runtime produces new sensor entities.
+
+    Reproduces issue #42: the platform is set up against the original model, then
+    a new CHEM object appears and the dynamic listener must create its sensors
+    without re-running async_setup_entry.
+    """
+    from custom_components.intellicenter.sensor import async_setup_entry
+
+    mock_coordinator.model = pool_model
+    state = _capture_listener(mock_coordinator)
+
+    entry = MagicMock()
+    entry.runtime_data = mock_coordinator
+    entry.async_on_unload = MagicMock()
+
+    added: list[Any] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    # Initial setup created sensors for the single existing IntelliChem (CHEM1).
+    initial_chem2 = [e for e in added if e.unique_id.startswith("test_entry_CHEM2")]
+    assert initial_chem2 == []
+    assert state["listener"] is not None
+
+    # A second IntelliChem comes online and enters the model.
+    new_obj = pool_model.add_object(CHEM2_OBJNAM, dict(CHEM2_PARAMS))
+    assert new_obj is not None
+
+    added.clear()
+    state["listener"]([new_obj])
+
+    # New sensors are created for CHEM2 (pH, ORP, tank levels, ...) at runtime.
+    chem2_sensors = [e for e in added if e.unique_id.startswith("test_entry_CHEM2")]
+    assert len(chem2_sensors) >= 2
+    assert all(e._pool_object.objnam == "CHEM2" for e in chem2_sensors)
+
+
+async def test_platform_does_not_duplicate_known_objects(
+    hass: HomeAssistant, pool_model: PoolModel, mock_coordinator: MagicMock
+) -> None:
+    """Re-notifying with an already-known object creates no duplicate entities."""
+    from custom_components.intellicenter.sensor import async_setup_entry
+
+    mock_coordinator.model = pool_model
+    state = _capture_listener(mock_coordinator)
+
+    entry = MagicMock()
+    entry.runtime_data = mock_coordinator
+    entry.async_on_unload = MagicMock()
+
+    added: list[Any] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    # CHEM1 already produced entities during initial setup.
+    existing_chem1 = pool_model["CHEM1"]
+    assert existing_chem1 is not None
+    before = len(added)
+
+    # A spurious notification for the already-known object must add nothing.
+    added.clear()
+    state["listener"]([existing_chem1])
+
+    assert added == []
+    assert before > 0
+
+
+async def test_multiple_platforms_handle_new_object(
+    hass: HomeAssistant,
+    pool_model_data: list[dict[str, Any]],
+    mock_coordinator: MagicMock,
+) -> None:
+    """The new IntelliChem produces both sensor and number entities at runtime."""
+    from custom_components.intellicenter.number import (
+        async_setup_entry as number_setup,
+    )
+    from custom_components.intellicenter.sensor import (
+        async_setup_entry as sensor_setup,
+    )
+
+    for setup in (sensor_setup, number_setup):
+        # Fresh model per platform so the new object is genuinely absent at setup.
+        model = PoolModel()
+        model.add_objects(pool_model_data)
+        mock_coordinator.model = model
+
+        state = _capture_listener(mock_coordinator)
+        entry = MagicMock()
+        entry.runtime_data = mock_coordinator
+        entry.async_on_unload = MagicMock()
+
+        # Set up against the original model (CHEM2 not yet present), then deliver
+        # the new IntelliChem via the dynamic listener - mirroring it coming
+        # online after startup.
+        added: list[Any] = []
+        await setup(hass, entry, added.extend)
+
+        new_obj = model.add_object(CHEM2_OBJNAM, dict(CHEM2_PARAMS))
+        assert new_obj is not None
+
+        added.clear()
+        state["listener"]([new_obj])
+
+        chem2 = [e for e in added if e.unique_id.startswith("test_entry_CHEM2")]
+        # Both platforms expose at least one CHEM2 entity (sensor readings /
+        # setpoint numbers).
+        assert chem2, f"{setup.__module__} created no entity for the new IntelliChem"
+
+
+# -------------------------------------------------------------------------------------
+# bodies_affected_by helper
+# -------------------------------------------------------------------------------------
+
+
+class TestBodiesAffectedBy:
+    """Tests for the heater/body cross-reference helper."""
+
+    def test_body_candidate_returned(
+        self, hass: HomeAssistant, pool_model: PoolModel, mock_coordinator: MagicMock
+    ) -> None:
+        """A body passed as a candidate is returned."""
+        mock_coordinator.model = pool_model
+        body = pool_model["POOL1"]
+        assert body is not None
+
+        result = bodies_affected_by(mock_coordinator, [body])
+
+        assert [b.objnam for b in result] == ["POOL1"]
+
+    def test_heater_candidate_resolves_to_served_bodies(
+        self, hass: HomeAssistant, pool_model: PoolModel, mock_coordinator: MagicMock
+    ) -> None:
+        """A candidate heater maps to every body it serves."""
+        mock_coordinator.model = pool_model
+        heater = pool_model["HTR01"]
+        assert heater is not None  # serves "POOL1 SPA01"
+
+        result = bodies_affected_by(mock_coordinator, [heater])
+
+        assert {b.objnam for b in result} == {"POOL1", "SPA01"}
+
+    def test_non_body_non_heater_ignored(
+        self, hass: HomeAssistant, pool_model: PoolModel, mock_coordinator: MagicMock
+    ) -> None:
+        """Unrelated candidate objects yield no bodies."""
+        mock_coordinator.model = pool_model
+        sensor = pool_model["SENSE1"]
+        assert sensor is not None
+
+        assert bodies_affected_by(mock_coordinator, [sensor]) == []
+
+
+# -------------------------------------------------------------------------------------
+# async_setup_pool_entities dedup
+# -------------------------------------------------------------------------------------
+
+
+async def test_setup_pool_entities_dedups_across_calls(
+    hass: HomeAssistant, pool_model: PoolModel, mock_coordinator: MagicMock
+) -> None:
+    """The shared helper never emits the same unique_id twice."""
+    mock_coordinator.model = pool_model
+    state = _capture_listener(mock_coordinator)
+
+    entry = MagicMock()
+    entry.runtime_data = mock_coordinator
+    entry.async_on_unload = MagicMock()
+
+    added: list[Any] = []
+
+    def _build(coordinator: IntelliCenterCoordinator, candidates: Any) -> list[Any]:
+        # Always emit a single entity for CHEM1 regardless of the candidate set,
+        # to prove dedup is keyed on unique_id and not on the candidate identity.
+        chem1 = coordinator.model["CHEM1"]
+        from custom_components.intellicenter.sensor import PoolSensor
+
+        return [
+            PoolSensor(coordinator, chem1, device_class=None, attribute_key="PHVAL")
+        ]
+
+    async_setup_pool_entities(entry, added.extend, _build)
+    assert len(added) == 1
+
+    # Driving the listener again with the same builder output must add nothing.
+    added.clear()
+    state["listener"]([pool_model["CHEM1"]])
+    assert added == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_library_contract.py
+++ b/tests/test_library_contract.py
@@ -92,3 +92,18 @@ def test_controller_methods_exist_and_callable() -> None:
         f"ICModelController is missing methods the integration calls: {missing}. "
         "This is library/integration contract drift that mocked tests cannot catch."
     )
+
+
+def test_light_effects_includes_sam_show() -> None:
+    """The installed library must map the SAm light show (issue #47).
+
+    IntelliCenter reports the SAm show via USE=SAMMOD; ``light.py`` maps that
+    code through ``LIGHT_EFFECTS``. Asserting against the *installed* library
+    catches a manifest pin shipping a version without the fix -- the drift the
+    mocked light tests cannot see.
+    """
+    effects = pyintellicenter.LIGHT_EFFECTS
+    assert effects.get("SAMMOD") == "SAm", (
+        "Installed pyintellicenter is missing the SAMMOD->'SAm' light show. "
+        "Bump the manifest pin to a version that includes it."
+    )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -195,6 +195,26 @@ async def test_light_current_effect(
     assert light.effect == "Party Mode"
 
 
+async def test_light_sam_effect_resolves(
+    hass: HomeAssistant,
+    pool_object_light: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Regression test for issue #47: the SAm light show must resolve.
+
+    IntelliCenter reports the SAm light show via USE=SAMMOD. When it was
+    missing from LIGHT_EFFECTS, the effect property returned None and the HA
+    entity showed null. It must now resolve to the "SAm" effect name.
+    """
+    pool_object_light.update({"USE": "SAMMOD"})
+
+    light = PoolLight(mock_coordinator, pool_object_light, LIGHT_EFFECTS)
+
+    assert light.effect == "SAm"
+    assert light.effect_list is not None
+    assert "SAm" in light.effect_list
+
+
 async def test_light_state_updates(
     hass: HomeAssistant,
     pool_object_light: PoolObject,
@@ -293,6 +313,7 @@ async def test_light_is_not_updated_by_irrelevant_attributes(
 @pytest.mark.parametrize(
     "effect_code,effect_name",
     [
+        ("SAMMOD", "SAm"),
         ("PARTY", "Party Mode"),
         ("CARIB", "Caribbean"),
         ("SSET", "Sunset"),

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.1.16" },
+    { name = "pyintellicenter", specifier = ">=0.1.17" },
 ]
 
 [package.metadata.requires-dev]
@@ -1756,16 +1756,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.16"
+version = "0.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/5e/2c24032bff0c399e4d8a2ce8d98f29dee53117530ac60f2631b241e725f3/pyintellicenter-0.1.16.tar.gz", hash = "sha256:d854e43dc918954d5d97e26157c9bded746e1745830c1cc0b6bc08d4d7fba7f5", size = 50668, upload-time = "2026-06-01T02:41:09.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/d5/8da264fb5b484baa4ede29009cbe5dc3142efac56ada2023b307ce23a5d8/pyintellicenter-0.1.17.tar.gz", hash = "sha256:73e524b5348144943eb1b6369b63ae5c5c829114f304ea8bebbc8aa07dc2518c", size = 53313, upload-time = "2026-06-01T14:39:26.479Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/b1/3abd93457c546d7689eb3abca1c9a454f4fb41865fd99920940a4cb07851/pyintellicenter-0.1.16-py3-none-any.whl", hash = "sha256:12983aab0915317a4395d6031468c6af4e73a7401c477f21638747b21b2bf5bc", size = 64314, upload-time = "2026-06-01T02:41:08.364Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/005f2baa8d09594eb37665cc191203c8454d24cea1341932594b5ac3dc9c/pyintellicenter-0.1.17-py3-none-any.whl", hash = "sha256:ced0fc89e416622d6cfa98840ee95e185ff2329472f1c16cbc3054cf6416c69b", size = 67129, upload-time = "2026-06-01T14:39:24.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Consumes **pyintellicenter 0.1.17** to deliver two user-reported improvements. Bumps the pin to `>=0.1.17` (manifest.json + pyproject + uv.lock).

### Added — Runtime detection of newly-added equipment (#42, @bhamiltoncx)
Equipment added after Home Assistant starts (e.g. a second IntelliChem) now surfaces its entities automatically — no restart. The coordinator watches the pool model for previously-unseen objects and notifies each platform to create the matching entities at runtime (deduped by `unique_id`); all 9 platforms share one `_build_entities` shape via `async_setup_pool_entities`. Paired with pyintellicenter 0.1.17 — which now adds a brand-new object to the model from a live `NotifyList` and re-requests its monitoring — detection works without even a reconnect.

### Fixed — IntelliBrite "SAm" effect (#47, @CrewDawg72)
With pyintellicenter 0.1.17, `USE=SAMMOD` now resolves to the "SAm" light show instead of `null`. Adds regression tests (light effect resolution + a library-contract guard).

## Test plan
- `uv run pytest` → **275 passed**
- `uv run ruff check` + `ruff format --check` → clean
- `uv run bandit -r custom_components/intellicenter -ll` → no issues
- `uv run mypy custom_components/intellicenter` (strict) → clean

## Reviews
- code-simplifier: aligned the `_build_entities` shape across all 9 platforms (#42) and confirmed the library change was already clean.
- Codex adversarial review: library-side findings (batch-limit + malformed-response robustness) folded into 0.1.17; integration-side review in progress (will fold in before merge).

## Notes
- **No integration version bump** (other fixes pending before the next release).
- Requires `pyintellicenter>=0.1.17` (live on PyPI).
- Closes #47. Implements #42 — final confirmation against a live second IntelliChem is recommended before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
