### PR TITLE
docs(valves): correct ASSIGN mischaracterization; mark design superseded

### DIFF
--- a/docs/claude/VALVE_FINDINGS_SUMMARY.md
+++ b/docs/claude/VALVE_FINDINGS_SUMMARY.md
@@ -1,18 +1,32 @@
 # Valve Control Findings - Executive Summary
 
 **Date:** 2025-01-15
-**System:** IntelliCenter @ 10.100.11.60
-**Status:** ✅ CONFIRMED - Ready for Implementation
+**System:** Live IntelliCenter unit
+**Status:** ⚠️ SUPERSEDED — `ASSIGN` premise corrected 2026-07-11
 
 ---
 
+> ## ⚠️ Correction (2026-07-11)
+>
+> This summary (and the companion `docs/valve-control-implementation.md`)
+> mischaracterizes `ASSIGN` as the valve's *current position*. Verified
+> against live hardware: **`ASSIGN` is a static role assignment**
+> (`INTAKE`/`RETURN`/`NONE` — which plumbing function the valve output
+> serves). Valve actuators have **no feedback path** to IntelliCenter — no
+> position, no mode (an IntelliValve stuck in SERVICE after a power outage is
+> invisible to the panel). Writing `ASSIGN` re-configures the valve's role;
+> it does not rotate the actuator. See the README's
+> [Circulation Watchdog](../../README.md#circulation-watchdog-stuck-valve-detection)
+> section for the hardware-verified behavior and the indirect detection
+> approach.
+
 ## Quick Summary
 
-Valve control for the Pentair IntelliCenter Home Assistant integration is **fully feasible and ready to implement**. We have:
+Valve control for the Pentair IntelliCenter Home Assistant integration ~~is **fully feasible and ready to implement**~~ — **see correction above**: the protocol permits editing a valve's role assignment, not commanding/reading its position. The captures below remain accurate. We have:
 
 - ✅ Verified the protocol with a live system
 - ✅ Found 4 working VALVE objects
-- ✅ Confirmed 3-state control (NONE, INTAKE, RETURN)
+- ⚠️ ~~Confirmed 3-state control (NONE, INTAKE, RETURN)~~ 3-state **role assignment**, not position control
 - ✅ Created complete implementation guide
 - ✅ Written production-ready code with tests
 
@@ -22,7 +36,7 @@ Valve control for the Pentair IntelliCenter Home Assistant integration is **full
 
 ### Discovered Valves
 
-| Object ID | Name | Current Position | Parent Module |
+| Object ID | Name | Role Assignment | Parent Module |
 |-----------|------|-----------------|---------------|
 | VAL03 | Intake | `INTAKE` | M0102 |
 | VAL04 | Return | `RETURN` | M0102 |
@@ -96,12 +110,12 @@ Valve control for the Pentair IntelliCenter Home Assistant integration is **full
 
 ### Protocol Commands
 
-**Read Current Position:**
+**Read Role Assignment:**
 ```json
 GetParamList → Response includes ASSIGN: "INTAKE"
 ```
 
-**Change Position:**
+**Change Role Assignment (configuration write — does not rotate the actuator):**
 ```json
 SETPARAMLIST {"ASSIGN": "RETURN"} → Response: 200 OK
 ```
@@ -141,7 +155,7 @@ docs/
 ### Known Limitations
 
 1. **Hardware Dependent** - Requires IntelliCenter with valve modules
-2. **Position Feedback** - Relies on ASSIGN attribute (no separate confirmation)
+2. **Position Feedback** - None exists; ASSIGN is a role assignment, not position telemetry (see correction at top)
 3. **Physical Constraints** - Valve actuation takes 5-30 seconds
 4. **Single Valve Type** - Only "LEGACY" subtype observed so far
 
@@ -154,8 +168,8 @@ docs/
 1. **Review the guide**: Read `docs/valve-control-implementation.md`
 2. **Copy the code**: All code is written and tested
 3. **Run tests**: `pytest tests/test_select.py -v`
-4. **Test live**: Deploy to test system at 10.100.11.60
-5. **Verify operation**: Check all 4 valves change positions
+4. **Test live**: Deploy to the local test system
+5. **Verify operation**: Check all 4 valves' role assignments update
 
 ### For Future Enhancements
 
@@ -284,7 +298,10 @@ data:
 **A:** Protocol responds in <500ms, but physical actuation takes 5-30 seconds.
 
 ### Q: Can we detect if a valve is stuck?
-**A:** Not directly - would need to monitor ASSIGN changes over time (future enhancement).
+**A:** Not directly — there is no feedback path at all, and ASSIGN never
+changes with valve motion, so monitoring it would detect nothing. The working
+approach is indirect detection via the pump's hydraulic signature; see the
+README's "Circulation Watchdog (Stuck Valve Detection)" section.
 
 ### Q: Are there other valve types besides LEGACY?
 **A:** Not observed in test system, but code should handle unknown types gracefully.
@@ -316,6 +333,6 @@ Valve control implementation is **production-ready** with:
 ---
 
 **Prepared By:** Claude Code (Anthropic)
-**System Tested:** IntelliCenter @ 10.100.11.60
+**System Tested:** IntelliCenter @ <intellicenter-ip>
 **Integration:** joyfulhouse/intellicenter (Gold Quality Scale)
 **Last Updated:** 2025-01-15

--- a/docs/valve-control-implementation.md
+++ b/docs/valve-control-implementation.md
@@ -1,15 +1,40 @@
 # Valve Control Implementation Guide
 
-**Status:** Ready for Implementation
-**Date:** 2025-01-15
-**Version:** 1.0
-**Tested On:** IntelliCenter @ 10.100.11.60 (4 valves confirmed)
+**Status:** ⚠️ Superseded — premise corrected (see below)
+**Date:** 2025-01-15 (correction: 2026-07-11)
+**Version:** 1.1
+**Tested On:** Live IntelliCenter system (4 valves confirmed)
 
 ---
 
+> ## ⚠️ Correction (2026-07-11)
+>
+> This document mischaracterizes the `ASSIGN` attribute as "current valve
+> position." Live-hardware investigation (see the README's
+> [Circulation Watchdog](../README.md#circulation-watchdog-stuck-valve-detection)
+> section) established:
+>
+> - **`ASSIGN` is a static role assignment** — it declares which plumbing
+>   function a valve output serves (`INTAKE`/`RETURN`/`NONE`). It is
+>   configuration, not telemetry, and does not change when the valve turns.
+> - **Valve actuators have no feedback path.** IntelliCenter drives them
+>   blind over a 3-wire 24VAC interface; neither position nor mode (e.g. an
+>   IntelliValve stuck in SERVICE) is ever reported back. `VALVE` objects
+>   expose no `STATUS`/`MODE` attribute.
+> - Writing `ASSIGN` therefore **re-configures the valve's role** in the
+>   system; it does not command the actuator to rotate. Actual valve motion
+>   is driven by IntelliCenter's body/circuit logic.
+>
+> The select-entity design below would build a configuration editor, not a
+> valve control — it is retained for the (accurate) protocol captures, but
+> the "position control" framing should not be implemented as designed.
+
 ## Executive Summary
 
-Valve control is **fully feasible** and ready for implementation. The IntelliCenter integration already has VALVE object type definitions, and the protocol has been verified against a live system with 4 working valves.
+~~Valve control is **fully feasible** and ready for implementation.~~ See the
+correction above: what the protocol allows is editing a valve's *role
+assignment*, not commanding or reading its *position*. The protocol captures
+in this document remain accurate.
 
 **Implementation Effort:** ~2 hours
 **Risk Level:** Low (follows established patterns)
@@ -32,7 +57,7 @@ Valve control is **fully feasible** and ready for implementation. The IntelliCen
 
 ### System Details
 
-**IntelliCenter IP:** 10.100.11.60
+**IntelliCenter IP:** <intellicenter-ip>
 **Protocol Port:** 6681
 **Valves Found:** 4
 
@@ -117,7 +142,7 @@ Valve control is **fully feasible** and ready for implementation. The IntelliCen
 | OBJTYP | `"VALVE"` | Object type identifier |
 | SUBTYP | `"LEGACY"` | Valve subtype (all valves) |
 | SNAME | Various | Friendly name for display |
-| ASSIGN | `"NONE"`, `"INTAKE"`, `"RETURN"` | **Current valve position** |
+| ASSIGN | `"NONE"`, `"INTAKE"`, `"RETURN"` | **Valve role assignment** (configuration — not live position; see correction above) |
 | DLY | `"OFF"` | Delay setting (unused in test system) |
 | PARENT | `"M0101"`, `"M0102"` | Parent module reference |
 | CIRCUIT | `"00000"` | Not linked to circuits |
@@ -166,7 +191,7 @@ VALVE_ATTRIBUTES = {
 }
 ```
 
-#### Change Valve Position
+#### Change Valve Role Assignment (configuration write — does not rotate the actuator)
 ```json
 {
   "messageID": "123",
@@ -766,7 +791,7 @@ pytest tests/test_select.py --cov=custom_components/intellicenter/select --cov-r
 
 #### Phase 1: Discovery
 1. Install integration in Home Assistant
-2. Configure with IP: 10.100.11.60
+2. Configure with IP: <intellicenter-ip>
 3. Verify 4 valve entities are created:
    - `select.intellicenter_intake`
    - `select.intellicenter_return`
@@ -1167,7 +1192,7 @@ automation:
 
 ### Version 1.0 (2025-01-15)
 - Initial documentation
-- Live system analysis completed (10.100.11.60)
+- Live system analysis completed (<intellicenter-ip>)
 - 4 valves discovered and documented
 - Full implementation guide created
 - Testing strategy defined
@@ -1178,7 +1203,7 @@ automation:
 ## Contributors
 
 - **Analysis:** Claude Code (Anthropic)
-- **Live System:** IntelliCenter @ 10.100.11.60
+- **Live System:** IntelliCenter @ <intellicenter-ip>
 - **Integration Base:** dwradcliffe/intellicenter (original)
 - **Repository:** joyfulhouse/intellicenter
 


### PR DESCRIPTION
## Summary

Follow-up from the #85 review: the valve-control design docs contradicted the (hardware-verified) premise of the new README Circulation Watchdog section.

- `docs/valve-control-implementation.md` and `docs/claude/VALVE_FINDINGS_SUMMARY.md` described `ASSIGN` as **current valve position** and proposed a select entity as position control.
- Verified against live hardware: `ASSIGN` is a **static role assignment** (INTAKE/RETURN/NONE plumbing function) — configuration, not telemetry. Valve actuators have **no feedback path** at all (no STATUS/MODE attribute; 3-wire 24VAC drive only). Writing `ASSIGN` re-configures the role; it does not rotate the actuator.

## Changes

- Correction banners on both docs; design marked superseded (protocol captures remain accurate and are retained)
- Fixed misleading table rows/headings ("Current Position" → "Role Assignment")
- Stuck-valve Q&A now points at the README watchdog instead of suggesting ASSIGN monitoring (which would detect nothing)
- Scrubbed internal unit IP from both docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)