### PR TITLE
chore: drop pyintellicenter mypy skip, pin >=0.1.19 (#35 follow-up)

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.18"],
+  "requirements": ["pyintellicenter>=0.1.19"],
   "version": "3.7.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,15 +30,3 @@ ignore_missing_imports = True
 
 [mypy-voluptuous.*]
 ignore_missing_imports = True
-
-# pyintellicenter's mixins inherit a typing-only Protocol (_ModelControllerProtocol)
-# under TYPE_CHECKING. Because that Protocol sits ahead of the concrete
-# ICBaseController in ICModelController's MRO, mypy reports ICModelController as
-# abstract (system_info / send_cmd / _system_info), so instantiating it in
-# coordinator.py fails with [abstract]. That is a library-side typing bug that
-# can only be fixed in pyintellicenter, not in the integration, so we keep
-# follow_imports = skip here (treating its symbols as Any) until the library is
-# fixed. See https://github.com/joyfulhouse/pyintellicenter.
-[mypy-pyintellicenter.*]
-ignore_missing_imports = True
-follow_imports = skip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.1.18",
+    "pyintellicenter>=0.1.19",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.1.18" },
+    { name = "pyintellicenter", specifier = ">=0.1.19" },
 ]
 
 [package.metadata.requires-dev]
@@ -1756,16 +1756,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.18"
+version = "0.1.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/1d/65c2bb1c70ef55fb3031783e071e28fa1bd672d37d3ecb3da853fb53ff51/pyintellicenter-0.1.18.tar.gz", hash = "sha256:eabe6bab81d2f32d5259c74eb683604d4f0499124e86d3ec842b2e3e9d537f23", size = 53372, upload-time = "2026-06-01T19:51:16.008Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/aa/28554121188b3948204037421939d6c7fbf12f91f1991a94744372d8d6da/pyintellicenter-0.1.19.tar.gz", hash = "sha256:410c04501741f8b64c05a777ea8894227ae1d194f2f37db3bbe08b734e6c939a", size = 53803, upload-time = "2026-06-02T12:15:20.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/4b/e4ea8901ba7546c63c8cbd0ac8791b983ded4e4955484af5009ba9dbb604/pyintellicenter-0.1.18-py3-none-any.whl", hash = "sha256:e33500891e4490d12d8dfc6673ebaaace31eeaa1d0b2464199ca8c9b37aa0fff", size = 67236, upload-time = "2026-06-01T19:51:14.706Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7a/bed4818585c5e8536e348546b4c95df0ae2c1ffda9ce8639734566da4fef/pyintellicenter-0.1.19-py3-none-any.whl", hash = "sha256:d7dc8450ac730f0df9288b22060ae7008c1452c676aa5528b3ec65708b32e689", size = 67646, upload-time = "2026-06-02T12:15:18.862Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Downstream follow-up to **joyfulhouse/pyintellicenter#35** (fixed in [pyintellicenter v0.1.19](https://github.com/joyfulhouse/pyintellicenter/releases/tag/v0.1.19), now on PyPI).

## What & why
`pyintellicenter` 0.1.19 fixes the `ICModelController` `[abstract]` typing artifact — its mixins no longer leak abstractness from a `TYPE_CHECKING` Protocol. The integration therefore no longer needs to treat the library as `Any` to type-check.

- **`mypy.ini`** — remove the `[mypy-pyintellicenter.*] follow_imports = skip` block (and its explanatory comment). This was the **last mypy boundary** in this repo; mypy now type-checks fully through the library's real public API.
- **`manifest.json` + `pyproject.toml`** — bump the pin `0.1.18 → 0.1.19` so the typing fix is guaranteed present before the skip is dropped.
- **`uv.lock`** — refresh to `pyintellicenter` 0.1.19.

## Key decisions
- **No integration version bump / no release.** The library fix is typing-only (zero runtime change), so this is a CI-hygiene chore, not a user-facing release.
- Pin bumped to `>=0.1.19` (not left at `>=0.1.18`) specifically so dropping the skip is safe — CI type-checks against a version that contains the fix.

## Test plan
Verified locally against the **published 0.1.19 wheel** (not an editable install):
- `mypy custom_components/intellicenter/` — clean with the skip removed (14 files, 0 issues)
- `ruff check` + `ruff format --check` — clean
- `pytest` — 296 passed
- version-sync guard (manifest == pyproject pin) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)