### PR TITLE
docs: bump pyintellicenter pin references to >=0.1.19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ uv pip install -e /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter
 ```
 
 For normal test/CI runs the published release is used (per `manifest.json`:
-`pyintellicenter>=0.1.16`). Keep `pyproject.toml`'s pin and `uv.lock` in sync with
+`pyintellicenter>=0.1.19`). Keep `pyproject.toml`'s pin and `uv.lock` in sync with
 `manifest.json` — they have drifted in the past.
 
 ### Testing
@@ -188,7 +188,7 @@ The integration follows a layered architecture:
 
 2. **Protocol/Model Layer** (`pyintellicenter` - external package)
    - Separate repository: https://github.com/joyfulhouse/pyintellicenter (checked out at `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter`)
-   - Installed via `manifest.json` requirements: `pyintellicenter>=0.1.16`
+   - Installed via `manifest.json` requirements: `pyintellicenter>=0.1.19`
    - `controller.py` - Controller classes (all `IC`-prefixed):
      - `ICBaseController`: connection + command handling; exposes `ICSystemInfo` and `ICConnectionMetrics`
      - `ICModelController`: manages `PoolModel` state, tracks attribute changes, and provides domain control/query helpers (lights, pumps, heaters, bodies, chemistry). NOTE: this class is large (~1,200 lines / 130+ methods) and is the main refactor target

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Technical documentation for developers working on the Pentair IntelliCenter Home
 | **Quality Scale** | Platinum |
 | **Test Coverage** | 257 tests |
 | **Home Assistant** | 2025.11+ required |
-| **pyintellicenter** | 0.1.16+ required |
+| **pyintellicenter** | 0.1.19+ required |
 
 ## Documentation Index
 


### PR DESCRIPTION
Follow-up to #67. The actual `manifest.json` / `pyproject.toml` pin is now `pyintellicenter>=0.1.19` (the #35 typing fix), but a few architecture/requirement docs still cited `0.1.16`.

## Changes (docs-only)
- `CLAUDE.md` — two prose references (`0.1.16 → 0.1.19`)
- `docs/README.md` — the "pyintellicenter | 0.1.x+ required" table row

## Deliberately left unchanged
Historical `docs/CHANGELOG.md` entries that cite `>=0.1.18` (SERVICE_ATTR) and `>=0.1.17` (SAMMOD) — those record the version a feature actually shipped in and must remain accurate.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)