### PR TITLE
chore: bump version to 3.8.0b1 (pre-release)

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.20"],
-  "version": "3.7.0",
+  "version": "3.8.0b1",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.7.0"
+version = "3.8.0b1"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.7.0"
+version = "3.8.0b1"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Version bump for the 3.8.0b1 pre-release (dual-source: manifest.json + pyproject.toml, drift-guard green). Carries #72's code-review hardening, live-verified on the dev system against the real panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)