### PR TITLE
fix: dependency-aware runtime entity detection (#57)

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -28,6 +28,7 @@ from pyintellicenter import (
     BODY_ATTR,
     BODY_TYPE,
     HEATER_TYPE,
+    LISTORD_ATTR,
     STATUS_ATTR,
     ICConnectionError,
     ICModelController,
@@ -275,9 +276,10 @@ def bodies_affected_by(
     Heater-dependent platforms (water_heater, climate) create one entity per
     body, but whether that entity exists depends on the heaters wired to the
     body. A body is included when it is itself a candidate OR when a candidate
-    heater serves it, so adding a heater to an existing body re-evaluates that
-    body (issue #42). Duplicate entities for bodies that already have one are
-    filtered by ``async_setup_pool_entities`` via ``unique_id``.
+    heater serves it, so adding a heater to a body re-evaluates that body
+    (issue #42). When the body already has an entity, the duplicate is filtered
+    by ``async_setup_pool_entities`` via ``unique_id`` and the existing entity
+    instead picks up the new heater from its live heater list (issue #57).
 
     Args:
         coordinator: The coordinator providing the pool model.
@@ -301,6 +303,38 @@ def bodies_affected_by(
         if body is not None and body.objtype == BODY_TYPE:
             bodies.append(body)
     return bodies
+
+
+def heaters_for_body(
+    coordinator: IntelliCenterCoordinator, body_objnam: str
+) -> list[str]:
+    """Return the objnams of the heaters wired to a body, in UI order.
+
+    A heater serves a body when the body's objnam appears in the heater's
+    (space-separated) ``BODY`` attribute. Heaters are ordered by ``LISTORD``;
+    those without one sort last.
+
+    Heater-dependent entities (water_heater, climate) call this against the
+    *live* model so their heater composition tracks heaters added to an existing
+    body at runtime, rather than being frozen when the entity was built (issue
+    #57).
+
+    Args:
+        coordinator: The coordinator providing the pool model.
+        body_objnam: The body whose heaters should be returned.
+
+    Returns:
+        The heater objnams serving the body, ordered by ``LISTORD``.
+    """
+    heaters = sorted(
+        coordinator.model.get_by_type(HEATER_TYPE),
+        key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
+    )
+    return [
+        heater.objnam
+        for heater in heaters
+        if body_objnam in (heater[BODY_ATTR] or "").split(" ")
+    ]
 
 
 # -------------------------------------------------------------------------------------

--- a/custom_components/intellicenter/climate.py
+++ b/custom_components/intellicenter/climate.py
@@ -28,12 +28,9 @@ from homeassistant.components.climate import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
-    BODY_ATTR,
     HEATER_ATTR,
-    HEATER_TYPE,
     HITMP_ATTR,
     HTMODE_ATTR,
-    LISTORD_ATTR,
     LOTMP_ATTR,
     LSTTMP_ATTR,
     NULL_OBJNAM,
@@ -47,6 +44,7 @@ from . import (
     PoolEntity,
     async_setup_pool_entities,
     bodies_affected_by,
+    heaters_for_body,
 )
 from .coordinator import IntelliCenterCoordinator
 
@@ -64,14 +62,9 @@ def _build_entities(
     Only bodies whose heat pump supports cooling get a climate entity. A body is
     (re)evaluated when it is itself a candidate OR when a candidate heater serves
     it (issue #42). Duplicate entities for already-known bodies are filtered by
-    the caller via ``unique_id``.
+    the caller via ``unique_id``; an existing entity keeps its (live) heater
+    composition up to date itself (issue #57).
     """
-    # Find all heaters sorted by UI order
-    heaters = sorted(
-        coordinator.model.get_by_type(HEATER_TYPE),
-        key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
-    )
-
     climate_entities: list[PoolClimate] = []
     for body in bodies_affected_by(coordinator, candidates):
         # Check if this body supports cooling (has UltraTemp heat pump)
@@ -79,11 +72,7 @@ def _build_entities(
             continue
 
         # Build list of heaters that support this body
-        heater_list = [
-            heater.objnam
-            for heater in heaters
-            if body.objnam in heater[BODY_ATTR].split(" ")
-        ]
+        heater_list = heaters_for_body(coordinator, body.objnam)
 
         if heater_list:
             climate_entities.append(PoolClimate(coordinator, body, heater_list))
@@ -124,8 +113,24 @@ class PoolClimate(PoolEntity, ClimateEntity):
             pool_object,
             extra_state_attributes=[HEATER_ATTR, HTMODE_ATTR],
         )
-        self._heater_list = heater_list
+        # Heaters wired to this body are derived live from the model (see
+        # `_heater_list`) so a heater added to an existing body shows up as a
+        # preset on the next coordinator update without rebuilding the entity
+        # (issue #57). The list captured at construction is retained only as a
+        # fallback for when the live model cannot be enumerated.
+        self._seed_heater_list = heater_list
         self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL]
+
+    @property
+    def _heater_list(self) -> list[str]:
+        """Return the heaters wired to this body, derived from the live model.
+
+        Recomputed on each access so the entity's preset list tracks heaters
+        added to (or removed from) its body at runtime (issue #57). Falls back
+        to the list captured at construction if the live model yields nothing.
+        """
+        live = heaters_for_body(self.coordinator, self._pool_object.objnam)
+        return live if live else self._seed_heater_list
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -398,14 +398,17 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         # platforms. Dependents are already known, so they need no recording.
         self._known_objnams.update(new_objnams)
 
+        dependents_note = ""
+        if dependents:
+            dependents_note = (
+                f"; re-evaluating {len(dependents)} dependent(s): "
+                + ", ".join(obj.objnam for obj in dependents)
+            )
         _LOGGER.debug(
             "Detected %d new pool object(s): %s%s",
             len(new_objects),
             ", ".join(obj.objnam for obj in new_objects),
-            f"; re-evaluating {len(dependents)} dependent(s): "
-            + ", ".join(obj.objnam for obj in dependents)
-            if dependents
-            else "",
+            dependents_note,
         )
         # Dispatch the new objects together with any dependents whose parent just
         # arrived, so a child that was skipped before its parent existed is now

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -359,11 +359,16 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         registered listeners so the platforms can create entities for them at
         runtime. Does nothing until the initial connection has completed.
 
-        Independent new objects (e.g. a newly-installed IntelliChem) are handled
-        fully. Objects whose entities depend on *another* object — a heater added
-        to an existing body, or a PMPCIRC arriving before its parent pump in a
-        separate update — may still require an integration reload (tracked in
-        issue #57).
+        Both independent and dependent new equipment are handled. Independent
+        objects (e.g. a newly-installed IntelliChem) dispatch on their own.
+        Some entities, however, can only be built once *another* object exists:
+        a PMPCIRC's select/number entities need its parent pump, and a body's
+        heater-dependent entities need the heater. To cover the case where the
+        dependency arrives in a *separate, later* update than the child, any
+        already-known object whose parent is among the just-arrived objects is
+        re-dispatched alongside the new objects so a previously-skipped entity
+        now gets built (issue #57). ``unique_id`` de-duplication in the platforms
+        makes re-dispatching an already-built dependent harmless.
         """
         if not self._started:
             return
@@ -374,24 +379,44 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         if not new_objects:
             return
 
+        # Re-evaluate already-known children whose parent is among the objects
+        # that just arrived. Such a child was skipped earlier (its parent was
+        # absent) and would otherwise never be reconsidered. Guard PARENT_ATTR
+        # access: not every object carries it.
+        new_objnams = {obj.objnam for obj in new_objects}
+        dependents = [
+            obj
+            for obj in self._model
+            if obj.objnam in self._known_objnams
+            and obj.objnam not in new_objnams
+            and (obj[PARENT_ATTR] or "") in new_objnams
+        ]
+
         # Record before notifying so a listener cannot observe the objects as
         # "new" a second time (e.g. via a re-entrant refresh); duplicate entity
         # creation is additionally guarded by unique_id de-duplication in the
-        # platforms.
-        self._known_objnams.update(obj.objnam for obj in new_objects)
+        # platforms. Dependents are already known, so they need no recording.
+        self._known_objnams.update(new_objnams)
 
         _LOGGER.debug(
-            "Detected %d new pool object(s): %s",
+            "Detected %d new pool object(s): %s%s",
             len(new_objects),
             ", ".join(obj.objnam for obj in new_objects),
+            f"; re-evaluating {len(dependents)} dependent(s): "
+            + ", ".join(obj.objnam for obj in dependents)
+            if dependents
+            else "",
         )
-        # Dispatch to each platform independently: a failure in one platform's
-        # builder must not skip the rest. Builders are deterministic, so a logged
-        # error would recur rather than resolve on retry, which is why the objects
-        # stay recorded as known above.
+        # Dispatch the new objects together with any dependents whose parent just
+        # arrived, so a child that was skipped before its parent existed is now
+        # built. Dispatch to each platform independently: a failure in one
+        # platform's builder must not skip the rest. Builders are deterministic,
+        # so a logged error would recur rather than resolve on retry, which is
+        # why the objects stay recorded as known above.
+        dispatched = new_objects + dependents
         for listener in list(self._new_objects_listeners):
             try:
-                listener(new_objects)
+                listener(dispatched)
             except Exception:
                 _LOGGER.exception(
                     "Error dispatching new pool objects to a platform listener"

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -38,11 +38,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from pyintellicenter import (
-    BODY_ATTR,
     HEATER_ATTR,
-    HEATER_TYPE,
     HTMODE_ATTR,
-    LISTORD_ATTR,
     LOTMP_ATTR,
     LSTTMP_ATTR,
     MODE_ATTR,
@@ -58,6 +55,7 @@ from . import (
     PoolEntity,
     async_setup_pool_entities,
     bodies_affected_by,
+    heaters_for_body,
 )
 from .coordinator import IntelliCenterCoordinator
 
@@ -91,21 +89,12 @@ def _build_entities(
     itself is a candidate OR when a candidate heater serves it, so that adding a
     heater to an existing body surfaces a water heater entity too. Duplicate
     entities for already-known bodies are filtered out by the caller via
-    ``unique_id``.
+    ``unique_id``; an existing entity keeps its (live) heater composition up to
+    date itself (issue #57).
     """
-    # All heaters, sorted by their UI order (objects without one go last).
-    heaters = sorted(
-        coordinator.model.get_by_type(HEATER_TYPE),
-        key=lambda h: int(h[LISTORD_ATTR]) if h[LISTORD_ATTR] else 100,
-    )
-
     water_heaters: list[PoolWaterHeater] = []
     for body in bodies_affected_by(coordinator, candidates):
-        heater_list = [
-            heater.objnam
-            for heater in heaters
-            if body.objnam in heater[BODY_ATTR].split(" ")
-        ]
+        heater_list = heaters_for_body(coordinator, body.objnam)
         if heater_list:
             water_heaters.append(PoolWaterHeater(coordinator, body, heater_list))
 
@@ -142,16 +131,36 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
             pool_object,
             extra_state_attributes=[HEATER_ATTR, HTMODE_ATTR],
         )
-        self._heater_list = heater_list
-        self._is_multimode: bool = self._detect_multimode()
+        # The heaters wired to this body are derived live from the model (see
+        # `_heater_list`), so a heater added to an existing body is reflected on
+        # the next coordinator update without rebuilding the entity (issue #57).
+        # The list supplied at construction is retained only as a fallback for
+        # the (rare) case where the live model cannot be enumerated.
+        self._seed_heater_list = heater_list
         # Remember the last non-off operation so turn-on can restore it. None
         # means the body is currently off (nothing to restore yet).
         self._last_operation: str | None = self.current_operation
         if self._last_operation == STATE_OFF:
             self._last_operation = None
 
-    def _detect_multimode(self) -> bool:
-        """Return True if any heater in this entity's list is a multi-mode (HCOMBO) heater."""
+    @property
+    def _heater_list(self) -> list[str]:
+        """Return the heaters wired to this body, derived from the live model.
+
+        Recomputed on each access so the entity reflects heaters added to (or
+        removed from) its body at runtime (issue #57). Falls back to the list
+        captured at construction if the live model yields nothing, which keeps
+        behaviour stable when the model is not enumerable.
+        """
+        live = heaters_for_body(self.coordinator, self._pool_object.objnam)
+        return live if live else self._seed_heater_list
+
+    @property
+    def _is_multimode(self) -> bool:
+        """Return True if any heater wired to this body is a multi-mode (HCOMBO) heater.
+
+        Derived from the live heater list so it tracks heaters added at runtime.
+        """
         for heater_id in self._heater_list:
             heater_obj = self.coordinator.model[heater_id]
             if heater_obj is not None and heater_obj.subtype == _HCOMBO_SUBTYPE:

--- a/tests/test_dynamic_entities.py
+++ b/tests/test_dynamic_entities.py
@@ -18,7 +18,14 @@ from unittest.mock import MagicMock
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from pyintellicenter import CHEM_TYPE, SENSE_TYPE, PoolModel, PoolObject
+from pyintellicenter import (
+    CHEM_TYPE,
+    PMPCIRC_TYPE,
+    PUMP_TYPE,
+    SENSE_TYPE,
+    PoolModel,
+    PoolObject,
+)
 import pytest
 
 from custom_components.intellicenter import (
@@ -400,6 +407,149 @@ async def test_setup_pool_entities_dedups_across_calls(
     added.clear()
     state["listener"]([pool_model["CHEM1"]])
     assert added == []
+
+
+# -------------------------------------------------------------------------------------
+# issue #57: a PMPCIRC child arriving BEFORE its parent pump
+# -------------------------------------------------------------------------------------
+
+# A pump-circuit whose parent pump may not yet be in the model. Its select
+# entity can only be built once the parent VSF pump (supporting BOTH RPM and
+# GPM) is present, so it cleanly demonstrates the "child before parent" skip.
+PMPCIRC2_OBJNAM = "PMPCIRC2"
+PMPCIRC2_PARAMS: dict[str, str] = {
+    "OBJTYP": PMPCIRC_TYPE,
+    "SNAME": "Spa Pump Circuit",
+    "PARENT": "PUMP2",
+    "CIRCUIT": "SPA01",
+    "SELECT": "RPM",
+    "SPEED": "2400",
+    "GPM": "60",
+}
+
+PUMP2_OBJNAM = "PUMP2"
+PUMP2_PARAMS: dict[str, str] = {
+    "OBJTYP": PUMP_TYPE,
+    "SUBTYP": "VSF",
+    "SNAME": "Spa Pump",
+    "STATUS": "10",
+    "MIN": "450",
+    "MAX": "3450",
+    "MINF": "15",
+    "MAXF": "140",
+}
+
+
+async def test_pmpcirc_select_built_when_parent_pump_arrives_later(
+    hass: HomeAssistant,
+    pool_model: PoolModel,
+) -> None:
+    """A PMPCIRC's select entity is built once its parent pump arrives later.
+
+    Regression test for issue #57 (Fix B). The pump-mode select needs its parent
+    pump to know the pump supports BOTH RPM and GPM. If the PMPCIRC arrives in
+    one update and the pump in a LATER separate update, the child was previously
+    skipped, marked known, and never reconsidered. The coordinator now
+    re-dispatches an already-known object whose parent just arrived, so the
+    select entity is finally created.
+    """
+    from custom_components.intellicenter.select import async_setup_entry
+
+    coordinator = _make_coordinator(hass, pool_model)
+
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    entry.async_on_unload = MagicMock()
+
+    added: list[Any] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    def added_for(objnam: str) -> list[Any]:
+        return [e for e in added if e._pool_object.objnam == objnam]
+
+    # The PMPCIRC child appears first, while its parent pump is still absent.
+    new_child = pool_model.add_object(PMPCIRC2_OBJNAM, dict(PMPCIRC2_PARAMS))
+    assert new_child is not None
+    assert pool_model[PUMP2_OBJNAM] is None  # parent genuinely not in the model
+
+    added.clear()
+    coordinator._async_detect_new_objects()
+
+    # With no parent pump, capabilities are unknown so NO select is created. The
+    # child is now recorded as known (and would never be reconsidered without
+    # the dependent re-dispatch).
+    assert added_for(PMPCIRC2_OBJNAM) == []
+    assert PMPCIRC2_OBJNAM in coordinator._known_objnams
+
+    # The parent pump arrives in a SEPARATE, later update.
+    new_pump = pool_model.add_object(PUMP2_OBJNAM, dict(PUMP2_PARAMS))
+    assert new_pump is not None
+
+    added.clear()
+    coordinator._async_detect_new_objects()
+
+    # The pump itself is new; the PMPCIRC is re-dispatched as a dependent and its
+    # select is now created because the parent pump's capabilities are known.
+    assert added_for(PMPCIRC2_OBJNAM), (
+        "select did not create an entity for the PMPCIRC once its parent pump arrived"
+    )
+
+
+async def test_pmpcirc_redispatched_when_parent_pump_arrives_later(
+    hass: HomeAssistant,
+    pool_model: PoolModel,
+) -> None:
+    """A known PMPCIRC is re-dispatched when its parent pump arrives later.
+
+    Regression test for issue #57 (Fix B) at the coordinator layer, covering the
+    re-dispatch mechanism that feeds every dependent platform (select AND number
+    both key their PMPCIRC entities off the parent pump). The PMPCIRC is known
+    but its parent pump only arrives in a later, separate update; the coordinator
+    must include the PMPCIRC in that update's dispatched batch so the platforms
+    get a chance to (re)build its entities.
+    """
+    coordinator = _make_coordinator(hass, pool_model)
+
+    received: list[list[PoolObject]] = []
+    coordinator.async_add_new_objects_listener(received.append)
+
+    # The PMPCIRC arrives before its parent pump and is skipped/recorded.
+    pool_model.add_object(PMPCIRC2_OBJNAM, dict(PMPCIRC2_PARAMS))
+    coordinator._async_detect_new_objects()
+    assert len(received) == 1
+    assert {obj.objnam for obj in received[0]} == {PMPCIRC2_OBJNAM}
+
+    # The parent pump arrives later; the known PMPCIRC is re-dispatched with it.
+    pool_model.add_object(PUMP2_OBJNAM, dict(PUMP2_PARAMS))
+    coordinator._async_detect_new_objects()
+    assert len(received) == 2
+    dispatched = {obj.objnam for obj in received[1]}
+    assert dispatched == {PUMP2_OBJNAM, PMPCIRC2_OBJNAM}
+
+
+async def test_pmpcirc_not_redispatched_without_parent_arrival(
+    hass: HomeAssistant, pool_model: PoolModel
+) -> None:
+    """A known PMPCIRC is not re-dispatched when an UNRELATED object arrives.
+
+    The dependent re-dispatch (issue #57, Fix B) must be scoped to children
+    whose parent is among the just-arrived objects, so an unrelated new object
+    does not cause spurious re-evaluation of every known child.
+    """
+    coordinator = _make_coordinator(hass, pool_model)
+
+    received: list[list[PoolObject]] = []
+    coordinator.async_add_new_objects_listener(received.append)
+
+    # PMPCIRC01 (parent PUMP1) is already known from the fixture. An unrelated
+    # new sensor arrives - it shares no parent relationship with the PMPCIRC.
+    pool_model.add_object(SENSE2_OBJNAM, dict(SENSE2_PARAMS))
+    coordinator._async_detect_new_objects()
+
+    assert len(received) == 1
+    dispatched = {obj.objnam for obj in received[0]}
+    # Only the genuinely-new sensor is dispatched; the known PMPCIRC is not.
+    assert dispatched == {SENSE2_OBJNAM}
 
 
 if __name__ == "__main__":

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -1,5 +1,6 @@
 """Test the Pentair IntelliCenter water heater platform."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.water_heater import (
@@ -1693,3 +1694,106 @@ async def test_water_heater_standard_heater_named_like_hcombo_not_misrouted(
     mock_coordinator.controller.request_changes.assert_called_once_with(
         "POOL1", {HEATER_ATTR: "HTR01"}
     )
+
+
+# -------------------------------------------------------------------------------------
+# issue #57: a heater added to an EXISTING body must surface on the existing entity
+# -------------------------------------------------------------------------------------
+
+
+async def test_water_heater_second_heater_added_to_existing_body(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A second heater added to an existing body shows on the existing entity.
+
+    Regression test for issue #57 (Fix A). A body that already has a water
+    heater entity gains a SECOND heater at runtime. The heater list is derived
+    live from the model, so the existing entity's ``operation_list`` must gain
+    the new heater on the next coordinator update WITHOUT a fresh entity being
+    created (the platform de-dups the rebuilt entity by ``unique_id``).
+    """
+    # A real model so the live heater derivation (get_by_type) actually runs.
+    model = PoolModel()
+    model.add_objects(
+        [
+            {
+                "objnam": "POOL1",
+                "params": {
+                    "OBJTYP": BODY_TYPE,
+                    "SUBTYP": "POOL",
+                    "SNAME": "Pool",
+                    "STATUS": "ON",
+                    "LSTTMP": "78",
+                    "LOTMP": "72",
+                    "HEATER": "HTR01",
+                    "HTMODE": "1",
+                },
+            },
+            {
+                "objnam": "HTR01",
+                "params": {
+                    "OBJTYP": HEATER_TYPE,
+                    "SUBTYP": "GAS",
+                    "SNAME": "Gas Heater",
+                    "BODY": "POOL1",
+                    "LISTORD": "1",
+                },
+            },
+        ]
+    )
+    mock_coordinator.model = model
+
+    # Build the platform's entities for the objects present at setup, capturing
+    # the dynamic new-objects listener and de-duplicating by unique_id exactly
+    # like the production helper does.
+    from custom_components.intellicenter.water_heater import async_setup_entry
+
+    listener_holder: dict[str, Any] = {"listener": None}
+
+    def _register(listener: Any) -> Any:
+        listener_holder["listener"] = listener
+        return MagicMock()
+
+    mock_coordinator.async_add_new_objects_listener = MagicMock(side_effect=_register)
+
+    entry = MagicMock()
+    entry.runtime_data = mock_coordinator
+    entry.async_on_unload = MagicMock()
+
+    added: list[PoolWaterHeater] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    # Exactly one water heater for POOL1 was created, and it lists only the gas
+    # heater so far.
+    pool_heaters = [e for e in added if e._pool_object.objnam == "POOL1"]
+    assert len(pool_heaters) == 1
+    existing = pool_heaters[0]
+    assert "Gas Heater" in existing.operation_list
+    assert "Solar Heater" not in existing.operation_list
+
+    # A second heater for the SAME body comes online in a later update.
+    new_heater = model.add_object(
+        "HTR02",
+        {
+            "OBJTYP": HEATER_TYPE,
+            "SUBTYP": "SOLAR",
+            "SNAME": "Solar Heater",
+            "BODY": "POOL1",
+            "LISTORD": "2",
+        },
+    )
+    assert new_heater is not None
+
+    # The platform re-evaluates the body; the rebuilt entity is de-duped away.
+    added.clear()
+    assert listener_holder["listener"] is not None
+    listener_holder["listener"]([new_heater])
+
+    # No duplicate water heater entity was added for the already-known body.
+    assert [e for e in added if e._pool_object.objnam == "POOL1"] == []
+
+    # The EXISTING entity now exposes the new heater because its heater list is
+    # derived from the live model.
+    assert "Gas Heater" in existing.operation_list
+    assert "Solar Heater" in existing.operation_list


### PR DESCRIPTION
## Summary

Follow-up to the #42 runtime-detection work. Two inter-object-dependency edge cases previously required an integration reload; both are now handled at runtime.

### Fix A — heater added to an EXISTING body (water_heater + climate)

`PoolWaterHeater` and `PoolClimate` froze their heater list at construction. When a body that already had a water_heater/climate entity gained a **second** heater, `_build_entities` rebuilt the entity but `async_setup_pool_entities` de-duped it away by `unique_id`, so the existing entity kept its stale heater list and never exposed the new heater. (A body that had *no* heater and gains its first one already worked — a brand-new entity is created — and still does.)

- Added a shared `heaters_for_body(coordinator, body_objnam)` helper in `__init__.py` (next to `bodies_affected_by`) that computes the heater list from the **live** model: all `HEATER` objects whose `BODY` (space-split) contains the body, ordered by `LISTORD` (those without one last).
- `PoolWaterHeater._heater_list` and `PoolClimate._heater_list` are now **properties** that recompute from the live model on each access. `_is_multimode` likewise derives from the live list. The list captured at construction is retained only as a fallback (`_seed_heater_list`) for when the live model cannot be enumerated; `_last_operation` remains instance state.
- `water_heater._build_entities` and `climate._build_entities` now use the shared helper.
- Entities already repaint via `_handle_coordinator_update`, so once the list is dynamic the existing entity's `operation_list` / preset list gains the new heater on the next update.

### Fix B — a child (PMPCIRC) arriving BEFORE its parent pump

A `PMPCIRC` references its parent pump via `PARENT`. Its `select` (needs the pump to confirm RPM+GPM support) and `number` entities can only be built once the parent pump is in the model. If the PMPCIRC arrived in one update and the pump in a **separate, later** update, the PMPCIRC was skipped, marked known, and never re-evaluated.

- `coordinator._async_detect_new_objects` now, after computing genuinely-new objects, also collects already-known objects whose `PARENT_ATTR` is among the just-arrived objects, and dispatches `new_objects + dependents` to the listeners. `PARENT_ATTR` access is guarded (not every object carries it). Platform `unique_id` dedup keeps re-dispatching an already-built dependent harmless; a previously-skipped one now gets built.

### Docstrings

Updated the now-outdated #57-limitation docstrings: coordinator `_async_detect_new_objects`, `bodies_affected_by`, and the water_heater/climate `_build_entities`.

## Test plan

All four gates pass locally:
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy custom_components/intellicenter/` — clean (14 files)
- `uv run pytest -q` — **279 passed** (275 prior + 4 new)

New regression tests:
- **Fix A** — `test_water_heater_second_heater_added_to_existing_body`: a body with one heater (entity exists) gains a second heater via a coordinator update; the **existing** entity's `operation_list` now includes the new heater and **no duplicate entity** is added.
- **Fix B** — `test_pmpcirc_select_built_when_parent_pump_arrives_later`: a PMPCIRC's select entity is **not** created while its parent pump is absent, then **is** created once the pump arrives in a separate update.
- `test_pmpcirc_redispatched_when_parent_pump_arrives_later`: verifies the coordinator re-dispatches the known PMPCIRC together with its parent pump (the mechanism shared by both the select and number platforms — number always builds a default-limits entity even without a parent, so the end-to-end select test plus this coordinator-level test together cover both).
- `test_pmpcirc_not_redispatched_without_parent_arrival`: the re-dispatch is correctly scoped — an unrelated new object does not re-evaluate every known child.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)