### PR TITLE
chore: release 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.1] - 2026-07-05
+
 ### Fixed
 - **System Mode showed "Unknown" in service/timeout mode** (#80) - IntelliCenter reports the timed service mode on the SYSTEM object's `SERVICE` attribute as the misspelled protocol string `TIMOUT` (no "E"). The System Mode sensor normalized it to `timout`, which is not one of the `auto`/`service`/`timeout` enum options, so it fell through to Unknown while the panel was actually in service/timeout mode. Raw `SERVICE` values are now resolved through an alias map, so both `TIMEOUT` and the hardware spelling `TIMOUT` map to `timeout`. `AUTO` and `TIMOUT` are now hardware-confirmed. Thanks to @nall for the report and the hardware-confirmed protocol string.
 

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": ["pyintellicenter>=0.1.20"],
-  "version": "3.8.1b1",
+  "version": "3.8.1",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.8.1b1"
+version = "3.8.1"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.8.1b1"
+version = "3.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
## Summary

Finalizes the **3.8.1** release (promotes `3.8.1b1` → `3.8.1`).

Ships the System Mode fix for the hardware-confirmed `SERVICE='TIMOUT'` protocol string (#80), verified live on prod at `3.8.1b1`.

## Changes

- Bump `manifest.json` + `pyproject.toml` `3.8.1b1` → `3.8.1`; refresh `uv.lock`.
- Promote CHANGELOG `[Unreleased]` → `[3.8.1] - 2026-07-05`.

Pin unchanged at `pyintellicenter>=0.1.20`.

## Release

After merge: `gh release create v3.8.1 --target main` (stable, not pre-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)