### PR TITLE
docs: add Buy Me a Coffee supporter link + FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+# Active: Buy Me a Coffee (https://buymeacoffee.com/btli)
+buy_me_a_coffee: btli
+# Uncomment once GitHub Sponsors is enabled on the account (0% platform fees):
+# github: btli

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Control your Pentair IntelliCenter pool system directly from Home Assistant with
 [![CI][ci-badge]][ci-workflow]
 [![Quality Scale][quality-badge]][quality-scale]
 [![Project Maintenance][maintenance-shield]][user_profile]
+[![Buy Me A Coffee][bmc-shield]][bmc]
 
 ## What Does This Integration Do?
 
@@ -345,6 +346,12 @@ See [docs/](docs/) for architecture documentation and development guidelines.
 - **Feature Requests**: [GitHub Issues](https://github.com/joyfulhouse/intellicenter/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/joyfulhouse/intellicenter/discussions)
 
+## Support Development
+
+This integration is built and maintained in my spare time, with real hardware and tooling costs behind every release. If it's useful to you, consider chipping in to help offset development and testing — it's genuinely appreciated and helps keep the project moving.
+
+[![Buy Me A Coffee][bmc-shield]][bmc]
+
 ## License
 
 GNU GENERAL PUBLIC LICENSE v3.0 - see [LICENSE](LICENSE) file for details.
@@ -390,3 +397,5 @@ We extend our sincere gratitude for their foundational work that made this integ
 [quality-scale]: https://www.home-assistant.io/docs/quality_scale/
 [maintenance-shield]: https://img.shields.io/badge/maintainer-joyfulhouse-blue.svg?style=for-the-badge
 [user_profile]: https://github.com/joyfulhouse
+[bmc-shield]: https://img.shields.io/badge/Buy_Me_A_Coffee-support-FFDD00.svg?style=for-the-badge&logo=buymeacoffee&logoColor=black
+[bmc]: https://buymeacoffee.com/btli


### PR DESCRIPTION
Adds a supporter/funding link so users can help offset development and testing costs.

## Changes
- **README** — Buy Me a Coffee badge in the header badge row + a concise **Support Development** section before the license.
- **`.github/FUNDING.yml`** — `buy_me_a_coffee: btli`, which gives the repo a native **Sponsor** button and surfaces a funding link in HACS. Includes a commented `github: btli` line to flip on GitHub Sponsors later.

## Platform choice
- **Buy Me a Coffee (btli)** — live + verified (HTTP 200), zero setup. Shipped now.
- **GitHub Sponsors** — recommended upgrade (0% platform fee vs BMAC's ~5%, native button), but `hasSponsorsListing` is currently `false` for the account, so the link would dead-end. Left commented in `FUNDING.yml` — uncomment once enabled.

## Test plan
- All badge reference links resolve (`bmc-shield`, `bmc` defined at the bottom).
- Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)