### PR TITLE
fix: covers no longer go unavailable when STATUS reads OFF (#107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,7 @@ The integration has achieved **Platinum** quality scale (v3.0.0). The roadmap be
     - Number: 39 tests (setpoint controls)
     - Sensor: 37 tests (incl. body Last Temp)
     - Climate: 24 tests (UltraTemp heat pump)
-    - Cover: 28 tests (STATUS enabled-flag gating, POSIT position)
+    - Cover: 27 tests (availability follows panel connection, POSIT position/actuation)
     - Binary Sensor: 31 tests (incl. Not in Auto problem sensor, cross-body heat source)
     - Switch: 13 tests (device class)
   - **Diagnostics tests**: 10 tests

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This integration connects your Pentair IntelliCenter pool control system to Home
 
 This release fixes cover semantics, heater detection, and adds firmware awareness — with major contributions from @bhamiltoncx:
 
-- **Correct Pool Cover Behavior** (thanks @bhamiltoncx): the integration previously conflated a cover's *enabled* setting with its *position*. Covers disabled in Settings > Covers now show as unavailable instead of appearing active, and position comes from the panel's real position attribute (`POSIT`). On older firmware that doesn't report position (e.g. IC 1.064), the cover state shows unknown and open/close report a clear error — previously these commands silently toggled the cover's enabled setting instead of moving it.
+- **Correct Pool Cover Behavior** (thanks @bhamiltoncx): the integration previously conflated a cover's *enabled* setting with its *position*. Position now comes from the panel's real position attribute (`POSIT`). On older firmware that doesn't report position (e.g. IC 1.064), the cover state shows unknown and open/close report a clear error — previously these commands silently toggled the cover's enabled setting instead of moving it. (Note: v3.9.0 also hid covers whose `STATUS` read `OFF`, which made some covers go permanently unavailable — corrected in a later release; see issue #107.)
 - **Cross-Body Heater Detection** (thanks @bhamiltoncx): a heater actively heating a body that isn't in its configured body list (possible on real panels) is now correctly reported as heating.
 - **Firmware Advisories**: the integration now recognizes firmware releases with documented problems (e.g. the withdrawn 2.x line) and raises a dismissible Repairs warning — and warns during initial setup before you finish adding the integration.
 - **"Not in Auto" Problem Sensor**: turns on when the panel is left in Service or Time Out mode (e.g. after maintenance or a power outage), which silently suspends schedules and automatic valve/pump control.
@@ -137,7 +137,7 @@ After setup, configure connection settings:
 | **Heaters** | Binary Sensor, Water Heater | Running status; HCOMBO (UltraTemp ETi Hybrid) Gas/Heat Pump/Hybrid/Dual modes |
 | **Schedules** | Binary Sensor | Active status (disabled by default) |
 | **System** | Switch, Binary Sensor, Sensors | Vacation mode, freeze protection, temperatures, System Mode (`auto`/`service`/`timeout`), "Not in Auto" problem indicator, firmware advisories (a Repairs warning is raised for firmware with documented issues, e.g. the pulled 2.x line) |
-| **Covers** | Cover | Pool cover position (`POSIT`) and open/close; covers disabled in Settings > Covers show unavailable; older firmware without position reporting shows unknown |
+| **Covers** | Cover | Pool cover position (`POSIT`) and open/close; availability follows the panel connection (STATUS never hides the entity); older firmware without position reporting shows unknown |
 
 ### Body (Pool/Spa) Last Temp Sensor
 

--- a/custom_components/intellicenter/cover.py
+++ b/custom_components/intellicenter/cover.py
@@ -2,16 +2,20 @@
 
 This module provides cover entities for pool covers and other motorized covers.
 
-Attribute semantics (confirmed by capturing the panel web UI's own
-SETPARAMLIST traffic — see joyfulhouse/pyintellicenter#44):
+Attribute semantics (from capturing the panel web UI's own SETPARAMLIST
+traffic — see joyfulhouse/pyintellicenter#44):
 
-- ``STATUS`` is the "Cover Enabled" flag from Settings > Covers. It is
-  configuration, never position.
-- ``POSIT`` is the physical cover position. Older firmware (e.g. IC 1.064,
-  verified live) omits POSIT entirely; on such panels there is NO live
-  position signal, so position is unknown and position commands are refused
-  rather than fabricated from STATUS (writing STATUS would toggle the
-  cover's enabled flag in the panel's settings, not move the cover).
+- ``STATUS`` maps to the "Cover Enabled" flag in Settings > Covers on the
+  panels captured for #44, but it is firmware-variable: on some panels it
+  reads OFF for a closed cover (issue #107). This integration therefore does
+  NOT use STATUS for position OR for entity availability. Writing STATUS can
+  toggle the enabled flag in the panel's settings rather than move the cover,
+  so it is never written.
+- ``POSIT`` is the physical cover position and the sole supported
+  position/actuation source. Older firmware (e.g. IC 1.064, verified live)
+  omits POSIT entirely; on such panels there is NO live position signal, so
+  position is unknown and position commands are refused rather than
+  fabricated from STATUS.
 """
 
 from __future__ import annotations
@@ -55,11 +59,11 @@ def _build_entities(
 ) -> list[PoolCover]:
     """Build cover entities for the given candidate pool objects.
 
-    Entities are created for every EXTINSTR/COVER object — including covers
-    disabled in Settings > Covers — and gated through ``available`` instead.
-    Creating them all keeps existing users' entity registry stable and means
-    a cover enabled after setup comes alive on the next push (STATUS updates
-    an existing object, which would never re-trigger entity creation).
+    Entities are created for every EXTINSTR/COVER object. Availability follows
+    the panel connection only (like every other platform); STATUS is not used
+    to gate availability because it is firmware-variable and a closed cover can
+    legitimately report STATUS=OFF — gating on it made covers go permanently
+    unavailable (issue #107). Position/actuation come from POSIT/NORMAL.
     """
     return [
         PoolCover(coordinator, pool_obj)
@@ -105,18 +109,6 @@ class PoolCover(PoolEntity, CoverEntity):
         self._attr_supported_features = (
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
         )
-
-    @property
-    def available(self) -> bool:
-        """Return whether the panel is connected and the cover is enabled.
-
-        STATUS is the Settings > Covers enabled flag; a disabled cover is a
-        configuration placeholder, not controllable equipment. Only an
-        explicit OFF hides the entity — a cover missing STATUS entirely
-        (unobserved, but protocol-plausible) fails open rather than becoming
-        permanently unavailable.
-        """
-        return super().available and self._pool_object.status != STATUS_OFF
 
     def _valid_position_state(self) -> tuple[bool, bool] | None:
         """Return (posit_is_on, normal_is_on), or None if either is invalid.

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -103,15 +103,15 @@ async def test_cover_setup_creates_entities(
     assert entities_added[0]._pool_object.sname == "Pool Cover"
 
 
-async def test_cover_setup_skips_disabled_cover(
+async def test_cover_setup_creates_status_off_cover_available(
     hass: HomeAssistant,
     mock_coordinator: MagicMock,
 ) -> None:
-    """A STATUS=OFF (disabled) cover still gets an entity, gated unavailable.
+    """A STATUS=OFF cover still gets an entity and stays available (issue #107).
 
-    Creating the entity keeps the registry stable and lets a cover enabled
-    after setup come alive on the next push (STATUS updates an existing
-    object, which never re-triggers entity creation).
+    STATUS does not gate availability: it is firmware-variable and a closed
+    cover can report STATUS=OFF, so gating on it made covers permanently
+    unavailable. Availability follows the panel connection only.
     """
     model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
     model.add_object(
@@ -119,7 +119,7 @@ async def test_cover_setup_skips_disabled_cover(
         {
             "OBJTYP": EXTINSTR_TYPE,
             "SUBTYP": "COVER",
-            "SNAME": "Disabled Cover",
+            "SNAME": "Cover",
             "STATUS": "OFF",
             "POSIT": "ON",
             "NORMAL": "ON",
@@ -137,7 +137,7 @@ async def test_cover_setup_skips_disabled_cover(
 
     assert len(entities_added) == 1
     mock_coordinator.connected = True
-    assert entities_added[0].available is False
+    assert entities_added[0].available is True
 
 
 async def test_cover_entity_properties(
@@ -221,12 +221,12 @@ async def test_cover_normally_open_is_open_when_position_on(
     assert cover.is_closed is False
 
 
-async def test_cover_position_and_enabled_availability_are_independent(
+async def test_cover_position_is_posit_driven_and_status_independent(
     hass: HomeAssistant,
     pool_object_cover_normally_closed: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test POSIT drives position while STATUS gates entity availability."""
+    """POSIT drives position; STATUS never changes availability (issue #107)."""
     mock_coordinator.connected = True
     cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
 
@@ -236,8 +236,9 @@ async def test_cover_position_and_enabled_availability_are_independent(
     pool_object_cover_normally_closed.update({POSIT_ATTR: "ON"})
     assert cover.is_closed is True
 
+    # Toggling STATUS must not affect availability in either direction.
     pool_object_cover_normally_closed.update({STATUS_ATTR: "OFF"})
-    assert cover.available is False
+    assert cover.available is True
     assert cover.is_closed is True
 
     pool_object_cover_normally_closed.update({STATUS_ATTR: "ON"})
@@ -572,15 +573,15 @@ async def test_cover_unknown_position_when_attributes_missing(
     assert cover.is_closed is None
 
 
-async def test_cover_missing_status_fails_open(
+async def test_cover_status_never_gates_availability(
     hass: HomeAssistant,
     mock_coordinator: MagicMock,
 ) -> None:
-    """A cover with no STATUS attribute at all stays available (fail-open).
+    """A cover stays available when connected, whatever STATUS reads.
 
-    Only an explicit STATUS=OFF (disabled in Settings > Covers) hides the
-    entity; an absent STATUS must not make a working cover permanently
-    unavailable.
+    STATUS must not veto Home Assistant availability: it is firmware-variable
+    (older releases wrote it as position) and gating on it makes a cover go
+    permanently unavailable whenever it reads OFF.
     """
     cover_obj = PoolObject(
         "COVER5",
@@ -597,3 +598,79 @@ async def test_cover_missing_status_fails_open(
 
     assert cover.available is True
     assert cover.is_closed is True
+
+    # An explicit STATUS=OFF must not hide the entity (issue #107).
+    cover_obj.update({STATUS_ATTR: "OFF"})
+    assert cover.available is True
+
+
+async def test_cover_regression_issue_107_status_off_stays_available(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Regression for issue #107: EXTINSTR/COVER with STATUS=OFF stays available.
+
+    The reporter's CVR01/CVR02 (device_class shade) went permanently
+    ``unavailable`` after upgrading to v3.9.0 while every other entity on the
+    same panel kept working, and a config-entry reload did not clear it. Root
+    cause: v3.9.0 added an availability gate ``status != STATUS_OFF``. A
+    closed cover reports STATUS=OFF in some configurations, so closing it made
+    the entity unavailable, and reload re-fetched the same STATUS=OFF and
+    re-hid it.
+
+    A closed normally-open cover (NORMAL=OFF, POSIT=OFF) with STATUS=OFF must
+    be created, available, and reported closed — and must stay so after the
+    model is rebuilt from scratch (as a config-entry reload does).
+    """
+    mock_coordinator.connected = True
+
+    def _build_covers() -> list[PoolCover]:
+        model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+        for objnam in ("CVR01", "CVR02"):
+            model.add_object(
+                objnam,
+                {
+                    "OBJTYP": EXTINSTR_TYPE,
+                    "SUBTYP": "COVER",
+                    "SNAME": f"Cover {objnam}",
+                    "STATUS": "OFF",  # closed cover reports STATUS=OFF here
+                    "POSIT": "OFF",
+                    "NORMAL": "OFF",  # normally open
+                },
+            )
+        mock_coordinator.model = model
+        return [PoolCover(mock_coordinator, obj) for obj in model]
+
+    covers = _build_covers()
+    assert len(covers) == 2
+    for cover in covers:
+        assert cover.available is True
+        # NORMAL=OFF, POSIT=OFF -> closed
+        assert cover.is_closed is True
+
+    # Simulate a config-entry reload: a fresh model re-fetches the same
+    # STATUS=OFF from the panel. The covers must remain available.
+    reloaded = _build_covers()
+    for cover in reloaded:
+        assert cover.available is True
+
+
+async def test_cover_unavailable_when_disconnected_regardless_of_status(
+    hass: HomeAssistant,
+    pool_object_cover_normally_closed: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Availability tracks the panel connection only."""
+    cover = PoolCover(mock_coordinator, pool_object_cover_normally_closed)
+
+    mock_coordinator.connected = False
+    assert cover.available is False
+
+    mock_coordinator.connected = True
+    assert cover.available is True
+
+    # STATUS toggling does not change availability either way.
+    pool_object_cover_normally_closed.update({STATUS_ATTR: "OFF"})
+    assert cover.available is True
+    mock_coordinator.connected = False
+    assert cover.available is False


### PR DESCRIPTION
## Bug

`EXTINSTR/COVER` cover entities (device_class `shade`, e.g. CVR01/CVR02) went permanently **`unavailable`** after upgrading to **v3.9.0**, while every other entity on the same panel (sensors, switches, water heaters, VSF pump) kept working. A config-entry **reload did not clear it**. Fixes #107.

## Root cause

v3.9.0 (#103) added a cover-only availability gate in `cover.py`:

```python
available = super().available and self._pool_object.status != STATUS_OFF
```

`super().available` is just `coordinator.connected` — which is why only covers were affected. `STATUS` is **firmware-variable**: on some panels a *closed* cover reports `STATUS=OFF` (pre-v3.9.0 the integration even wrote `STATUS` as the position). So closing a cover drove the entity `unavailable`, and a reload re-fetched the same `STATUS=OFF` and re-hid it. Confirmed independently by a tri-model review (see below); the coordinator was already tracking `STATUS`/`POSIT`/`NORMAL`, so the reporter's "re-subscribe/poll" theory was ruled out.

## Fix

Remove the `available` override so covers inherit `PoolEntity.available` (connection-only), matching every other platform and pre-v3.9.0 behavior. **Position and actuation are unchanged** (still `POSIT`/`NORMAL`-based), and `STATUS` is still never *written* (writing it can flip the Settings > Covers enabled flag on some firmware — the important part of #103 is preserved).

## Test plan

- Reworked the two tests that encoded the buggy gate.
- Added regression tests, including `test_cover_regression_issue_107_status_off_stays_available`, which builds the reporter's exact CVR01/CVR02 (`STATUS=OFF`, `NORMAL=OFF`, `POSIT=OFF`), asserts available + closed, then **rebuilds the model from scratch to simulate a config-entry reload** and asserts still-available.
- Also: availability tracks connection only regardless of STATUS; POSIT-missing → `is_closed=None` + commands refused (unchanged).
- **Full suite: 491 passed.** `ruff check`/`format` clean, `mypy` clean.

## Docs

Corrected the cover module docstring (STATUS qualified as firmware-variable, not used for position/availability), the README covers row + v3.9.0 note, and the `CLAUDE.md` cover-test line.

## Adversarial review (tri-vendor, pre-commit)

- **Claude (code-reviewer):** NO BLOCKING ISSUES.
- **Codex (gpt-5.6-sol @ xhigh):** ran the suite + mypy itself; only two LOW doc-accuracy findings (module docstring + CLAUDE.md) — both applied.
- **Gemini 3.1 Pro:** one LOW (docstring — applied) and one **MEDIUM risk-accepted**: `isUpdated` still tracks `STATUS_ATTR`. Kept intentionally — `PoolEntity.extra_state_attributes` surfaces `pool_obj.status` as a diagnostic **"Status"** attribute, and tracking STATUS keeps it fresh; this is long-standing pre-#103 behavior and `STATUS_ATTR` is not a dead import.

## Release note

Targets the 3.10 line; also being backported to a **3.9.1** patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)