### PR TITLE
chore: release 3.10.0b1 (pre-release)

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "pyintellicenter>=0.1.21"
   ],
-  "version": "3.9.0",
+  "version": "3.10.0b1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.9.0"
+version = "3.10.0b1"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Version bump for the 3.10.0b1 beta (roadmap batch #91–#100, merged in #105). Pre-release for community hardware testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)