### PR TITLE
fix: Use STATUS for enabling/disabling pool covers and POSIT for cover position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Covers disabled in Settings > Covers still appeared in Home Assistant.** `STATUS` on an `EXTINSTR`/`COVER` object was assumed to be the cover's open/closed position, but capturing the panel web app's own traffic shows `STATUS` is actually the "Cover Enabled" toggle - enabling a cover sends a `SETPARAMLIST` writing `STATUS` and never touching position. The real position attribute, `POSIT`, wasn't tracked at all. As a result, `is_closed`/open/close previously read and wrote the wrong attribute, and covers disabled on the panel still got a permanent, non-functional entity. The cover platform now skips creating an entity for a panel-disabled cover, and disables (via `disabled_by=INTEGRATION`, preserving entity_id/history) any cover entity already registered before this fix or before it was disabled on the panel - re-enabling it automatically if the panel re-enables the cover. Entities the user disabled manually are left untouched either way. `is_closed`/open/close now correctly use `POSIT`.
+
+### Changed
+- **Requires pyintellicenter >= 0.1.21** - Picks up `POSIT_ATTR` and the corrected `set_cover_state()`/`is_cover_on()` semantics (was previously writing/reading the wrong attribute for the same reason as above).
+
 ## [3.8.1] - 2026-07-05
 
 ### Fixed

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -60,6 +60,7 @@ from pyintellicenter import (
     PHVAL_ATTR,
     PHVOL_ATTR,
     PMPCIRC_TYPE,
+    POSIT_ATTR,
     PRIM_ATTR,
     PUMP_TYPE,
     PWR_ATTR,
@@ -157,7 +158,7 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
     # External instruments (pool covers). Without this entry PoolModel drops the
     # objects entirely and the cover platform never sees them (the model only
     # admits objtypes present in this map).
-    EXTINSTR_TYPE: {SNAME_ATTR, STATUS_ATTR, NORMAL_ATTR, SUBTYP_ATTR},
+    EXTINSTR_TYPE: {SNAME_ATTR, STATUS_ATTR, NORMAL_ATTR, POSIT_ATTR, SUBTYP_ATTR},
     # COOL is required by is_body_cooling(): without tracking it the heater
     # object's COOL attribute is never fetched and climate could never report
     # the COOLING action.

--- a/custom_components/intellicenter/cover.py
+++ b/custom_components/intellicenter/cover.py
@@ -14,11 +14,14 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     EXTINSTR_TYPE,
     NORMAL_ATTR,
+    POSIT_ATTR,
     STATUS_ATTR,
     STATUS_OFF,
     STATUS_ON,
@@ -26,6 +29,7 @@ from pyintellicenter import (
 )
 
 from . import IntelliCenterConfigEntry, PoolEntity, async_setup_pool_entities
+from .const import DOMAIN
 from .coordinator import IntelliCenterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,10 +43,22 @@ PARALLEL_UPDATES = 0
 def _build_entities(
     coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
 ) -> list[PoolCover]:
-    """Build cover entities for the given candidate pool objects."""
+    """Build cover entities for the given candidate pool objects.
+
+    STATUS on an EXTINSTR/COVER object is the "Cover Enabled" toggle in the
+    panel's Settings > Covers page, not its position (confirmed by capturing
+    the panel's own SETPARAMLIST traffic: enabling a cover writes STATUS and
+    never touches POSIT). A cover disabled there still exists as a static
+    object and would otherwise get a permanent, non-functional entity. Skip
+    it only on a confirmed STATUS_OFF - an unset/unknown STATUS (e.g. before
+    the model's initial backfill completes) still gets an entity rather than
+    being silently hidden.
+    """
     covers: list[PoolCover] = []
     for pool_obj in candidates:
         if pool_obj.objtype == EXTINSTR_TYPE and pool_obj.subtype == "COVER":
+            if pool_obj[STATUS_ATTR] == STATUS_OFF:
+                continue
             covers.append(PoolCover(coordinator, pool_obj))
     return covers
 
@@ -54,6 +70,80 @@ async def async_setup_entry(
 ) -> None:
     """Load pool cover entities based on a config entry."""
     async_setup_pool_entities(entry, async_add_entities, _build_entities)
+    _sync_disabled_covers(hass, entry)
+
+    # async_setup_pool_entities's dynamic listener only fires for genuinely new
+    # pool objects (issue #42), never for an attribute change on one it already
+    # knows about - so toggling a cover's "Cover Enabled" setting after setup
+    # would otherwise sit until the integration is reloaded. React on every push
+    # update instead (cheap: a handful of covers, one registry lookup each) to
+    # both build a newly-enabled cover's entity on its first enable and to
+    # disable/re-enable an already-registered one on every later toggle.
+    coordinator = entry.runtime_data
+    created_unique_ids = {
+        f"{entry.entry_id}_{cover.objnam}"
+        for cover in coordinator.controller.get_covers()
+        if cover[STATUS_ATTR] == STATUS_ON
+    }
+
+    @callback
+    def _async_handle_cover_update() -> None:
+        new_covers = [
+            cover
+            for cover in _build_entities(
+                coordinator, coordinator.controller.get_covers()
+            )
+            if cover.unique_id not in created_unique_ids
+        ]
+        if new_covers:
+            created_unique_ids.update(cover.unique_id for cover in new_covers)
+            async_add_entities(new_covers)
+        _sync_disabled_covers(hass, entry)
+
+    entry.async_on_unload(coordinator.async_add_listener(_async_handle_cover_update))
+
+
+@callback
+def _sync_disabled_covers(hass: HomeAssistant, entry: IntelliCenterConfigEntry) -> None:
+    """Disable (or re-enable) registry entries for covers the panel disables.
+
+    ``_build_entities`` only creates an entity for a cover reporting
+    STATUS=ON, so a cover disabled in the panel's Settings > Covers page
+    never gets an entity on a fresh setup. But an entity created before this
+    filter existed - or before the cover was disabled in the panel - stays
+    registered until something acts on it. Disabling it (rather than
+    removing it) matches Home Assistant's convention for integration-driven
+    unavailability: the entity_id, history, and any automations referencing
+    it survive, and the user can still manually re-enable it if they
+    disagree. A registry entry disabled for any other reason (e.g. the user
+    disabled it themselves) is left untouched - this only ever acts on
+    disabled_by values of None or our own INTEGRATION.
+
+    Known, accepted limitation: the registry only stores the current
+    disabled_by value, not who last changed it. If a user manually
+    re-enables (clears disabled_by on) a cover we disabled while the panel
+    still reports it disabled, that clear is indistinguishable here from a
+    fresh entity, and the next push re-disables it. Not worth working around
+    - a panel-disabled cover has no real POSIT data flowing anyway.
+    """
+    coordinator = entry.runtime_data
+    registry = er.async_get(hass)
+    for cover in coordinator.controller.get_covers():
+        unique_id = f"{entry.entry_id}_{cover.objnam}"
+        entity_id = registry.async_get_entity_id(Platform.COVER, DOMAIN, unique_id)
+        if entity_id is None:
+            continue
+        reg_entry = registry.entities[entity_id]
+        panel_enabled = cover[STATUS_ATTR] == STATUS_ON
+        if not panel_enabled and reg_entry.disabled_by is None:
+            registry.async_update_entity(
+                entity_id, disabled_by=er.RegistryEntryDisabler.INTEGRATION
+            )
+        elif (
+            panel_enabled
+            and reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        ):
+            registry.async_update_entity(entity_id, disabled_by=None)
 
 
 # -------------------------------------------------------------------------------------
@@ -78,7 +168,7 @@ class PoolCover(PoolEntity, CoverEntity):
         super().__init__(
             coordinator,
             pool_object,
-            extra_state_attributes=[NORMAL_ATTR],
+            extra_state_attributes=[NORMAL_ATTR, STATUS_ATTR],
             icon="mdi:arrow-expand-horizontal",
         )
         self._attr_supported_features = (
@@ -90,27 +180,29 @@ class PoolCover(PoolEntity, CoverEntity):
         """Return true if cover is closed, or None if the state is unknown."""
         # Without both attributes the position cannot be derived; report unknown
         # rather than fabricating "closed" (safety automations may key off this).
-        raw_status = self._pool_object[STATUS_ATTR]
+        raw_posit = self._pool_object[POSIT_ATTR]
         raw_normal = self._pool_object[NORMAL_ATTR]
-        if raw_status is None or raw_normal is None:
+        if raw_posit is None or raw_normal is None:
             return None
         # The cover is closed if:
-        # - STATUS is ON and NORMAL is ON (cover is normally closed)
-        # - STATUS is OFF and NORMAL is OFF (cover is normally open)
-        return bool((raw_status == STATUS_ON) == (raw_normal == STATUS_ON))
+        # - POSIT is ON and NORMAL is ON (cover is normally closed)
+        # - POSIT is OFF and NORMAL is OFF (cover is normally open)
+        return bool((raw_posit == STATUS_ON) == (raw_normal == STATUS_ON))
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        # To open the cover, we need to set STATUS opposite of NORMAL
+        # To open the cover, we need to set POSIT opposite of NORMAL
         normal = self._pool_object[NORMAL_ATTR] == STATUS_ON
-        self.request_changes({STATUS_ATTR: STATUS_OFF if normal else STATUS_ON})
+        self.request_changes({POSIT_ATTR: STATUS_OFF if normal else STATUS_ON})
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        # To close the cover, we need to set STATUS same as NORMAL
+        # To close the cover, we need to set POSIT same as NORMAL
         normal = self._pool_object[NORMAL_ATTR] == STATUS_ON
-        self.request_changes({STATUS_ATTR: STATUS_ON if normal else STATUS_OFF})
+        self.request_changes({POSIT_ATTR: STATUS_ON if normal else STATUS_OFF})
 
     def isUpdated(self, updates: dict[str, dict[str, str]]) -> bool:
         """Return true if the entity is updated by the updates from Intellicenter."""
-        return self._check_attributes_updated(updates, STATUS_ATTR, NORMAL_ATTR)
+        return self._check_attributes_updated(
+            updates, POSIT_ATTR, NORMAL_ATTR, STATUS_ATTR
+        )

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
-  "requirements": ["pyintellicenter>=0.1.20"],
+  "requirements": ["pyintellicenter>=0.1.21"],
   "version": "3.8.1",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "pentair*"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.1.20",
+    "pyintellicenter>=0.1.21",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,6 +439,8 @@ def mock_coordinator(
     mock_controller.is_body_heating = MagicMock(return_value=False)
     # Body cooling detection
     mock_controller.is_body_cooling = MagicMock(return_value=False)
+    # Covers - default to none; tests that exercise cover registry sync override this
+    mock_controller.get_covers = MagicMock(return_value=[])
     mock_coord.controller = mock_controller
 
     # Configure system info

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -3,25 +3,34 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from pyintellicenter import (
     EXTINSTR_TYPE,
     NORMAL_ATTR,
+    POSIT_ATTR,
     STATUS_ATTR,
     PoolModel,
     PoolObject,
 )
 import pytest
 
+from custom_components.intellicenter.const import DOMAIN
 from custom_components.intellicenter.coordinator import DEFAULT_ATTRIBUTES_MAP
-from custom_components.intellicenter.cover import PoolCover
+from custom_components.intellicenter.cover import PoolCover, _sync_disabled_covers
 
 pytestmark = pytest.mark.asyncio
+
+# STATUS is the "Cover Enabled" flag in the panel's Settings > Covers page.
+# POSIT is the cover's physical position. Confirmed by capturing the panel's
+# own SETPARAMLIST traffic: enabling a cover in the UI writes STATUS and
+# never touches POSIT.
 
 
 @pytest.fixture
 def pool_model_with_cover() -> PoolModel:
-    """Return a PoolModel with a cover."""
+    """Return a PoolModel with an enabled cover."""
     model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
     model.add_objects(
         [
@@ -31,7 +40,8 @@ def pool_model_with_cover() -> PoolModel:
                     "OBJTYP": EXTINSTR_TYPE,
                     "SUBTYP": "COVER",
                     "SNAME": "Pool Cover",
-                    "STATUS": "OFF",
+                    "STATUS": "ON",  # enabled
+                    "POSIT": "OFF",
                     "NORMAL": "ON",  # Normally closed
                 },
             },
@@ -42,14 +52,15 @@ def pool_model_with_cover() -> PoolModel:
 
 @pytest.fixture
 def pool_object_cover_normally_closed() -> PoolObject:
-    """Return a PoolObject representing a normally-closed cover."""
+    """Return a PoolObject representing an enabled, normally-closed cover."""
     return PoolObject(
         "COVER1",
         {
             "OBJTYP": EXTINSTR_TYPE,
             "SUBTYP": "COVER",
             "SNAME": "Pool Cover",
-            "STATUS": "OFF",
+            "STATUS": "ON",  # enabled
+            "POSIT": "OFF",
             "NORMAL": "ON",  # Normally closed
         },
     )
@@ -57,14 +68,15 @@ def pool_object_cover_normally_closed() -> PoolObject:
 
 @pytest.fixture
 def pool_object_cover_normally_open() -> PoolObject:
-    """Return a PoolObject representing a normally-open cover."""
+    """Return a PoolObject representing an enabled, normally-open cover."""
     return PoolObject(
         "COVER2",
         {
             "OBJTYP": EXTINSTR_TYPE,
             "SUBTYP": "COVER",
             "SNAME": "Spa Cover",
-            "STATUS": "OFF",
+            "STATUS": "ON",  # enabled
+            "POSIT": "OFF",
             "NORMAL": "OFF",  # Normally open
         },
     )
@@ -75,7 +87,7 @@ async def test_cover_setup_creates_entities(
     pool_model_with_cover: PoolModel,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test cover platform creates entities for covers."""
+    """Test cover platform creates entities for enabled covers."""
     # Set up the mock coordinator's model
     mock_coordinator.model = pool_model_with_cover
 
@@ -96,6 +108,143 @@ async def test_cover_setup_creates_entities(
     # Should create cover entity for COVER1
     assert len(entities_added) == 1
     assert entities_added[0]._pool_object.sname == "Pool Cover"
+
+
+async def test_cover_setup_skips_disabled_cover(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test cover platform does not create an entity for a panel-disabled cover."""
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    model.add_objects(
+        [
+            {
+                "objnam": "COVER1",
+                "params": {
+                    "OBJTYP": EXTINSTR_TYPE,
+                    "SUBTYP": "COVER",
+                    "SNAME": "Pool Cover",
+                    "STATUS": "OFF",  # disabled in Settings > Covers
+                    "POSIT": "OFF",
+                    "NORMAL": "ON",
+                },
+            },
+        ]
+    )
+    mock_coordinator.model = model
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.cover import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    assert entities_added == []
+
+
+async def test_cover_setup_includes_cover_when_status_unset(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A cover with no STATUS value yet (e.g. before backfill) is still created.
+
+    Only a confirmed STATUS=OFF should hide the entity - defaulting to
+    "hidden" on ambiguous data would silently drop entities on a timing
+    hiccup rather than a real panel setting.
+    """
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    model.add_objects(
+        [
+            {
+                "objnam": "COVER1",
+                "params": {
+                    "OBJTYP": EXTINSTR_TYPE,
+                    "SUBTYP": "COVER",
+                    "SNAME": "Pool Cover",
+                },
+            },
+        ]
+    )
+    mock_coordinator.model = model
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.cover import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    assert len(entities_added) == 1
+
+
+async def test_cover_live_enable_creates_entity_without_reload(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A cover enabled on the panel after setup gets its entity live.
+
+    async_setup_pool_entities's dynamic listener only reacts to genuinely new
+    pool objects, not an attribute change on one it already knows about, so
+    this must come from cover.py's own push-update listener instead of
+    requiring an integration reload.
+    """
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    model.add_objects(
+        [
+            {
+                "objnam": "COVER1",
+                "params": {
+                    "OBJTYP": EXTINSTR_TYPE,
+                    "SUBTYP": "COVER",
+                    "SNAME": "Pool Cover",
+                    "STATUS": "OFF",  # starts disabled
+                    "POSIT": "OFF",
+                    "NORMAL": "ON",
+                },
+            },
+        ]
+    )
+    mock_coordinator.model = model
+    mock_coordinator.controller.get_covers = MagicMock(return_value=[model["COVER1"]])
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    entities_added = []
+
+    def capture_entities(entities):
+        entities_added.extend(entities)
+
+    from custom_components.intellicenter.cover import async_setup_entry
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+    assert entities_added == []  # disabled at setup - nothing created yet
+
+    # Panel enables the cover; simulate the coordinator's push-update fan-out.
+    model["COVER1"].update({STATUS_ATTR: "ON"})
+    live_listener = mock_coordinator.async_add_listener.call_args[0][0]
+    live_listener()
+
+    assert len(entities_added) == 1
+    assert entities_added[0]._pool_object.objnam == "COVER1"
+
+    # A second call with no further change must not add a duplicate.
+    live_listener()
+    assert len(entities_added) == 1
 
 
 async def test_cover_entity_properties(
@@ -127,64 +276,63 @@ async def test_cover_supported_features(
     assert features & CoverEntityFeature.CLOSE
 
 
-async def test_cover_normally_closed_is_closed_when_status_off(
+async def test_cover_normally_closed_is_closed_when_posit_off(
     hass: HomeAssistant,
     pool_object_cover_normally_closed: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test normally-closed cover is closed when STATUS=OFF."""
+    """Test normally-closed cover is open when POSIT=OFF."""
 
-    # STATUS=OFF, NORMAL=ON (normally closed)
-    # Cover is closed when status == normal (both ON or both OFF)
+    # POSIT=OFF, NORMAL=ON (normally closed)
+    # Cover is closed when POSIT == NORMAL (both ON or both OFF)
     # Here: OFF != ON, so cover is OPEN
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
 
-    # Since STATUS=OFF and NORMAL=ON, OFF != ON, so is_closed is False (open)
     assert cover.is_closed is False
 
 
-async def test_cover_normally_closed_is_closed_when_status_on(
+async def test_cover_normally_closed_is_closed_when_posit_on(
     hass: HomeAssistant,
     pool_object_cover_normally_closed: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test normally-closed cover is closed when STATUS=ON."""
+    """Test normally-closed cover is closed when POSIT=ON."""
 
-    # Set STATUS=ON to match NORMAL=ON
-    pool_object_cover_normally_closed.update({STATUS_ATTR: "ON"})
+    # Set POSIT=ON to match NORMAL=ON
+    pool_object_cover_normally_closed.update({POSIT_ATTR: "ON"})
 
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
 
-    # STATUS=ON, NORMAL=ON, so is_closed is True
+    # POSIT=ON, NORMAL=ON, so is_closed is True
     assert cover.is_closed is True
 
 
-async def test_cover_normally_open_is_closed_when_status_off(
+async def test_cover_normally_open_is_closed_when_posit_off(
     hass: HomeAssistant,
     pool_object_cover_normally_open: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test normally-open cover is closed when STATUS=OFF."""
+    """Test normally-open cover is closed when POSIT=OFF."""
 
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_open)
 
-    # STATUS=OFF, NORMAL=OFF, OFF == OFF, so is_closed is True
+    # POSIT=OFF, NORMAL=OFF, OFF == OFF, so is_closed is True
     assert cover.is_closed is True
 
 
-async def test_cover_normally_open_is_open_when_status_on(
+async def test_cover_normally_open_is_open_when_posit_on(
     hass: HomeAssistant,
     pool_object_cover_normally_open: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test normally-open cover is open when STATUS=ON."""
+    """Test normally-open cover is open when POSIT=ON."""
 
-    # Set STATUS=ON
-    pool_object_cover_normally_open.update({STATUS_ATTR: "ON"})
+    # Set POSIT=ON
+    pool_object_cover_normally_open.update({POSIT_ATTR: "ON"})
 
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_open)
 
-    # STATUS=ON, NORMAL=OFF, ON != OFF, so is_closed is False
+    # POSIT=ON, NORMAL=OFF, ON != OFF, so is_closed is False
     assert cover.is_closed is False
 
 
@@ -202,12 +350,12 @@ async def test_cover_open_normally_closed(
 
     await cover.async_open_cover()
 
-    # To open a normally-closed cover (NORMAL=ON), set STATUS opposite = OFF
+    # To open a normally-closed cover (NORMAL=ON), set POSIT opposite = OFF
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[0] == "COVER1"
-    assert STATUS_ATTR in args[1]
-    assert args[1][STATUS_ATTR] == "OFF"
+    assert POSIT_ATTR in args[1]
+    assert args[1][POSIT_ATTR] == "OFF"
 
 
 async def test_cover_close_normally_closed(
@@ -224,12 +372,12 @@ async def test_cover_close_normally_closed(
 
     await cover.async_close_cover()
 
-    # To close a normally-closed cover (NORMAL=ON), set STATUS same = ON
+    # To close a normally-closed cover (NORMAL=ON), set POSIT same = ON
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[0] == "COVER1"
-    assert STATUS_ATTR in args[1]
-    assert args[1][STATUS_ATTR] == "ON"
+    assert POSIT_ATTR in args[1]
+    assert args[1][POSIT_ATTR] == "ON"
 
 
 async def test_cover_open_normally_open(
@@ -246,12 +394,12 @@ async def test_cover_open_normally_open(
 
     await cover.async_open_cover()
 
-    # To open a normally-open cover (NORMAL=OFF), set STATUS opposite = ON
+    # To open a normally-open cover (NORMAL=OFF), set POSIT opposite = ON
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[0] == "COVER2"
-    assert STATUS_ATTR in args[1]
-    assert args[1][STATUS_ATTR] == "ON"
+    assert POSIT_ATTR in args[1]
+    assert args[1][POSIT_ATTR] == "ON"
 
 
 async def test_cover_close_normally_open(
@@ -268,31 +416,34 @@ async def test_cover_close_normally_open(
 
     await cover.async_close_cover()
 
-    # To close a normally-open cover (NORMAL=OFF), set STATUS same = OFF
+    # To close a normally-open cover (NORMAL=OFF), set POSIT same = OFF
     mock_coordinator.controller.request_changes.assert_called_once()
     args = mock_coordinator.controller.request_changes.call_args[0]
     assert args[0] == "COVER2"
-    assert STATUS_ATTR in args[1]
-    assert args[1][STATUS_ATTR] == "OFF"
+    assert POSIT_ATTR in args[1]
+    assert args[1][POSIT_ATTR] == "OFF"
 
 
-async def test_cover_is_updated_status(
+async def test_cover_is_updated_posit(
     hass: HomeAssistant,
     pool_object_cover_normally_closed: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test cover isUpdated on status change."""
+    """Test cover isUpdated on position/enabled changes."""
 
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
 
-    # Should update on status change
-    assert cover.isUpdated({"COVER1": {STATUS_ATTR: "ON"}}) is True
+    # Should update on position change
+    assert cover.isUpdated({"COVER1": {POSIT_ATTR: "ON"}}) is True
 
     # Should update on normal change
     assert cover.isUpdated({"COVER1": {NORMAL_ATTR: "OFF"}}) is True
 
-    # Should update on both
-    assert cover.isUpdated({"COVER1": {STATUS_ATTR: "ON", NORMAL_ATTR: "OFF"}}) is True
+    # Should update on enabled-flag change too (surfaced via extra_state_attributes)
+    assert cover.isUpdated({"COVER1": {STATUS_ATTR: "OFF"}}) is True
+
+    # Should update on multiple
+    assert cover.isUpdated({"COVER1": {POSIT_ATTR: "ON", NORMAL_ATTR: "OFF"}}) is True
 
 
 async def test_cover_is_not_updated_other_object(
@@ -305,7 +456,7 @@ async def test_cover_is_not_updated_other_object(
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
 
     # Should not update on other object changes
-    assert cover.isUpdated({"COVER2": {STATUS_ATTR: "ON"}}) is False
+    assert cover.isUpdated({"COVER2": {POSIT_ATTR: "ON"}}) is False
 
 
 async def test_cover_is_not_updated_unrelated_attribute(
@@ -330,17 +481,17 @@ async def test_cover_state_updates(
 
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
 
-    # Initial state: STATUS=OFF, NORMAL=ON -> is_closed = False (open)
+    # Initial state: POSIT=OFF, NORMAL=ON -> is_closed = False (open)
     assert cover.is_closed is False
 
     # Simulate update from IntelliCenter
-    updates = {"COVER1": {STATUS_ATTR: "ON"}}
+    updates = {"COVER1": {POSIT_ATTR: "ON"}}
     assert cover.isUpdated(updates) is True
 
     # Apply the update
     pool_object_cover_normally_closed.update(updates["COVER1"])
 
-    # Verify state changed: STATUS=ON, NORMAL=ON -> is_closed = True
+    # Verify state changed: POSIT=ON, NORMAL=ON -> is_closed = True
     assert cover.is_closed is True
 
 
@@ -361,6 +512,8 @@ async def test_cover_extra_state_attributes(
     assert attrs["OBJNAM"] == "COVER1"
     assert NORMAL_ATTR in attrs  # Should include NORMAL attribute
     assert attrs[NORMAL_ATTR] == "ON"
+    assert STATUS_ATTR in attrs  # Should include the enabled flag
+    assert attrs[STATUS_ATTR] == "ON"
 
 
 async def test_cover_device_class(
@@ -381,10 +534,14 @@ async def test_production_attribute_map_admits_covers() -> None:
     PoolModel only admits objtypes present in its attribute map. Without an
     EXTINSTR entry, cover objects were silently dropped on real hardware and
     the platform never created any entities (tests previously passed only
-    because fixtures used the library's all-attributes default map).
+    because fixtures used the library's all-attributes default map). POSIT
+    must be tracked too, or the position attribute never gets backfilled or
+    updated in production even though STATUS (enabled) and NORMAL are.
     """
     assert EXTINSTR_TYPE in DEFAULT_ATTRIBUTES_MAP
-    assert {STATUS_ATTR, NORMAL_ATTR} <= DEFAULT_ATTRIBUTES_MAP[EXTINSTR_TYPE]
+    assert {STATUS_ATTR, NORMAL_ATTR, POSIT_ATTR} <= DEFAULT_ATTRIBUTES_MAP[
+        EXTINSTR_TYPE
+    ]
 
     model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
     admitted = model.add_object(
@@ -407,3 +564,141 @@ async def test_cover_unknown_position_when_attributes_missing(
     cover = PoolCover(mock_coordinator, cover_obj)
 
     assert cover.is_closed is None
+
+
+# -------------------------------------------------------------------------------------
+# Registry sync: disabling/re-enabling entities already registered before a
+# cover was disabled (or before this filter existed).
+# -------------------------------------------------------------------------------------
+
+
+def _register_cover_entity(
+    hass: HomeAssistant,
+    objnam: str,
+    *,
+    disabled_by: er.RegistryEntryDisabler | None = None,
+) -> str:
+    """Register a cover entity in the entity registry, as if created previously."""
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create(
+        Platform.COVER,
+        DOMAIN,
+        f"test_entry_{objnam}",
+    )
+    if disabled_by is not None:
+        registry.async_update_entity(entry.entity_id, disabled_by=disabled_by)
+    return entry.entity_id
+
+
+async def test_sync_disabled_covers_disables_registered_entity(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A registered cover the panel now reports disabled gets disabled_by=INTEGRATION."""
+    entity_id = _register_cover_entity(hass, "COVER1")
+
+    disabled_cover = PoolObject(
+        "COVER1",
+        {
+            "OBJTYP": EXTINSTR_TYPE,
+            "SUBTYP": "COVER",
+            "SNAME": "Pool Cover",
+            "STATUS": "OFF",
+        },
+    )
+    mock_coordinator.controller.get_covers = MagicMock(return_value=[disabled_cover])
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    _sync_disabled_covers(hass, mock_entry)
+
+    registry = er.async_get(hass)
+    assert (
+        registry.entities[entity_id].disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    )
+
+
+async def test_sync_disabled_covers_reenables_when_panel_enables(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A previously integration-disabled cover is re-enabled once the panel enables it."""
+    entity_id = _register_cover_entity(
+        hass, "COVER1", disabled_by=er.RegistryEntryDisabler.INTEGRATION
+    )
+
+    enabled_cover = PoolObject(
+        "COVER1",
+        {
+            "OBJTYP": EXTINSTR_TYPE,
+            "SUBTYP": "COVER",
+            "SNAME": "Pool Cover",
+            "STATUS": "ON",
+        },
+    )
+    mock_coordinator.controller.get_covers = MagicMock(return_value=[enabled_cover])
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    _sync_disabled_covers(hass, mock_entry)
+
+    registry = er.async_get(hass)
+    assert registry.entities[entity_id].disabled_by is None
+
+
+async def test_sync_disabled_covers_respects_user_disabled(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A cover the user disabled manually is never touched, either direction."""
+    entity_id = _register_cover_entity(
+        hass, "COVER1", disabled_by=er.RegistryEntryDisabler.USER
+    )
+
+    disabled_cover = PoolObject(
+        "COVER1",
+        {
+            "OBJTYP": EXTINSTR_TYPE,
+            "SUBTYP": "COVER",
+            "SNAME": "Pool Cover",
+            "STATUS": "OFF",
+        },
+    )
+    mock_coordinator.controller.get_covers = MagicMock(return_value=[disabled_cover])
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    _sync_disabled_covers(hass, mock_entry)
+
+    registry = er.async_get(hass)
+    assert registry.entities[entity_id].disabled_by is er.RegistryEntryDisabler.USER
+
+
+async def test_sync_disabled_covers_ignores_unregistered_cover(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A disabled cover with no existing registry entry is simply skipped."""
+    disabled_cover = PoolObject(
+        "COVER1",
+        {
+            "OBJTYP": EXTINSTR_TYPE,
+            "SUBTYP": "COVER",
+            "SNAME": "Pool Cover",
+            "STATUS": "OFF",
+        },
+    )
+    mock_coordinator.controller.get_covers = MagicMock(return_value=[disabled_cover])
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.runtime_data = mock_coordinator
+
+    # Should not raise
+    _sync_disabled_covers(hass, mock_entry)

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.1.20" },
+    { name = "pyintellicenter", specifier = ">=0.1.21" },
 ]
 
 [package.metadata.requires-dev]
@@ -1756,16 +1756,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.20"
+version = "0.1.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/04/925131764d530d76fb3d9983a1bd7f1bbcf536d2ec9d221493c59a8e4333/pyintellicenter-0.1.20.tar.gz", hash = "sha256:1eb868d7563b5e45f07e82bc7510f54245a4af3ae01caad881ebe5ade1930dd1", size = 53335, upload-time = "2026-06-10T13:40:36.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/b9/cd03ebbab62a27a77c7309b9c94fe4deceec2dcb24b7a3f3cf7ef119568a/pyintellicenter-0.1.21.tar.gz", hash = "sha256:591c6fc845acbae4a33ac1bb5546e1ba18b694b016fdc028d55063ed28492c85", size = 53766, upload-time = "2026-07-12T19:21:51.661Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/5d/82580c7615967ca94721b6111c919b2377bd32e48adf0f3c83ac98c8727f/pyintellicenter-0.1.20-py3-none-any.whl", hash = "sha256:1d4909278934e34955a51f2111ea971e63d9984de7d292b7b8a46597e4779913", size = 67101, upload-time = "2026-06-10T13:40:35.182Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0a/ede6822128ffd55d300c8217dd39580e1a8b0fd3848371a142dc634f9228/pyintellicenter-0.1.21-py3-none-any.whl", hash = "sha256:0dead9f6d2d973f44d8ed0d20c4930fc669b4b46ec3f9bc9ebdcc0dfc823a129", size = 67595, upload-time = "2026-07-12T19:21:50.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is the rest of the fix for https://github.com/joyfulhouse/pyintellicenter/issues/44 and depends on bumping `pyintellicenter`'s version to include that fix (>= 0.1.21).

This PR changes the cover logic to observe `STATUS` to decide when to enable or disable pool cover entities. If `STATUS` is `OFF` when first run, the entities will not be created.

Otherwise, the entities' enabled/disabled state will be synced with `STATUS`.

Now, `POSIT` will be used to determine if the cover is open or closed.

Fixes https://github.com/joyfulhouse/pyintellicenter/issues/44 .

Tested: `uv add --editable ~/Developer/Source/pyintellicenter && uv run pytest tests/` . In intellicenter web UI, enabled and disabled covers. Confirmed they were instantly enabled or disabled in the HA UI.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
