### PR TITLE
fix: correct version to 3.7.0 (not 3.8.0)

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.18"],
-  "version": "3.8.0",
+  "version": "3.7.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.8.0] - 2026-06-01
-
 ### Added
 - **System operating mode sensor (Auto / Service / Time out)** - Exposes the IntelliCenter system operating mode that the Pentair app shows as a dashboard banner. IntelliCenter reports it on the SYSTEM object's `SERVICE` attribute; the integration surfaces it as an enum sensor (`auto`/`service`/`timeout`) with per-state labels localized across all 12 supported languages. Requires pyintellicenter >= 0.1.18 (which exports the `SERVICE_ATTR` constant). Only the `AUTO` value is hardware-confirmed; the Service/Timeout protocol strings are inferred from Pentair documentation and normalized case/space-insensitively, with any unexpected value reported as unknown. Thanks to the Home Assistant community member (dbb1) who requested it.
 - **Runtime detection of newly-added equipment** (#42) - Equipment added to the Pentair system after Home Assistant has started (for example a second IntelliChem controller coming online) now surfaces its sensors and controls automatically, without requiring a restart. The coordinator watches the pool model for previously-unseen objects and notifies each platform so it can create the matching entities at runtime. Thanks to @bhamiltoncx for the report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.8.0"
+version = "3.7.0"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 # Tracks the Python floor of the Home Assistant release we target (2026.5.x ->

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.8.0"
+version = "3.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
The System Mode sensor (#63) was mistakenly bumped to **3.8.0**. Since 3.7.0 was never released stable (only `v3.7.0-beta.1`/`beta.2`; latest stable is 3.6.6), the System Mode sensor and all accumulated `[Unreleased]` changes belong to the **3.7.0** line. This reverts manifest/pyproject/uv.lock to `3.7.0` and folds the changelog entry back under `[Unreleased]`. Content unchanged; `pyintellicenter>=0.1.18` pin unaffected. Next beta will be `v3.7.0-beta.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)