### PR TITLE
fix(sensor): map hardware SERVICE='TIMOUT' to timeout system mode

### DIFF
--- a/custom_components/intellicenter/sensor.py
+++ b/custom_components/intellicenter/sensor.py
@@ -408,11 +408,22 @@ class PoolSensor(PoolEntity, SensorEntity):
         return self._attr_native_unit_of_measurement
 
 
-# The documented IntelliCenter system operating modes. Only "auto" is
-# hardware-confirmed (the SYSTEM object reports SERVICE='AUTO' in normal
-# automatic operation); the exact "service"/"timeout" protocol strings are
-# inferred from Pentair documentation and have not been observed on hardware.
+# The canonical IntelliCenter system operating modes exposed as enum states
+# (localized via the ``system_mode`` translation key).
 SYSTEM_MODE_OPTIONS = ["auto", "service", "timeout"]
+
+# Raw SERVICE protocol strings -> canonical option. Values are matched after
+# normalizing (lower-case, spaces removed). Two modes are hardware-confirmed:
+# ``AUTO`` in normal automatic operation, and ``TIMOUT`` -- Pentair's misspelled
+# protocol string for the timed service mode (issue #80), which would not match
+# the ``timeout`` option on its own. The indefinite ``SERVICE`` string is
+# documented but not yet observed on hardware.
+SYSTEM_MODE_ALIASES = {
+    "auto": "auto",
+    "service": "service",
+    "timeout": "timeout",
+    "timout": "timeout",  # hardware protocol spelling (issue #80)
+}
 
 
 class SystemModeSensor(PoolSensor):
@@ -425,11 +436,11 @@ class SystemModeSensor(PoolSensor):
     -- because ``PoolEntity.name`` overrides Home Assistant's translation-based
     naming, so a ``translation_key`` name would never be consulted.
 
-    Only the ``AUTO`` value is hardware-confirmed; ``service`` and ``timeout``
-    are the documented modes (Pentair manuals) but their exact protocol strings
-    are inferred. Raw values are normalized case- and space-insensitively, and
-    any value outside the known options is reported as unknown so the enum
-    sensor never raises on an unexpected string.
+    ``AUTO`` and ``TIMOUT`` are hardware-confirmed; the indefinite ``SERVICE``
+    string is documented but not yet observed. Raw values are normalized
+    case- and space-insensitively and mapped via ``SYSTEM_MODE_ALIASES``, and
+    any value outside the known set is reported as unknown so the enum sensor
+    never raises on an unexpected string.
     """
 
     _attr_translation_key = "system_mode"
@@ -456,8 +467,9 @@ class SystemModeSensor(PoolSensor):
     def native_value(self) -> str | None:
         """Return the normalized system mode, or None if unrecognized.
 
-        The raw SERVICE value is normalized case- and space-insensitively so
-        variants like "AUTO", "Service", or "TIME OUT" map onto the documented
+        The raw SERVICE value is normalized case- and space-insensitively and
+        resolved through ``SYSTEM_MODE_ALIASES`` so variants like "AUTO",
+        "Service", "TIME OUT", or the hardware spelling "TIMOUT" map onto the
         ``auto``/``service``/``timeout`` options. A value outside that set is
         reported as ``None`` (unknown) rather than returned verbatim, because
         Home Assistant raises ``ValueError`` when an enum sensor's state is not
@@ -467,4 +479,4 @@ class SystemModeSensor(PoolSensor):
         if raw_value is None:
             return None
         normalized = str(raw_value).strip().lower().replace(" ", "")
-        return normalized if normalized in SYSTEM_MODE_OPTIONS else None
+        return SYSTEM_MODE_ALIASES.get(normalized)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -650,6 +650,10 @@ async def test_system_mode_sensor_enum_contract(
         ("TIMEOUT", "timeout"),
         ("TIME OUT", "timeout"),
         ("Time Out", "timeout"),
+        # Hardware protocol spelling: IntelliCenter reports the timed service
+        # mode as the misspelled "TIMOUT" (issue #80, hardware-confirmed).
+        ("TIMOUT", "timeout"),
+        ("timout", "timeout"),
         # Absent or unrecognized values surface as unknown (None). HA raises
         # ValueError if an enum sensor reports a state outside its options, so
         # anything other than auto/service/timeout must normalize to None.


### PR DESCRIPTION
## Summary

Fixes #80. The System Mode sensor showed **Unknown** whenever the panel was in service/timeout mode.

IntelliCenter reports the timed service mode on the `SYSTEM` object's `SERVICE` attribute as the **misspelled** protocol string `TIMOUT` (no "E"). The enum normalizer lower-cased and space-stripped it to `"timout"`, which isn't one of the `["auto","service","timeout"]` options, so `native_value` fell through to `None` → Unknown. The reporter (@nall) confirmed `SERVICE: TIMOUT` on their hardware (v3.8.0, IC firmware 1.064).

## Change

- Add `SYSTEM_MODE_ALIASES` mapping raw protocol strings → canonical enum options.
- Resolve `native_value` through the alias map so both `TIMEOUT` and the hardware spelling `TIMOUT` map to `timeout`.
- `AUTO` and `TIMOUT` are now hardware-confirmed; the indefinite `SERVICE` string remains documented-but-unobserved (comments updated).

## Testing

- Parametrized `test_system_mode_sensor_native_value` extended with `TIMOUT`/`timout` → `timeout`.
- `uv run pytest tests/test_sensor.py` → 39 passed.
- ruff + mypy clean.

## Hardware verification note

Verified against the live panel (`6245 Willard`, IC 1.064): the `SYSTEM` object exposes `SERVICE` (currently `AUTO`, panel in auto mode). The `TIMOUT` value is hardware-confirmed by the issue reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)