### PR TITLE
Release 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-06-22
+
 ### Added
 - **Body "Last Temp" sensor** (#75) - Each body of water (Pool, Spa) now exposes a "Last Temp" temperature sensor (e.g. "Pool Last Temp") reading the IntelliCenter body's `LSTTMP` (last recorded temperature), enabled by default. Unlike the physical Water Sensor - whose probe sits in an above-ground pipe and reads colder when the pump is off - the Last Temp value latches the last circulating temperature, so it stays steady while the pump is idle. This restores the "last temp" entity that the original dwradcliffe integration provided. Thanks to @sheyman1 for the request.
+
+### Fixed
+- **Stale availability after connection changes** (#72) - Entities not named in the most recent push update could stay `available` with stale values through an outage, or remain `unavailable` after a reconnect. Connection-state changes now fan out to every entity (rendered from the live model) and drop optimistic state, so a command issued around a disconnect can no longer wedge the UI.
+- **Pool covers missing on real hardware** (#72) - External-instrument pool covers (`EXTINSTR`) were never admitted into the production pool model, so the cover platform created no entities on actual systems (tests passed only because fixtures used the library's all-attributes default). Covers are now tracked and created, and `is_closed` reports unknown instead of fabricating "closed" when status is missing. Test fixtures were realigned to the production attribute map.
+- **Config flow crash on a failed discovered unit** (#72) - Selecting a Zeroconf-discovered unit that then failed to connect escaped the flow as a generic "unknown error" (HTTP 500). The discovery step now re-shows the picker with a `cannot_connect` error, and slow-but-reachable panels (IntelliCenter timeout/command errors) are mapped correctly instead of surfacing as "unknown".
+- **Body temperature limits ignored panel units; spa min-temp typo** (#72) - A shared `body_temperature_limits()` helper (40-104 °F / 5-40 °C) now backs water_heater, climate, and the HITMP "Max Temperature" number, replacing three drifted copies. Fixes a long-standing dropped-zero bug where the spa water_heater minimum was 4 °F instead of 40 °F (out-of-range setpoints reached the panel verbatim), and makes the HITMP number usable on METRIC panels (it previously rejected every valid Celsius setpoint and rendered values unconverted).
+- **Defensive parsing and runtime backfill** (#72) - Malformed integer attributes no longer crash platform setup or live property reads (a bad pump flow value skips that sensor instead of killing every sensor; unparseable heater sort keys sort last). Equipment added at runtime is re-dispatched after the controller backfills its tracked attributes, so attribute-gated entities (pump power/RPM/GPM, pump limits) are created on the first update rather than skipped.
+
+### Changed
+- **Requires pyintellicenter >= 0.1.20** - Bumped the protocol-library pin (manifest + pyproject) and dropped the pyintellicenter mypy skip.
 
 ## [3.7.0] - 2026-06-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This is a Home Assistant custom integration for Pentair IntelliCenter pool contr
 **Current Quality Scale**: **Platinum** ✅ (v3.1.0+)
 
 The integration meets **Platinum** quality scale requirements with:
-- 257 automated tests across all platforms
+- 323 automated tests across all platforms
 - Comprehensive type annotations (mypy strict mode)
 - Full code documentation
 - Production hardening (circuit breaker, metrics, health monitoring)
@@ -306,7 +306,7 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 - ✅ Supports translations (English in `strings.json`)
 - ✅ Extensive non-technical user documentation (README with troubleshooting, automation examples)
 - ⚠️ Firmware/software updates through HA - Not applicable (hardware doesn't support)
-- ✅ **Automated tests covering entire integration** - 257 tests across 13 test files
+- ✅ **Automated tests covering entire integration** - 323 tests across 14 test files
 - ✅ UI reconfiguration support (options flow for keepalive/reconnect settings)
 - ✅ Diagnostic capabilities (`diagnostics.py` with connection metrics)
 
@@ -346,21 +346,22 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 
 **Testing**: ✅ COMPLETE
 - ✅ **Comprehensive automated test suite** using `pytest-homeassistant-custom-component`:
-  - **Config flow tests**: 13 tests
-  - **Integration tests**: 21 tests (setup/unload, retry-on-transient-error, PoolConnectionHandler)
+  - **Config flow tests**: 19 tests
+  - **Integration tests**: 24 tests (setup/unload, retry-on-transient-error, PoolConnectionHandler)
+  - **Dynamic entity tests**: 18 tests (runtime equipment detection)
   - **Platform tests**:
-    - Light: 47 tests (parameterized effect tests)
-    - Water Heater: 46 tests (incl. HCOMBO multi-mode operation)
-    - Number: 33 tests (setpoint controls)
-    - Climate: 22 tests (UltraTemp heat pump)
-    - Sensor: 18 tests (pH device class)
-    - Cover: 17 tests (device class)
-    - Binary Sensor: 15 tests
-    - Switch: 11 tests (device class)
+    - Light: 50 tests (parameterized effect tests)
+    - Water Heater: 48 tests (incl. HCOMBO multi-mode operation)
+    - Number: 39 tests (setpoint controls)
+    - Sensor: 37 tests (incl. body Last Temp)
+    - Climate: 24 tests (UltraTemp heat pump)
+    - Cover: 19 tests (device class)
+    - Binary Sensor: 17 tests
+    - Switch: 13 tests (device class)
   - **Diagnostics tests**: 10 tests
-  - **Library contract tests**: 2 tests
+  - **Library contract tests**: 3 tests
   - **Version sync tests**: 2 tests
-  - **Total**: 257 automated tests across 13 test files with TCP connection mocking
+  - **Total**: 323 automated tests across 14 test files with TCP connection mocking
   - Protocol, controller, and model tests are in the [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository
 - ✅ **Type checking**: mypy configuration (`mypy.ini`) with strict type checking enabled
 - ✅ **Code quality**: Pre-commit hooks configured with ruff, ruff-format, codespell, bandit
@@ -370,21 +371,21 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 **Platinum Quality Scale Status**: ✅ **ACHIEVED** (v3.1.0+)
 
 The integration now meets ALL Platinum quality requirements:
-1. ✅ **Bronze**: Automated test suite with 257 tests
+1. ✅ **Bronze**: Automated test suite with 323 tests
 2. ✅ **Silver**: Comprehensive troubleshooting documentation
 3. ✅ **Gold**: Extensive test coverage across all critical components
 4. ✅ **Platinum**: Complete implementation
    - ✅ Full type annotations in all critical modules
    - ✅ Comprehensive code comments explaining complex logic
    - ✅ Optimized async performance with orjson
-   - ✅ 257 automated tests covering config flow, setup/retry, and all platforms (protocol, controller, and model are tested in the pyintellicenter repository)
+   - ✅ 323 automated tests covering config flow, setup/retry, and all platforms (protocol, controller, and model are tested in the pyintellicenter repository)
    - ✅ mypy type checking configured
    - ✅ All pre-commit hooks passing
 
 **Platinum Achievements Summary**:
 - **Type Safety**: Complete type annotations with mypy strict mode
 - **Code Documentation**: Detailed docstrings and comments throughout
-- **Test Coverage**: 257 tests across 13 test files
+- **Test Coverage**: 323 tests across 14 test files
 - **Performance**: Optimized async architecture with orjson and minimal network overhead
 - **Code Quality**: Automated linting and formatting with ruff
 - **Production Hardening**: Circuit breaker, connection metrics, health monitoring

--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ This integration connects your Pentair IntelliCenter pool control system to Home
 - **Multi-Language**: User interface available in 12 languages
 - **Easy Reconfiguration**: Change connection settings without removing the integration
 
-## What's New in v3.7.0
+## What's New in v3.8.0
 
-This release adds hybrid heater support and improves setup reliability:
+This release adds the per-body Last Temp sensor and hardens connection, cover, config-flow, and temperature-limit handling:
 
-- **HCOMBO Multi-Mode Heaters**: UltraTemp ETi Hybrid (HCOMBO) heaters now expose Gas Only, Heat Pump Only, Hybrid, and Dual operation modes. The last-used operation is remembered and restored on turn-on, and bodies that combine an HCOMBO with a standard heater are fully supported.
-- **Resilient Setup**: Transient connection failures during startup now trigger Home Assistant's automatic retry with backoff instead of a permanent setup error, so the integration recovers on its own when the IntelliCenter is briefly unreachable.
+- **Body "Last Temp" Sensor**: Each body (Pool, Spa) now has a "Last Temp" sensor (e.g. *Pool Last Temp*) showing the IntelliCenter body's last recorded water temperature. Unlike the physical Water Sensor — whose probe sits in an above-ground pipe and reads colder when the pump is off — the Last Temp value holds the last circulating temperature, so it stays accurate while the pump is idle. Thanks to @sheyman1 for the request (#75).
+- **Reliable Availability**: Connection up/down now updates every entity, so values can no longer go stale during an outage or stick as unavailable after a reconnect.
+- **Pool Covers on Real Hardware**: External-instrument pool covers (`EXTINSTR`) are now created on actual systems (previously only appeared in tests).
+- **Resilient Config Flow**: A discovered unit that fails to connect re-shows the picker with a clear error instead of a generic 500.
+- **Panel-Aware Temperature Limits**: Water heater, climate, and the Max Temperature control share one set of unit-aware bounds (40-104 °F / 5-40 °C), fixing a spa minimum-temperature bug and METRIC-panel setpoints.
 
 ## Architecture
 
@@ -367,7 +370,7 @@ This integration meets the **Platinum tier** quality standards for Home Assistan
 **Gold Requirements:**
 - Full translation support (12 languages)
 - Easy reconfiguration through the UI
-- Comprehensive automated testing (257 tests)
+- Comprehensive automated testing (323 tests)
 - Extensive user-friendly documentation
 - Automatic Zeroconf discovery
 

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.20"],
-  "version": "3.8.0b2",
+  "version": "3.8.0",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,11 @@ Technical documentation for developers working on the Pentair IntelliCenter Home
 
 | Metric | Value |
 |--------|-------|
-| **Current Version** | 3.7.0 |
+| **Current Version** | 3.8.0 |
 | **Quality Scale** | Platinum |
-| **Test Coverage** | 257 tests |
+| **Test Coverage** | 323 tests |
 | **Home Assistant** | 2025.11+ required |
-| **pyintellicenter** | 0.1.19+ required |
+| **pyintellicenter** | 0.1.20+ required |
 
 ## Documentation Index
 
@@ -48,7 +48,7 @@ intellicenter/
 │       ├── climate.py       # UltraTemp heat pump
 │       ├── number.py        # Setpoints
 │       └── cover.py         # Pool covers
-├── tests/                   # 257 automated tests
+├── tests/                   # 323 automated tests
 ├── docs/                    # This documentation
 └── README.md                # User guide
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@ This document describes the automated testing infrastructure for the Pentair Int
 
 ## Test Framework
 
-This project uses `pytest` with the `pytest-homeassistant-custom-component` framework for automated testing. The integration test suite (257 tests across 13 files) covers:
+This project uses `pytest` with the `pytest-homeassistant-custom-component` framework for automated testing. The integration test suite (323 tests across 14 files) covers:
 
 - **Config Flow Tests**: User setup, Zeroconf discovery, error handling
 - **Integration/Setup Tests**: Entry setup and unload, retry on transient connection errors, connection handler behavior
@@ -211,31 +211,32 @@ Diagnostic export tests (10 tests):
 
 ### Current Coverage
 
-**Total Tests**: 257 tests across 13 test files
+**Total Tests**: 323 tests across 14 test files
 
 | Component | Tests | Status |
 |-----------|-------|--------|
-| Light Platform | 47 tests | ✅ Complete |
-| Water Heater | 46 tests | ✅ Complete |
-| Number Platform | 33 tests | ✅ Complete |
-| Climate Platform | 22 tests | ✅ Complete |
-| Integration / Setup | 21 tests | ✅ Complete |
-| Sensor Platform | 18 tests | ✅ Complete |
-| Cover Platform | 17 tests | ✅ Complete |
-| Binary Sensor | 15 tests | ✅ Complete |
-| Config Flow | 13 tests | ✅ Complete |
-| Switch Platform | 11 tests | ✅ Complete |
+| Light Platform | 50 tests | ✅ Complete |
+| Water Heater | 48 tests | ✅ Complete |
+| Number Platform | 39 tests | ✅ Complete |
+| Sensor Platform | 37 tests | ✅ Complete |
+| Integration / Setup | 24 tests | ✅ Complete |
+| Climate Platform | 24 tests | ✅ Complete |
+| Cover Platform | 19 tests | ✅ Complete |
+| Config Flow | 19 tests | ✅ Complete |
+| Dynamic Entities | 18 tests | ✅ Complete |
+| Binary Sensor | 17 tests | ✅ Complete |
+| Switch Platform | 13 tests | ✅ Complete |
 | Diagnostics | 10 tests | ✅ Complete |
-| Library Contract | 2 tests | ✅ Complete |
+| Library Contract | 3 tests | ✅ Complete |
 | Version Sync | 2 tests | ✅ Complete |
-| **Total** | **257 tests** | ✅ Complete |
+| **Total** | **323 tests** | ✅ Complete |
 
 > Protocol, controller, and model tests are maintained in the standalone
 > [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository and are not counted here.
 
 ### Gold Quality Requirements Met
 
-✅ **Extensive automated test coverage** - 257 tests covering:
+✅ **Extensive automated test coverage** - 323 tests covering:
   - Config flow (user + Zeroconf)
   - Integration setup, unload, and retry-on-transient-error
   - Platform entity creation across all platforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.8.0b2"
+version = "3.8.0"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.8.0b2"
+version = "3.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Finalizes the **3.8.0** release (promotes the `3.8.0b1`/`b2` beta cycle to stable).

## Version
- `manifest.json` + `pyproject.toml` + `uv.lock`: **3.8.0b2 → 3.8.0** (drift guard green).

## CHANGELOG — [3.8.0]
- **Added:** Body "Last Temp" sensor (#75).
- **Fixed (#72):** stale availability after connection changes; pool covers (EXTINSTR) now created on real hardware; config-flow crash on a failed discovered unit; panel-unit-aware body temperature limits (spa min-temp 4°F→40°F, METRIC HITMP); defensive int parsing + runtime backfill re-dispatch.
- **Changed:** require `pyintellicenter>=0.1.20`.

## Docs
- Refreshed stale test counts **257 → 323 across 14 files** (README, CLAUDE.md, docs/TESTING.md, docs/README.md), including the previously-missing `test_dynamic_entities.py`.
- README "What's New" updated to v3.8.0.

## Verification
- `uv run pytest` → **323 passed**; ruff + mypy clean; version-sync guard green.
- 3.8.0b2 already verified live on production (61 entities, Last Temp sensors reporting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)