### PR TITLE
feat: firmware advisory — Repairs warning for known-issue firmware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This is a Home Assistant custom integration for Pentair IntelliCenter pool contr
 **Current Quality Scale**: **Platinum** ✅ (v3.1.0+)
 
 The integration meets **Platinum** quality scale requirements with:
-- 337 automated tests across all platforms
+- 351 automated tests across all platforms
 - Comprehensive type annotations (mypy strict mode)
 - Full code documentation
 - Production hardening (circuit breaker, metrics, health monitoring)
@@ -306,7 +306,7 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 - ✅ Supports translations (English in `strings.json`)
 - ✅ Extensive non-technical user documentation (README with troubleshooting, automation examples)
 - ⚠️ Firmware/software updates through HA - Not applicable (hardware doesn't support)
-- ✅ **Automated tests covering entire integration** - 337 tests across 14 test files
+- ✅ **Automated tests covering entire integration** - 351 tests across 15 test files
 - ✅ UI reconfiguration support (options flow for keepalive/reconnect settings)
 - ✅ Diagnostic capabilities (`diagnostics.py` with connection metrics)
 
@@ -359,9 +359,10 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
     - Binary Sensor: 29 tests (incl. Not in Auto problem sensor)
     - Switch: 13 tests (device class)
   - **Diagnostics tests**: 10 tests
+  - **Firmware advisory tests**: 14 tests
   - **Library contract tests**: 3 tests
   - **Version sync tests**: 2 tests
-  - **Total**: 337 automated tests across 14 test files with TCP connection mocking
+  - **Total**: 351 automated tests across 15 test files with TCP connection mocking
   - Protocol, controller, and model tests are in the [pyintellicenter](https://github.com/joyfulhouse/pyintellicenter) repository
 - ✅ **Type checking**: mypy configuration (`mypy.ini`) with strict type checking enabled
 - ✅ **Code quality**: Pre-commit hooks configured with ruff, ruff-format, codespell, bandit
@@ -371,21 +372,21 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
 **Platinum Quality Scale Status**: ✅ **ACHIEVED** (v3.1.0+)
 
 The integration now meets ALL Platinum quality requirements:
-1. ✅ **Bronze**: Automated test suite with 337 tests
+1. ✅ **Bronze**: Automated test suite with 351 tests
 2. ✅ **Silver**: Comprehensive troubleshooting documentation
 3. ✅ **Gold**: Extensive test coverage across all critical components
 4. ✅ **Platinum**: Complete implementation
    - ✅ Full type annotations in all critical modules
    - ✅ Comprehensive code comments explaining complex logic
    - ✅ Optimized async performance with orjson
-   - ✅ 337 automated tests covering config flow, setup/retry, and all platforms (protocol, controller, and model are tested in the pyintellicenter repository)
+   - ✅ 351 automated tests covering config flow, setup/retry, and all platforms (protocol, controller, and model are tested in the pyintellicenter repository)
    - ✅ mypy type checking configured
    - ✅ All pre-commit hooks passing
 
 **Platinum Achievements Summary**:
 - **Type Safety**: Complete type annotations with mypy strict mode
 - **Code Documentation**: Detailed docstrings and comments throughout
-- **Test Coverage**: 337 tests across 14 test files
+- **Test Coverage**: 351 tests across 15 test files
 - **Performance**: Optimized async architecture with orjson and minimal network overhead
 - **Code Quality**: Automated linting and formatting with ruff
 - **Production Hardening**: Circuit breaker, connection metrics, health monitoring

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ After setup, configure connection settings:
 | **Heat Pumps** | Climate | UltraTemp heating/cooling with presets |
 | **Heaters** | Binary Sensor, Water Heater | Running status; HCOMBO (UltraTemp ETi Hybrid) Gas/Heat Pump/Hybrid/Dual modes |
 | **Schedules** | Binary Sensor | Active status (disabled by default) |
-| **System** | Switch, Binary Sensor, Sensors | Vacation mode, freeze protection, temperatures, System Mode (`auto`/`service`/`timeout`), "Not in Auto" problem indicator |
+| **System** | Switch, Binary Sensor, Sensors | Vacation mode, freeze protection, temperatures, System Mode (`auto`/`service`/`timeout`), "Not in Auto" problem indicator, firmware advisories (a Repairs warning is raised for firmware with documented issues, e.g. the pulled 2.x line) |
 | **Covers** | Cover | Pool cover open/close control |
 
 ### Body (Pool/Spa) Last Temp Sensor
@@ -475,7 +475,7 @@ This integration meets the **Platinum tier** quality standards for Home Assistan
 **Gold Requirements:**
 - Full translation support (12 languages)
 - Easy reconfiguration through the UI
-- Comprehensive automated testing (337 tests)
+- Comprehensive automated testing (351 tests)
 - Extensive user-friendly documentation
 - Automatic Zeroconf discovery
 

--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -47,6 +47,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import IntelliCenterCoordinator
+from .firmware import async_check_firmware
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -158,6 +159,9 @@ async def async_setup_entry(
         entry.runtime_data = coordinator
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+        # Warn (via Repairs) if the panel runs firmware with documented issues;
+        # also clears stale advisories after a firmware upgrade + reload.
+        async_check_firmware(hass, entry, coordinator)
         setup_complete = True
     except Exception as err:
         if not connected and _is_transient_connection_error(err):

--- a/custom_components/intellicenter/firmware.py
+++ b/custom_components/intellicenter/firmware.py
@@ -1,0 +1,172 @@
+"""Firmware version parsing and known-issue advisories.
+
+The SYSTEM object's VER attribute carries the panel firmware in the form
+``"IC: 1.064 , ICWEB:2021-10-19 1.007"``. This module parses the IC panel
+version and compares it against a curated table of firmware releases with
+documented problems. Matches raise Home Assistant Repairs issues so the user
+sees a dismissible warning in Settings instead of hitting the problem blind.
+
+Every advisory in ``KNOWN_FIRMWARE_ISSUES`` must cite a source via
+``learn_more_url`` — no speculative entries. The table is deliberately
+conservative: an advisory should describe a *documented* fault, not a hunch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from pyintellicenter import SYSTEM_TYPE, VER_ATTR
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from . import IntelliCenterConfigEntry
+    from .coordinator import IntelliCenterCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Matches the IC panel version inside a raw VER string: "IC: 1.064 , ..." or a
+# bare "1.064". The minor part is zero-padded on the wire ("064"), so both
+# components are compared as integers.
+_IC_VERSION_RE = re.compile(r"(?:IC:\s*)?(\d+)\.(\d+)")
+
+
+def parse_ic_version(raw_value: Any) -> tuple[int, int] | None:
+    """Extract the IC panel firmware version from a raw VER string.
+
+    Returns a comparable ``(major, minor)`` tuple — e.g. ``"IC: 1.064"`` ->
+    ``(1, 64)`` — or ``None`` when the value is missing or unparseable. An
+    unparseable version must never break setup; the caller treats ``None``
+    as "no advisories apply".
+    """
+    if raw_value is None:
+        return None
+    match = _IC_VERSION_RE.search(str(raw_value))
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)))
+
+
+@dataclass(frozen=True)
+class FirmwareAdvisory:
+    """A documented problem affecting specific IntelliCenter firmware versions.
+
+    Exactly one matcher should be set: ``max_version`` flags every version at
+    or below the bound (inclusive); ``exact_versions`` flags only the listed
+    versions. ``translation_key`` selects the issue text from strings.json
+    (``issues.<translation_key>``); ``learn_more_url`` cites the source that
+    documents the problem.
+    """
+
+    issue_id: str
+    translation_key: str
+    learn_more_url: str
+    max_version: tuple[int, int] | None = None
+    exact_versions: tuple[tuple[int, int], ...] | None = None
+
+    def matches(self, version: tuple[int, int]) -> bool:
+        """Return True if the given firmware version is affected."""
+        if self.max_version is not None and version <= self.max_version:
+            return True
+        return bool(self.exact_versions and version in self.exact_versions)
+
+
+# Curated advisories. Sources are mandatory (learn_more_url); entries are
+# deliberately conservative — documented faults only. Notably ABSENT:
+# - 1.064: the community-documented safe baseline and official revert point;
+#   warning on it would be pure noise.
+# - 3.004: mixed user reports (MicroBrite replay, freeze-protect toggle),
+#   but it is Pentair's mandatory stepping stone to 3.008 — candidates for a
+#   future entry if reports firm up (see issue #101).
+# All IntelliCenter OCP models share one firmware path (research found no
+# hardware generation stuck on 1.x), so the recommendations are universal:
+# official path 1.047 -> 1.064 -> 3.004 -> 3.008, wireless remote updated
+# together with the panel.
+KNOWN_FIRMWARE_ISSUES: list[FirmwareAdvisory] = [
+    # The 2.x line: 2.006 shipped with severe bugs (broken schedules incl.
+    # Celsius setpoint corruption, pumps randomly commanded to 0 RPM,
+    # spillway broken, RS-485 heater comm faults) and was pulled by Pentair;
+    # 2.017 introduced new heater-control bugs; 2.026 was also pulled.
+    # nodejs-poolController carried a hard "do not upgrade to 2.006" warning
+    # for years. Pentair's official upgrade path skips 2.x entirely.
+    FirmwareAdvisory(
+        issue_id="firmware_2x",
+        translation_key="firmware_2x",
+        learn_more_url="https://www.troublefreepool.com/threads/intellicenter-2-006-firmware.267174/",
+        exact_versions=((2, 6), (2, 17), (2, 26)),
+    ),
+    # Pre-1.064 firmware: superseded for years; only partial third-party
+    # protocol support is documented (njsPC: dual-body gaps, missing
+    # IntelliChem dose data), and Pentair's upgrade path requires stepping
+    # through 1.064 anyway.
+    FirmwareAdvisory(
+        issue_id="firmware_outdated_1x",
+        translation_key="firmware_outdated_1x",
+        learn_more_url="https://www.pentair.com/en-us/pool-spa/education-support/homeowner-support/software-downloads/intellicenter-control-system.html",
+        max_version=(1, 63),
+    ),
+]
+
+
+def matching_advisories(
+    version: tuple[int, int], advisories: list[FirmwareAdvisory]
+) -> list[FirmwareAdvisory]:
+    """Return the advisories affecting the given firmware version."""
+    return [adv for adv in advisories if adv.matches(version)]
+
+
+@callback
+def async_check_firmware(
+    hass: HomeAssistant,
+    entry: IntelliCenterConfigEntry,
+    coordinator: IntelliCenterCoordinator,
+    advisories: list[FirmwareAdvisory] | None = None,
+) -> None:
+    """Raise Repairs issues for known-problem firmware; clear stale ones.
+
+    Called at setup, after the model is populated. Issue ids are suffixed
+    with the entry id so multi-panel installs get per-panel issues. Every
+    known advisory that does NOT match is explicitly deleted, so an issue
+    raised before a firmware upgrade clears on the next (re)load.
+    """
+    if advisories is None:
+        advisories = KNOWN_FIRMWARE_ISSUES
+
+    version: tuple[int, int] | None = None
+    for obj in coordinator.model.get_by_type(SYSTEM_TYPE):
+        version = parse_ic_version(obj[VER_ATTR])
+        if version is not None:
+            break
+
+    matched: set[str] = set()
+    if version is not None:
+        for adv in matching_advisories(version, advisories):
+            matched.add(adv.issue_id)
+            _LOGGER.warning(
+                "IntelliCenter firmware %d.%03d has a known issue (%s); see %s",
+                version[0],
+                version[1],
+                adv.issue_id,
+                adv.learn_more_url,
+            )
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"{adv.issue_id}_{entry.entry_id}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                learn_more_url=adv.learn_more_url,
+                translation_key=adv.translation_key,
+                translation_placeholders={
+                    "firmware": f"{version[0]}.{version[1]:03d}",
+                },
+            )
+
+    for adv in advisories:
+        if adv.issue_id not in matched:
+            ir.async_delete_issue(hass, DOMAIN, f"{adv.issue_id}_{entry.entry_id}")

--- a/custom_components/intellicenter/strings.json
+++ b/custom_components/intellicenter/strings.json
@@ -96,5 +96,15 @@
         "websocket": "WebSocket (port 6680)"
       }
     }
+  },
+  "issues": {
+    "firmware_2x": {
+      "title": "IntelliCenter 2.x firmware has serious known issues",
+      "description": "Your IntelliCenter panel is running firmware {firmware}. The 2.x line (2.006 / 2.017 / 2.026) has severe documented problems — broken schedules, pumps randomly commanded to 0 RPM, heater communication failures — and 2.006 and 2.026 were pulled by Pentair. The official upgrade path skips 2.x entirely: update to 3.004 and then 3.008 (update the wireless remote together with the panel), or revert to 1.064."
+    },
+    "firmware_outdated_1x": {
+      "title": "IntelliCenter firmware is outdated",
+      "description": "Your IntelliCenter panel is running firmware {firmware}. Releases before 1.064 are long superseded and have documented protocol limitations. Pentair's official upgrade path is 1.047 → 1.064 → 3.004 → 3.008; update the wireless remote together with the panel."
+    }
   }
 }

--- a/custom_components/intellicenter/translations/en.json
+++ b/custom_components/intellicenter/translations/en.json
@@ -96,5 +96,15 @@
         "websocket": "WebSocket (port 6680)"
       }
     }
+  },
+  "issues": {
+    "firmware_2x": {
+      "title": "IntelliCenter 2.x firmware has serious known issues",
+      "description": "Your IntelliCenter panel is running firmware {firmware}. The 2.x line (2.006 / 2.017 / 2.026) has severe documented problems — broken schedules, pumps randomly commanded to 0 RPM, heater communication failures — and 2.006 and 2.026 were pulled by Pentair. The official upgrade path skips 2.x entirely: update to 3.004 and then 3.008 (update the wireless remote together with the panel), or revert to 1.064."
+    },
+    "firmware_outdated_1x": {
+      "title": "IntelliCenter firmware is outdated",
+      "description": "Your IntelliCenter panel is running firmware {firmware}. Releases before 1.064 are long superseded and have documented protocol limitations. Pentair's official upgrade path is 1.047 → 1.064 → 3.004 → 3.008; update the wireless remote together with the panel."
+    }
   }
 }

--- a/docs/claude/FEATURE_GAP_ANALYSIS_2026-07.md
+++ b/docs/claude/FEATURE_GAP_ANALYSIS_2026-07.md
@@ -1,0 +1,57 @@
+# Feature Gap Analysis — Unimplemented IntelliCenter Controls
+
+**Date:** 2026-07-12
+**Method:** Four independent tracks, cross-validated:
+1. Codex (GPT) full codebase sweep of the integration + pyintellicenter (319 type/attribute pairs audited)
+2. Claude coverage map (attributes package vs `DEFAULT_ATTRIBUTES_MAP` vs platform `_build_entities`)
+3. External research: nodejs-poolController feature set, official IntelliCenter Web App User's Guide (same local protocol), user feature requests (jlvaillant #26/#28/#33/#46, joyfulhouse #19/#27)
+4. Live protocol probes against a real unit (full object inventory + attribute dumps)
+
+## Headline numbers
+
+- The protocol library defines **20 object types / 319 type-attribute pairs**; the coordinator tracks **11 types**, and `PoolModel` **drops untracked types entirely** (coordinator.py `DEFAULT_ATTRIBUTES_MAP`).
+- **71 of 89** public `ICModelController` helpers are never called by the integration (most are benign — platforms read attributes directly — but the unused *setters* and helpers for untracked attributes mark real gaps).
+- The official Web App speaks the same objnam/param JSON protocol on ports 6680/6681, so everything in its user guide is presumed reachable locally.
+
+## Consensus top gaps (all tracks agree)
+
+| # | Feature | Surface | Evidence / notes |
+|---|---------|---------|------------------|
+| 1 | **Schedule enable/disable switch** + schedule detail attributes (circuit, days, start/stop, per-schedule heat mode + setpoint) | switch + attributes on existing binary_sensor | `SCHED.STATUS` (enabled) is distinct from `ACT` (running) — **confirmed live**: Chlorinator schedule showed `STATUS=ON, ACT=OFF`. Library has `is_schedule_enabled()` + full getters, unused. Only SNAME/ACT/VACFLO tracked today. Web app/njsPC do full schedule CRUD. |
+| 2 | **Delays: status + Cancel Delays action** | binary_sensor + button | Heater cooldown / valve-rotation delays; njsPC implements `cancelDelay`. Explains "spa won't turn off" confusion. Nothing exposed today. Protocol write semantics need device verification. |
+| 3 | **True circuit/light groups (CIRCGRP)** + atomic multi-circuit ops, light Sync/Swim/Set | light/switch | CIRCGRP tracked but no builder branch handles `objtype == CIRCGRP` (only CIRCUIT-subtype CIRCGRP). `set_multiple_circuit_states()` unused. Direct user requests: jlvaillant #26, #46. |
+| 4 | **Egg timer (TIME) + Don't Stop (DNTSTP)** per circuit | number + switch (disabled by default) | `TIME` already tracked but dead (coordinator.py). Live values confirmed (Pool 720 min, Backwash 2 min). Web app: 0–12h or Don't Stop. |
+| 5 | **Non-featured circuit switches** | switch (disabled by default) | switch.py only creates entities for `FEATR=ON` circuits; e.g. "AUX 4" on the live unit has no entity. Opt-in exposure avoids entity spam. |
+| 6 | **Dimmer brightness / fixed colors / MagicStream extras** | light | `LIMIT` attr observed live on GLOW circuits (7/10). Web app: 50/75/100% dimming for dimmer subtypes, fixed color selection, MagicStream Capture/Thumper/Hold/Recall. Requested in jlvaillant #28. |
+| 7 | **Chemistry: LSI sensor + aggregate chem alert + superchlorinate duration + chlorinator status** | sensor/binary_sensor/number | `SINDEX` untracked though `get_saturation_index()` exists; `get_chem_alerts()`/`has_chem_alert()` unused; IntelliChlor `TIMOUT` (boost duration) + `CHLOR` (on/off) untracked. |
+| 8 | **Solar heat modes + Spa Manual Heat** | water_heater/climate/switch | Heat source incl. Solar Only / Solar Preferred; `MANHT` on BODY/SYSTEM untracked. Live unit has Solar sensor + Solar function circuits. `set_heat_mode()` helper unused. |
+| 9 | **Hardware diagnostics: MODULE/PANEL firmware, SYSTEM.UPDATE flag, SENSE PROBE/CALIB** | sensors (diagnostic) | MODULE has per-module `VER`; `UPDATE` = firmware-available flag; raw-vs-calibrated probe comparison diagnoses sensor drift. All untracked. `GetHardwareDefinition` never consumed. |
+| 10 | **Pump priming config (PRIMFLO/PRIMTIM) + body live TEMP + BOOST** | number/sensor/switch | Attributes defined but untracked; write semantics need hardware verification. |
+| 11 | **Firmware advisory: detect version, warn on known-issue firmware** | HA Repairs issue (+ existing Firmware Version sensor) | We already parse `VER` ("IC: 1.064 ..."); compare against a curated, sourced known-issues table and raise a Repairs warning (e.g. protocol quirks like the 1.064 `TIMOUT` token, versions with documented local-protocol instability, out-of-date firmware). Also candidates: `SYSTEM.UPDATE` firmware-available flag (untracked today). |
+
+## Deliberately excluded
+
+- **PERMIT** (users/passwords): the protocol returns panel passwords in cleartext — keep out of HA state and diagnostics.
+- **Valve position/mode**: no feedback path exists (see `docs/valve-control-implementation.md` correction banner); indirect watchdog is the sanctioned approach. A valve *role* (ASSIGN) config editor is possible but is configuration, not control.
+- **History/usage graphs, notifications delivery, firmware update trigger**: Pentair-cloud or panel-local only; HA long-term statistics already covers history.
+
+## Unknowns needing device probing before implementation
+
+- Writing `SCHED.STATUS` / schedule CRUD over the local socket (njsPC does it via RS-485; web app does it via this protocol — near-certain but unverified on our unit)
+- Delay-cancel command shape
+- Whether Service/Timeout mode can be *set* remotely (we only read it)
+- `FEATR`/`PRESS` object semantics (placeholders on the test unit)
+- Sun-relative schedule starts (`START=SRIS/SSET` accepted on write?)
+
+## Suggested implementation order
+
+1. Schedule enable switch + schedule detail attributes (small, high value, one probe needed)
+2. Egg timer + freeze-protection surfacing (attributes already tracked — cheapest wins)
+3. Chemistry LSI + chem alert + superchlorinate duration
+4. Delay status + cancel button (after probing)
+5. Circuit/light groups
+6. Dimmer brightness + light extras
+7. Diagnostics tier (MODULE firmware, UPDATE flag, PROBE/CALIB)
+8. Solar heat modes / manual heat (needs a system with solar to verify)
+
+Full Codex report (object-type table, all 71 unused methods, 253 unexposed attribute pairs) is preserved in the session records; regenerate with the audit method above if needed.

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -1,0 +1,148 @@
+"""Test firmware version parsing and known-issue advisories."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+import pytest
+
+from custom_components.intellicenter.const import DOMAIN
+from custom_components.intellicenter.firmware import (
+    KNOWN_FIRMWARE_ISSUES,
+    FirmwareAdvisory,
+    async_check_firmware,
+    matching_advisories,
+    parse_ic_version,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# -------------------------------------------------------------------------------------
+# parse_ic_version
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Hardware-observed format (IC 1.064 unit)
+        ("IC: 1.064 , ICWEB:2021-10-19 1.007", (1, 64)),
+        ("IC: 2.006", (2, 6)),
+        ("IC:1.047", (1, 47)),
+        ("IC: 3.004 , ICWEB:2024-11-02 2.010", (3, 4)),
+        # Version without the IC: prefix (defensive)
+        ("1.064", (1, 64)),
+        # Unparseable values
+        ("", None),
+        ("garbage", None),
+        (None, None),
+    ],
+)
+async def test_parse_ic_version(
+    raw: str | None, expected: tuple[int, int] | None
+) -> None:
+    """The IC panel version is extracted from the raw VER string."""
+    assert parse_ic_version(raw) == expected
+
+
+# -------------------------------------------------------------------------------------
+# matching_advisories
+
+
+def _advisory(**overrides) -> FirmwareAdvisory:
+    """Return a test advisory with sensible defaults."""
+    defaults = {
+        "issue_id": "test_advisory",
+        "translation_key": "firmware_test",
+        "max_version": None,
+        "exact_versions": None,
+        "learn_more_url": "https://example.com",
+    }
+    defaults.update(overrides)
+    return FirmwareAdvisory(**defaults)
+
+
+async def test_matching_advisories_max_version() -> None:
+    """A max_version advisory matches all versions at or below the bound."""
+    adv = _advisory(max_version=(1, 47))
+    assert adv in matching_advisories((1, 40), [adv])
+    assert adv in matching_advisories((1, 47), [adv])
+    assert adv not in matching_advisories((1, 64), [adv])
+    assert adv not in matching_advisories((2, 6), [adv])
+
+
+async def test_matching_advisories_exact_versions() -> None:
+    """An exact_versions advisory matches only the listed versions."""
+    adv = _advisory(exact_versions=((1, 64),))
+    assert adv in matching_advisories((1, 64), [adv])
+    assert adv not in matching_advisories((1, 63), [adv])
+    assert adv not in matching_advisories((2, 6), [adv])
+
+
+async def test_known_firmware_issues_are_well_formed() -> None:
+    """Every curated advisory has an id, translation key, source, and a matcher."""
+    for adv in KNOWN_FIRMWARE_ISSUES:
+        assert adv.issue_id
+        assert adv.translation_key
+        assert adv.learn_more_url and adv.learn_more_url.startswith("https://")
+        assert adv.max_version is not None or adv.exact_versions is not None
+
+
+# -------------------------------------------------------------------------------------
+# async_check_firmware
+
+
+def _mock_coordinator_with_ver(pool_model, raw_ver: str | None) -> MagicMock:
+    """Build a minimal coordinator mock exposing a SYSTEM object with VER."""
+    coordinator = MagicMock()
+    system_obj = MagicMock()
+    system_obj.__getitem__ = MagicMock(return_value=raw_ver)
+    coordinator.model.get_by_type.return_value = [system_obj]
+    return coordinator
+
+
+async def test_async_check_firmware_creates_issue(hass: HomeAssistant) -> None:
+    """A firmware version matching an advisory raises a Repairs issue."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    coordinator = _mock_coordinator_with_ver(None, "IC: 1.040")
+
+    advisories = [_advisory(issue_id="outdated", max_version=(1, 47))]
+    async_check_firmware(hass, entry, coordinator, advisories=advisories)
+    await hass.async_block_till_done()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, "outdated_test_entry") is not None
+
+
+async def test_async_check_firmware_clears_stale_issue(hass: HomeAssistant) -> None:
+    """An issue raised for an old firmware is deleted once the version no longer matches."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    advisories = [_advisory(issue_id="outdated", max_version=(1, 47))]
+
+    coordinator = _mock_coordinator_with_ver(None, "IC: 1.040")
+    async_check_firmware(hass, entry, coordinator, advisories=advisories)
+    await hass.async_block_till_done()
+
+    # Firmware upgraded -> advisory no longer applies
+    coordinator = _mock_coordinator_with_ver(None, "IC: 2.006")
+    async_check_firmware(hass, entry, coordinator, advisories=advisories)
+    await hass.async_block_till_done()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, "outdated_test_entry") is None
+
+
+async def test_async_check_firmware_unparseable_is_noop(hass: HomeAssistant) -> None:
+    """An unparseable VER value raises no issue and does not crash setup."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    coordinator = _mock_coordinator_with_ver(None, "garbage")
+
+    advisories = [_advisory(issue_id="outdated", max_version=(1, 47))]
+    async_check_firmware(hass, entry, coordinator, advisories=advisories)
+    await hass.async_block_till_done()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, "outdated_test_entry") is None


### PR DESCRIPTION
Closes #101. Also adds the 2026-07 feature gap analysis doc that produced issues #91–#101.

## What it does

Parses the IC panel version from the SYSTEM `VER` attribute ("IC: 1.064 , ICWEB:...") and compares it against a curated, **source-cited** `KNOWN_FIRMWARE_ISSUES` table. Matches raise a **Home Assistant Repairs warning** (dismissible, per config entry, with a learn-more link to the documenting source). Advisories that no longer match after a firmware upgrade are cleared on the next reload.

## Initial advisory table (conservative, all sourced)

| Match | Advisory | Source |
|---|---|---|
| 2.006 / 2.017 / 2.026 | 2.x line: broken schedules (Celsius setpoint corruption), pumps randomly commanded to 0 RPM, heater comm failures; 2.006 & 2.026 **pulled by Pentair**; official upgrade path skips 2.x | TFP 2.006 thread; njsPC carried a hard "do not upgrade to 2.006" README warning for years |
| ≤ 1.063 | Long superseded; partial third-party protocol support documented; Pentair's official path steps through 1.064 | Pentair downloads page |

**Deliberately no advisory** for 1.064 (community-documented safe baseline and official revert point — warning on it would be noise) or 3.004 (Pentair's mandatory stepping stone; user reports mixed). Research found no hardware generation stuck on 1.x, so recommendations are universal.

## Implementation

- New `firmware.py`: `parse_ic_version()` (regex, tolerant of missing prefix, returns comparable tuple), frozen `FirmwareAdvisory` dataclass (max_version / exact_versions matchers), `async_check_firmware()` hooked into `async_setup_entry` after platform setup
- First `issue_registry` (Repairs) usage in the integration; `issues` section added to strings.json + translations
- Unparseable `VER` is a guaranteed no-op — an odd firmware string can never break setup

## Tests

TDD: 14 new tests (parser matrix incl. hardware-observed format, matcher bounds, table well-formedness incl. mandatory source URL, Repairs create/clear/no-op via hass fixture). **351 passed**, ruff + mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)