### PR TITLE
chore: modernize integration types against HA 2026.5.x API (#55)

### DIFF
--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -594,7 +594,19 @@ class PoolEntity(CoordinatorEntity[IntelliCenterCoordinator], Entity):
 # -------------------------------------------------------------------------------------
 
 
-class OnOffControlMixin:
+# Under static type checking the mixin is treated as an ``Entity`` subclass so
+# mypy can resolve the ``Entity`` members it uses (``hass``,
+# ``async_write_ha_state``) without re-declaring them - re-declaring
+# ``async_write_ha_state`` would clash with its ``@final`` marker on ``Entity``.
+# At runtime the mixin stays a plain ``object`` subclass, so the method
+# resolution order of the concrete entity classes is unchanged.
+if TYPE_CHECKING:
+    _MixinBase = Entity
+else:
+    _MixinBase = object
+
+
+class OnOffControlMixin(_MixinBase):
     """Mixin for entities with simple on/off control.
 
     Classes using this mixin must also inherit from PoolEntity.
@@ -606,14 +618,9 @@ class OnOffControlMixin:
     _optimistic_state: bool | None = None  # None = use real state
 
     if TYPE_CHECKING:
-        hass: HomeAssistant
 
         def request_changes(self, changes: dict[str, Any]) -> None:
             """Request changes - provided by PoolEntity."""
-            ...
-
-        def async_write_ha_state(self) -> None:
-            """Write entity state to Home Assistant - provided by Entity."""
             ...
 
         def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:

--- a/custom_components/intellicenter/climate.py
+++ b/custom_components/intellicenter/climate.py
@@ -17,10 +17,10 @@ from collections.abc import Iterable
 import logging
 from typing import Any
 
-from homeassistant.components.climate import (
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,

--- a/custom_components/intellicenter/config_flow.py
+++ b/custom_components/intellicenter/config_flow.py
@@ -17,18 +17,20 @@ from homeassistant.components import zeroconf
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow as HAConfigFlow,
+    ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import (
+    SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
 )
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pyintellicenter import ICBaseController, ICConnectionError, ICSystemInfo
 import voluptuous as vol
 
@@ -54,6 +56,7 @@ from .const import (
     MIN_RECONNECT_DELAY,
     TRANSPORT_TCP,
     TRANSPORT_WEBSOCKET,
+    TransportType,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,11 +92,7 @@ def _validate_host(host: str) -> str:
     return host
 
 
-# HA's ConfigFlow defines the ``domain`` class keyword via __init_subclass__,
-# but homeassistant is a skipped (untyped) import in mypy.ini, so mypy resolves
-# the kwarg against object and flags it. Removable once the integration is typed
-# against HA's current API (tracked as the type-drift follow-up).
-class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
+class ConfigFlow(HAConfigFlow, domain=DOMAIN):
     """Pentair Intellicenter config flow."""
 
     VERSION = 1
@@ -112,7 +111,9 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         """Get the options flow for this handler."""
         return OptionsFlowHandler()
 
-    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle a flow initiated by the user.
 
         Presents options to discover devices or enter manually.
@@ -126,8 +127,8 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         return await self.async_step_manual()
 
     async def async_step_discover(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResult:
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle the discovery step."""
         errors: dict[str, str] = {}
 
@@ -192,8 +193,8 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         return self._show_device_picker_form(errors)
 
     async def async_step_manual(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResult:
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle manual IP entry step."""
         if user_input is None:
             return self._show_manual_form()
@@ -224,7 +225,9 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
         return self._show_manual_form(errors)
 
-    async def async_step_zeroconf(self, discovery_info: ConfigType) -> FlowResult:
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
         """Handle device found via zeroconf."""
         _LOGGER.debug("Zeroconf discovery: %s", discovery_info)
 
@@ -242,13 +245,7 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             self._discovered_host = host
             self._discovered_name = system_info.prop_name
 
-            self.context.update(
-                {
-                    CONF_HOST: host,
-                    CONF_NAME: system_info.prop_name,
-                    "title_placeholders": {"name": system_info.prop_name},
-                }
-            )
+            self.context["title_placeholders"] = {"name": system_info.prop_name}
 
             return self._show_confirm_dialog()
 
@@ -261,13 +258,13 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             return self.async_abort(reason="unknown")
 
     async def async_step_zeroconf_confirm(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResult:
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle a flow initiated by zeroconf."""
         if user_input is None:
             return self._show_confirm_dialog()
 
-        host = self._discovered_host or self.context.get(CONF_HOST)
+        host = self._discovered_host
         if host is None:
             return self.async_abort(reason="unknown")
 
@@ -291,7 +288,7 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     def _show_pick_method_form(
         self, errors: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Show the form to pick setup method."""
         options = [SETUP_MANUAL]
 
@@ -319,13 +316,13 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     def _show_device_picker_form(
         self, errors: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Show the form to pick a discovered device."""
         options = [
-            {
-                "value": unit.host,
-                "label": f"{unit.name} ({unit.host})",
-            }
+            SelectOptionDict(
+                value=unit.host,
+                label=f"{unit.name} ({unit.host})",
+            )
             for unit in self._discovered_units
         ]
 
@@ -345,7 +342,9 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             description_placeholders={"count": str(len(self._discovered_units))},
         )
 
-    def _show_no_devices_form(self, errors: dict[str, str] | None = None) -> FlowResult:
+    def _show_no_devices_form(
+        self, errors: dict[str, str] | None = None
+    ) -> ConfigFlowResult:
         """Show form when no devices are found."""
         return self.async_show_form(
             step_id="manual",
@@ -354,7 +353,9 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             description_placeholders={"reason": "no_devices_found"},
         )
 
-    def _show_manual_form(self, errors: dict[str, str] | None = None) -> FlowResult:
+    def _show_manual_form(
+        self, errors: dict[str, str] | None = None
+    ) -> ConfigFlowResult:
         """Show the manual setup form."""
         return self.async_show_form(
             step_id="manual",
@@ -375,17 +376,17 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             errors=errors or {},
         )
 
-    def _show_confirm_dialog(self) -> FlowResult:
+    def _show_confirm_dialog(self) -> ConfigFlowResult:
         """Show the confirm dialog for zeroconf discovery."""
-        host = self._discovered_host or self.context.get(CONF_HOST)
-        name = self._discovered_name or self.context.get(CONF_NAME)
-
         return self.async_show_form(
             step_id="zeroconf_confirm",
-            description_placeholders={"host": host, "name": name},
+            description_placeholders={
+                "host": self._discovered_host or "",
+                "name": self._discovered_name or "",
+            },
         )
 
-    async def _async_create_entry_from_unit(self, unit: ICUnit) -> FlowResult:
+    async def _async_create_entry_from_unit(self, unit: ICUnit) -> ConfigFlowResult:
         """Create a config entry from a discovered unit."""
         try:
             system_info = await self._get_system_info(unit.host)
@@ -402,7 +403,7 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
             raise CannotConnect from err
 
     async def _get_system_info(
-        self, host: str, transport: str = DEFAULT_TRANSPORT
+        self, host: str, transport: TransportType = DEFAULT_TRANSPORT
     ) -> ICSystemInfo:
         """Attempt to connect and retrieve system information.
 
@@ -444,7 +445,7 @@ class ConfigFlow(HAConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle reconfiguration of the integration.
 
         Allows users to change the host address and transport type after initial setup.
@@ -523,7 +524,7 @@ class OptionsFlowHandler(OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage the options for IntelliCenter integration."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/custom_components/intellicenter/diagnostics.py
+++ b/custom_components/intellicenter/diagnostics.py
@@ -13,6 +13,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from . import IntelliCenterConfigEntry
+from .coordinator import IntelliCenterCoordinator
 
 # Keys to redact from diagnostics output for privacy
 TO_REDACT = {
@@ -49,8 +50,13 @@ async def async_get_config_entry_diagnostics(
     }
 
     try:
-        # Get coordinator from runtime_data
-        coordinator = entry.runtime_data
+        # ``runtime_data`` is typed as the coordinator, but Home Assistant deletes
+        # it when the entry unloads (and it is unset before the entry loads), so
+        # read it defensively: ``getattr`` yields ``None`` instead of raising if
+        # it is absent.
+        coordinator: IntelliCenterCoordinator | None = getattr(
+            entry, "runtime_data", None
+        )
         if coordinator is None:
             diagnostics_data["error"] = "Coordinator not found"
             return dict(async_redact_data(diagnostics_data, TO_REDACT))

--- a/custom_components/intellicenter/light.py
+++ b/custom_components/intellicenter/light.py
@@ -8,14 +8,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import logging
-from typing import Any, ClassVar
+from typing import Any
 
-from homeassistant.components.light import (
-    ATTR_EFFECT,
-    ColorMode,
-    LightEntity,
-    LightEntityFeature,
-)
+from homeassistant.components.light import ATTR_EFFECT, LightEntity
+from homeassistant.components.light.const import ColorMode, LightEntityFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
@@ -85,7 +81,7 @@ class PoolLight(PoolEntity, LightEntity):
     """
 
     _attr_color_mode = ColorMode.ONOFF
-    _attr_supported_color_modes: ClassVar[set[ColorMode]] = {ColorMode.ONOFF}
+    _attr_supported_color_modes: set[ColorMode] = {ColorMode.ONOFF}
     _attr_supported_features = LightEntityFeature(0)
 
     def __init__(

--- a/custom_components/intellicenter/number.py
+++ b/custom_components/intellicenter/number.py
@@ -21,9 +21,12 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberMode,
 )
-from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION, PERCENTAGE
+from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
+    PERCENTAGE,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     ALK_ATTR,
@@ -259,7 +262,7 @@ def _build_entities(
             # Get the associated circuit for naming
             circuit_objnam = pool_obj[CIRCUIT_ATTR]
             circuit = coordinator.model[circuit_objnam] if circuit_objnam else None
-            circuit_name = circuit.sname if circuit else circuit_objnam
+            circuit_name = (circuit.sname if circuit else None) or str(circuit_objnam)
 
             # Get limits from parent pump
             # Initialize RPM with defaults (most pumps support RPM)
@@ -305,7 +308,7 @@ def _build_entities(
             )  # Only True if MAXF_ATTR was set from parent pump
 
             # Determine pump name for entity naming
-            pump_name = parent_pump.sname if parent_pump else "Pump"
+            pump_name = (parent_pump.sname if parent_pump else None) or "Pump"
 
             if supports_rpm and supports_gpm:
                 # VSF pump: Create single dynamic PumpSpeedNumber entity

--- a/custom_components/intellicenter/select.py
+++ b/custom_components/intellicenter/select.py
@@ -11,8 +11,8 @@ import logging
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     CIRCUIT_ATTR,
@@ -76,10 +76,10 @@ def _build_entities(
             # Get the associated circuit for naming
             circuit_objnam = pool_obj[CIRCUIT_ATTR]
             circuit = coordinator.model[circuit_objnam] if circuit_objnam else None
-            circuit_name = circuit.sname if circuit else circuit_objnam
+            circuit_name = (circuit.sname if circuit else None) or str(circuit_objnam)
 
             # Get pump name from parent pump (PMPCIRC objects don't have meaningful sname)
-            pump_name = parent_pump.sname if parent_pump else "Pump"
+            pump_name = (parent_pump.sname if parent_pump else None) or "Pump"
 
             selects.append(
                 PumpModeSelect(

--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -23,10 +23,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
+    EntityCategory,
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     CHEM_TYPE,

--- a/custom_components/intellicenter/switch.py
+++ b/custom_components/intellicenter/switch.py
@@ -11,8 +11,8 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     BODY_TYPE,
@@ -44,9 +44,9 @@ PARALLEL_UPDATES = 0
 
 def _build_entities(
     coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
-) -> list[PoolCircuit]:
+) -> list[SwitchEntity]:
     """Build switch entities for the given candidate pool objects."""
-    switches: list[PoolCircuit] = []
+    switches: list[SwitchEntity] = []
     for pool_obj in candidates:
         if pool_obj.objtype == BODY_TYPE:
             switches.append(PoolBody(coordinator, pool_obj))

--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -365,7 +365,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
             return
         await self._controller.request_changes(self._pool_object.objnam, changes)
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on, restoring the last operation or a safe default."""
         operation = self._last_operation
         if operation is None or self._operation_to_changes(operation) is None:
@@ -374,7 +374,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
         if changes is not None:
             await self._controller.request_changes(self._pool_object.objnam, changes)
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off, clearing both control planes atomically."""
         await self._controller.request_changes(
             self._pool_object.objnam,

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,19 +23,22 @@ warn_no_return = True
 warn_unreachable = True
 strict_equality = True
 
-# Home Assistant and pyintellicenter are treated as untyped boundaries.
-# follow_imports = skip makes mypy treat their symbols as Any instead of
-# checking the integration against their (fast-moving) public APIs. This matches
-# how mypy has always run here (CI ran it without Home Assistant installed), and
-# keeps the strict gate focused on our own code. Type drift against Home
-# Assistant's current API is tracked as a separate modernization effort.
+# Home Assistant exposes a typed public API; mypy checks the integration against
+# it so type drift is caught at the boundary.
 [mypy-homeassistant.*]
 ignore_missing_imports = True
-follow_imports = skip
 
 [mypy-voluptuous.*]
 ignore_missing_imports = True
 
+# pyintellicenter's mixins inherit a typing-only Protocol (_ModelControllerProtocol)
+# under TYPE_CHECKING. Because that Protocol sits ahead of the concrete
+# ICBaseController in ICModelController's MRO, mypy reports ICModelController as
+# abstract (system_info / send_cmd / _system_info), so instantiating it in
+# coordinator.py fails with [abstract]. That is a library-side typing bug that
+# can only be fixed in pyintellicenter, not in the integration, so we keep
+# follow_imports = skip here (treating its symbols as Any) until the library is
+# fixed. See https://github.com/joyfulhouse/pyintellicenter.
 [mypy-pyintellicenter.*]
 ignore_missing_imports = True
 follow_imports = skip


### PR DESCRIPTION
## Summary

Removes the `follow_imports = skip` escape hatch for `homeassistant.*` in `mypy.ini` and fixes the **~54 pre-existing type-drift errors** that surfaced when checking the integration against the *installed* Home Assistant **2026.5.4** typed API. Also removes the now-unnecessary `# type: ignore[call-arg]` on the `ConfigFlow` class declaration.

`mypy --strict` over `custom_components/intellicenter/` now passes with HA typed: **54 → 0 errors**, no "unused section" notes.

Closes #55

## Categories fixed

| Category | Files | Change |
|---|---|---|
| `[return-value]` ×21 + `[override]` ×3 | `config_flow.py` | Flow-step methods annotated `ConfigFlowResult` (was `FlowResult`), imported from `homeassistant.config_entries`. |
| `[override]` + `[attr-defined]` | `config_flow.py` | `async_step_zeroconf` now takes `ZeroconfServiceInfo` (from `homeassistant.helpers.service_info.zeroconf`) with attribute access. |
| `[typeddict-item]` / `[dict-item]` | `config_flow.py` | Set only the valid `title_placeholders` context key; build device-picker options as `SelectOptionDict`. |
| `[arg-type]` (transport) | `config_flow.py` | `_get_system_info` transport param typed `TransportType`. |
| `[call-arg]` | `config_flow.py` | Removed `# type: ignore[call-arg]` on `class ConfigFlow(..., domain=DOMAIN)` — unnecessary once HA is typed. |
| `[attr-defined]` ("not explicitly export") ×12 | `climate.py`, `light.py`, `number.py`, `select.py`, `sensor.py`, `switch.py` | Import enums/consts from canonical locations: `...components.climate.const`, `...components.light.const`, and `homeassistant.const` for `EntityCategory`. |
| `[misc]` (ClassVar clash) | `light.py` | `_attr_supported_color_modes` declared as instance attr to match `LightEntity`. |
| `[override]` ×2 | `water_heater.py` | `async_turn_on`/`async_turn_off` accept `**kwargs: Any` to match supertype. |
| `[arg-type]` (PoolVacation) | `switch.py` | Entity builder typed `list[SwitchEntity]` (common base of `PoolCircuit` and `PoolVacation`). |
| `[misc]` (`@final` override) | `__init__.py` | `OnOffControlMixin` inherits `Entity` only under `TYPE_CHECKING`; runtime MRO unchanged (plain `object`). |
| `[arg-type]` (pump/circuit names) ×4 | `number.py`, `select.py` | Coerce `sname`/objnam to `str` before constructing entities. |
| `[unreachable]` | `diagnostics.py` | Read `runtime_data` via `getattr(..., None)` typed `IntelliCenterCoordinator | None` — keeps the "Coordinator not found" guard reachable and reflects HA deleting `runtime_data` on unload. |

## `pyintellicenter` skip kept (with reason)

The single `[abstract]` error in `coordinator.py` (`Cannot instantiate abstract class ICModelController`) is a **library-side typing bug**: pyintellicenter's domain mixins inherit a typing-only `Protocol` (`_ModelControllerProtocol`) under `TYPE_CHECKING`, and that Protocol sits ahead of the concrete `ICBaseController` in `ICModelController`'s MRO, so mypy treats `system_info`/`send_cmd`/`_system_info` as abstract. It can only be fixed in pyintellicenter (latest published version 0.1.17 still has it), so the `[mypy-pyintellicenter.*] follow_imports = skip` is retained with an explanatory comment. The HA modernization (the primary goal) is complete.

## Test plan

- `uv run mypy custom_components/intellicenter/` → **Success: no issues found in 14 source files** (0 errors, no unused-section notes)
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 32 files already formatted
- `uv run pytest -q` → **279 passed** (incl. config-flow zeroconf and diagnostics tests — type changes do not alter runtime behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)