### PR TITLE
chore: release 3.10.0b2 (pre-release)

### DIFF
--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "pyintellicenter>=0.1.21"
   ],
-  "version": "3.10.0b1",
+  "version": "3.10.0b2",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.10.0b1"
+version = "3.10.0b2"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.9.0"
+version = "3.10.0b2"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Pre-release version bump to **3.10.0b2**.

Rolls up the issue #107 cover-availability fix (#108, already merged to main) into a taggable pre-release.

- `manifest.json` + `pyproject.toml`: `3.10.0b1` → `3.10.0b2`
- `uv.lock`: sync self-version (the b1 bump left it stale at `3.9.0`)

Version-sync guard tests pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)