### PR TITLE
docs: enable GitHub Sponsors + Ko-fi funding (replace Buy Me a Coffee)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,3 @@
 # These are supported funding model platforms
-# Active: Buy Me a Coffee (https://buymeacoffee.com/btli)
-buy_me_a_coffee: btli
-# Uncomment once GitHub Sponsors is enabled on the account (0% platform fees):
-# github: btli
+github: btli
+ko_fi: bryanli

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Control your Pentair IntelliCenter pool system directly from Home Assistant with
 [![CI][ci-badge]][ci-workflow]
 [![Quality Scale][quality-badge]][quality-scale]
 [![Project Maintenance][maintenance-shield]][user_profile]
-[![Buy Me A Coffee][bmc-shield]][bmc]
+[![GitHub Sponsors][gh-sponsors-shield]][gh-sponsors]
+[![Ko-fi][kofi-shield]][kofi]
 
 ## What Does This Integration Do?
 
@@ -348,9 +349,9 @@ See [docs/](docs/) for architecture documentation and development guidelines.
 
 ## Support Development
 
-This integration is built and maintained in my spare time, with real hardware and tooling costs behind every release. If it's useful to you, consider chipping in to help offset development and testing — it's genuinely appreciated and helps keep the project moving.
+This integration is built and maintained in my spare time, with real hardware and tooling costs behind every release. If it's useful to you, consider sponsoring the project or leaving a tip to help offset development and testing — it's genuinely appreciated and helps keep the project moving.
 
-[![Buy Me A Coffee][bmc-shield]][bmc]
+[![GitHub Sponsors][gh-sponsors-shield]][gh-sponsors] [![Ko-fi][kofi-shield]][kofi]
 
 ## License
 
@@ -397,5 +398,7 @@ We extend our sincere gratitude for their foundational work that made this integ
 [quality-scale]: https://www.home-assistant.io/docs/quality_scale/
 [maintenance-shield]: https://img.shields.io/badge/maintainer-joyfulhouse-blue.svg?style=for-the-badge
 [user_profile]: https://github.com/joyfulhouse
-[bmc-shield]: https://img.shields.io/badge/Buy_Me_A_Coffee-support-FFDD00.svg?style=for-the-badge&logo=buymeacoffee&logoColor=black
-[bmc]: https://buymeacoffee.com/btli
+[gh-sponsors-shield]: https://img.shields.io/badge/Sponsor-GitHub-EA4AAA.svg?style=for-the-badge&logo=githubsponsors&logoColor=white
+[gh-sponsors]: https://github.com/sponsors/btli
+[kofi-shield]: https://img.shields.io/badge/Ko--fi-support-FF5E5B.svg?style=for-the-badge&logo=ko-fi&logoColor=white
+[kofi]: https://ko-fi.com/bryanli


### PR DESCRIPTION
Sets up the funding options now that **GitHub Sponsors is enabled** on the account (`hasSponsorsListing: true`, verified).

## Changes
- **`.github/FUNDING.yml`** — `github: btli` + `ko_fi: bryanli` (drops `buy_me_a_coffee`). Drives the repo's native Sponsor button + HACS funding links.
- **README** — GitHub Sponsors + Ko-fi badges in the header badge row and the **Support Development** section. Buy Me a Coffee badge/links/refs removed.

## Why these two
- **GitHub Sponsors** (primary, recurring) — 0% platform fee, native GitHub/HACS integration.
- **Ko-fi** (one-time tips) — 0% platform fee on donations; replaces Buy Me a Coffee (~5%).

## Test plan
- No leftover `bmc`/`buymeacoffee` references; all new badge refs (`gh-sponsors-shield`, `gh-sponsors`, `kofi-shield`, `kofi`) defined and used.
- `github.com/sponsors/btli` confirmed live (Sponsors enabled); `ko-fi.com/bryanli` provided by maintainer.
- Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)