### PR TITLE
chore: remove unused mypy config sections

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -33,14 +33,7 @@ strict_equality = True
 ignore_missing_imports = True
 follow_imports = skip
 
-[mypy-pytest_homeassistant_custom_component.*]
-ignore_missing_imports = True
-follow_imports = skip
-
 [mypy-voluptuous.*]
-ignore_missing_imports = True
-
-[mypy-zeroconf.*]
 ignore_missing_imports = True
 
 [mypy-pyintellicenter.*]


### PR DESCRIPTION
## Summary

Running `uv run mypy custom_components/intellicenter/` with `warn_unused_configs = True` emitted:

> `mypy.ini: note: unused section(s): [mypy-pytest_homeassistant_custom_component.*], [mypy-zeroconf.*]`

Both per-module override sections matched **no analyzed module** under the strict gate. Only `custom_components/intellicenter/` is type-checked, and it does not import either package at a path covered by these overrides, so they were dead configuration. This change removes both:

- `[mypy-pytest_homeassistant_custom_component.*]`
- `[mypy-zeroconf.*]`

The load-bearing overrides are intentionally **kept** unchanged:
- `[mypy-homeassistant.*]` and `[mypy-pyintellicenter.*]` — both carry `follow_imports = skip`, which treats those fast-moving public APIs as untyped boundaries
- `[mypy-voluptuous.*]` — not flagged as unused
- The explanatory comment block above `[mypy-homeassistant.*]`

No code or behavior changes; this is config cleanup only.

## Test plan

All four gates run from the worktree on this branch:

- `uv run mypy custom_components/intellicenter/` → `Success: no issues found in 14 source files` (and **no** "unused section" note)
- `uv run ruff check .` → `All checks passed!`
- `uv run ruff format --check .` → `32 files already formatted`
- `uv run pytest -q` → `275 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)