### PR TITLE
feat: light-group Color Sync + real CIRCGRP membership (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Color Sync light-group action** (#93) - Added the blocking `intellicenter.color_sync` service for complete light groups with exactly two distinct GloBrite members on firmware 1.064, available over TCP and WebSocket.
+
+### Changed
+
+- **Requires pyintellicenter >= 0.1.22** (#93) - The Color Sync action uses the protocol library's blocking authoritative lifecycle: it observes the physical action, continues through a 60-second post-terminal window, and performs a final controller read while isolating other mutations on the Home Assistant connection.
+
+### Fixed
+
+- **Light-group parent modeling** (#93) - Real `CIRCUIT` light-group parents are no longer confused with `CIRCGRP` membership rows, preventing row-derived duplicate entities while preserving ordered group membership.
+
 ## [3.8.1] - 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ After setup, configure connection settings:
 |----------|-------------|----------|
 | **Pool/Spa** | Switch, Sensors, Water Heater | On/off, temperature, heater control (incl. HCOMBO hybrid modes) |
 | **Lights** | Light | On/off, color effects (IntelliBrite, MagicStream) |
-| **Light Shows** | Light | Coordinated multi-light effects |
+| **Light Shows** | Light | Coordinated multi-light effects and the Color Sync action over TCP or WebSocket |
 | **Circuits** | Switch | All "Featured" circuits (cleaner, blower, etc.) |
 | **Pumps** | Binary Sensor, Sensors | Running status, power (W), speed (RPM), flow (GPM) |
 | **Chemistry** | Sensors, Number | pH, ORP, tank levels, setpoints (IntelliChem) |
@@ -148,6 +148,38 @@ After setup, configure connection settings:
   so it stays accurate while the pump is idle.
 
 ## Automation Examples
+
+### Color Sync for a GloBrite Light Group
+
+Use the `intellicenter.color_sync` action with the complete light-group entity:
+
+```yaml
+action:
+  - service: intellicenter.color_sync
+    target:
+      entity_id: light.pool_light_group
+```
+
+Color Sync is intentionally limited to the hardware-confirmed safety envelope:
+firmware `1.064`, one complete light group containing exactly two distinct
+GloBrite members, and a uniform starting state in which both members are all off
+or all on. Color Set, Color Swim, and member-position controls are not exposed.
+
+The call is synchronous. On the observed firmware it usually takes roughly
+96-97 seconds plus request latency because it waits for the physical action, a
+60-second post-terminal observation, and a final controller read before
+returning. During that interval, other IntelliCenter object mutations requested
+through this Home Assistant connection fail immediately rather than queueing
+behind Color Sync. Read-only updates continue. Urgent control from the physical
+panel remains available, but changing panel state during the action can make the
+action report an incomplete outcome.
+
+An explicit failure means dispatch did not begin or IntelliCenter rejected the
+command, so no action was confirmed. An uncertain no-response outcome means
+dispatch started but IntelliCenter did not respond, so the action may have run.
+An acknowledged or visibly started but incomplete outcome means authoritative
+completion could not be confirmed. For either uncertain or incomplete outcomes,
+inspect the lights and panel state before retrying.
 
 ### Evening Spa Warmup
 

--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -245,7 +245,8 @@ def async_setup_pool_entities(
 
     Entities are de-duplicated by ``unique_id`` so an object can never produce a
     duplicate entity, even though the coordinator already reports each new object
-    only once.
+    only once. A duplicate builder result refreshes the original entity's shared
+    model context, allowing cross-object capabilities to change in place.
 
     Args:
         entry: The config entry whose ``runtime_data`` is the coordinator.
@@ -255,16 +256,18 @@ def async_setup_pool_entities(
             objects to consider; returns the list of entities to add.
     """
     coordinator = entry.runtime_data
-    created_unique_ids: set[str] = set()
+    created_entities: dict[str, Any] = {}
 
     @callback
     def _add(candidates: Iterable[PoolObject]) -> None:
         entities: list[Any] = []
         for entity in build_entities(coordinator, candidates):
             uid = entity.unique_id
-            if uid in created_unique_ids:
+            existing = created_entities.get(uid)
+            if existing is not None:
+                existing.async_refresh_model_context()
                 continue
-            created_unique_ids.add(uid)
+            created_entities[uid] = entity
             entities.append(entity)
         if entities:
             async_add_entities(entities)
@@ -645,6 +648,10 @@ class PoolEntity(CoordinatorEntity[IntelliCenterCoordinator], Entity):
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
         return self._attribute_key in updates.get(self._pool_object.objnam, {})
+
+    @callback
+    def async_refresh_model_context(self) -> None:
+        """Refresh state derived from other objects in the shared model."""
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -145,7 +145,11 @@ DEFAULT_ATTRIBUTES_MAP: dict[str, set[str]] = {
         DNTSTP_ATTR,
         FREEZE_ATTR,  # Freeze protection status
     },
-    CIRCGRP_TYPE: {SNAME_ATTR, STATUS_ATTR, USE_ATTR, CIRCUIT_ATTR},  # Circuit groups
+    CIRCGRP_TYPE: {
+        PARENT_ATTR,
+        CIRCUIT_ATTR,
+        LISTORD_ATTR,
+    },  # Circuit-group membership rows
     CHEM_TYPE: {
         SNAME_ATTR,
         BODY_ATTR,

--- a/custom_components/intellicenter/light.py
+++ b/custom_components/intellicenter/light.py
@@ -23,6 +23,8 @@ from pyintellicenter import (
     LIGHT_EFFECTS,
     STATUS_ATTR,
     USE_ATTR,
+    ICError,
+    ICLightGroupError,
     PoolObject,
 )
 
@@ -42,11 +44,12 @@ PARALLEL_UPDATES = 0
 
 _DIMMABLE_SUBTYPES = frozenset({"DIMMER"})
 _SUPPORTED_DIMMER_LEVELS = (50, 75, 100)
-_MAGICSTREAM_SERVICES = {
+_ENTITY_SERVICES = {
     "capture": "async_capture",
     "thumper": "async_thumper",
     "hold": "async_hold",
     "recall": "async_recall",
+    "color_sync": "async_color_sync",
 }
 
 
@@ -151,7 +154,7 @@ async def async_setup_entry(
 ) -> None:
     """Load pool lights based on a config entry."""
     platform = entity_platform.async_get_current_platform()
-    for service_name, method_name in _MAGICSTREAM_SERVICES.items():
+    for service_name, method_name in _ENTITY_SERVICES.items():
         platform.async_register_entity_service(service_name, None, method_name)
     async_setup_pool_entities(entry, async_add_entities, _build_entities)
 
@@ -343,6 +346,37 @@ class PoolLight(PoolEntity, OnOffControlMixin, LightEntity):
     async def async_recall(self) -> None:
         """Recall the saved MagicStream color."""
         await self._async_magicstream_command("RECALL")
+
+    async def async_color_sync(self) -> None:
+        """Synchronize the supported two-light IntelliCenter group."""
+        if not _is_color_sync_eligible(self.coordinator, self._pool_object):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="light_group_command_unsupported",
+            )
+        try:
+            await self._controller.run_light_group_sync(self._pool_object.objnam)
+        except ValueError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="light_group_command_unsupported",
+            ) from err
+        except ICLightGroupError as err:
+            if err.acknowledged or err.onset_seen:
+                translation_key = "light_group_command_incomplete"
+            elif err.dispatch_started and not err.response_received:
+                translation_key = "light_group_command_uncertain"
+            else:
+                translation_key = "light_group_command_failed"
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key=translation_key,
+            ) from err
+        except ICError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="light_group_command_failed",
+            ) from err
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""

--- a/custom_components/intellicenter/light.py
+++ b/custom_components/intellicenter/light.py
@@ -12,12 +12,13 @@ from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_EFFECT, LightEntity
 from homeassistant.components.light.const import ColorMode, LightEntityFeature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     ACT_ATTR,
+    CIRCUIT_ATTR,
     CIRCUIT_TYPE,
     LIGHT_EFFECTS,
     STATUS_ATTR,
@@ -98,8 +99,30 @@ def _build_entities(
     coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
 ) -> list[PoolLight]:
     """Build light entities for the given candidate pool objects."""
+    candidate_list = list(candidates)
+    candidate_objnams = {obj.objnam for obj in candidate_list}
+    entity_objects = {
+        obj.objnam: obj
+        for obj in candidate_list
+        if obj.is_a_light or obj.is_a_light_show
+    }
+
+    # Re-evaluate an existing parent when a membership row or referenced child
+    # arrives later. The shared setup helper de-duplicates the replacement by
+    # unique_id and asks the original entity to refresh its model context.
+    for parent in coordinator.model:
+        if not parent.is_a_light_show:
+            continue
+        members = coordinator.controller.get_circuit_group_members(parent.objnam)
+        if parent.objnam in candidate_objnams or any(
+            member.objnam in candidate_objnams
+            or member[CIRCUIT_ATTR] in candidate_objnams
+            for member in members
+        ):
+            entity_objects.setdefault(parent.objnam, parent)
+
     lights: list[PoolLight] = []
-    for obj in candidates:
+    for obj in entity_objects.values():
         if obj.is_a_light:
             lights.append(
                 PoolLight(
@@ -160,18 +183,52 @@ class PoolLight(PoolEntity, OnOffControlMixin, LightEntity):
         """
         super().__init__(coordinator, pool_object, extra_state_attributes=[USE_ATTR])
 
-        self._light_effects = color_effects
+        self._attr_supported_features = LightEntityFeature(0)
+        self._light_effects: dict[str, str] | None = None
+        self._reversed_light_effects: dict[str, str] | None = None
         self._dimmable = pool_object.subtype in _DIMMABLE_SUBTYPES
-        self._reversed_light_effects: dict[str, str] | None = (
-            {v: k for k, v in color_effects.items()} if color_effects else None
-        )
 
         if self._dimmable:
             self._attr_color_mode = ColorMode.BRIGHTNESS
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
-        if self._light_effects:
+        self._set_light_effects(color_effects)
+
+    def _set_light_effects(self, color_effects: dict[str, str] | None) -> bool:
+        """Replace the effect mapping and report whether capability changed."""
+        if self._light_effects == color_effects:
+            return False
+        self._light_effects = color_effects
+        self._reversed_light_effects = (
+            {value: key for key, value in color_effects.items()}
+            if color_effects
+            else None
+        )
+        if color_effects:
             self._attr_supported_features |= LightEntityFeature.EFFECT
+        else:
+            self._attr_supported_features &= ~LightEntityFeature.EFFECT
+        return True
+
+    def _refresh_light_group_effects(self) -> bool:
+        """Refresh group effects from the current complete membership model."""
+        if not self._pool_object.is_a_light_show:
+            return False
+        color_effects = (
+            LIGHT_EFFECTS
+            if _is_complete_color_light_group(self.coordinator, self._pool_object)
+            else None
+        )
+        return self._set_light_effects(color_effects)
+
+    @callback
+    def async_refresh_model_context(self) -> None:
+        """Refresh cross-object group capability without replacing the entity."""
+        current = self.coordinator.model[self._pool_object.objnam]
+        if current is not None:
+            self._pool_object = current
+        if self._refresh_light_group_effects() and self.hass is not None:
+            self.async_write_ha_state()
 
     @property
     def brightness(self) -> int | None:
@@ -289,6 +346,16 @@ class PoolLight(PoolEntity, OnOffControlMixin, LightEntity):
 
     def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
         """Return true if the entity is updated by the updates from IntelliCenter."""
-        return self._check_attributes_updated(
-            updates, STATUS_ATTR, USE_ATTR, LIMIT_ATTR
+        return self._refresh_light_group_effects() or self._check_attributes_updated(
+            updates,
+            STATUS_ATTR,
+            USE_ATTR,
+            LIMIT_ATTR,
         )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Refresh group capability across reconnects and ordinary updates."""
+        if not (self.coordinator.data or {}):
+            self._refresh_light_group_effects()
+        super()._handle_coordinator_update()

--- a/custom_components/intellicenter/light.py
+++ b/custom_components/intellicenter/light.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyintellicenter import (
     ACT_ATTR,
-    CIRCUIT_ATTR,
+    CIRCUIT_TYPE,
     LIGHT_EFFECTS,
     STATUS_ATTR,
     USE_ATTR,
@@ -49,6 +49,51 @@ _MAGICSTREAM_SERVICES = {
 }
 
 
+def _complete_light_group_children(
+    coordinator: IntelliCenterCoordinator, parent: PoolObject
+) -> tuple[PoolObject, ...] | None:
+    """Resolve every distinct child of a real light-group parent."""
+    if parent.objtype != CIRCUIT_TYPE or parent.subtype != "LITSHO":
+        return None
+    members = coordinator.controller.get_circuit_group_members(parent.objnam)
+    children = coordinator.controller.get_circuits_in_group(parent.objnam)
+    if (
+        not members
+        or len(children) != len(members)
+        or len({child.objnam for child in children}) != len(children)
+    ):
+        return None
+    return tuple(children)
+
+
+def _is_complete_color_light_group(
+    coordinator: IntelliCenterCoordinator, parent: PoolObject
+) -> bool:
+    """Return whether a complete light group supports existing color effects."""
+    children = _complete_light_group_children(coordinator, parent)
+    return children is not None and all(
+        child.supports_color_effects for child in children
+    )
+
+
+def _is_color_sync_eligible(
+    coordinator: IntelliCenterCoordinator, parent: PoolObject
+) -> bool:
+    """Return whether the group matches the evidence-scoped Color Sync gate."""
+    children = _complete_light_group_children(coordinator, parent)
+    system_info = coordinator.system_info
+    return bool(
+        system_info is not None
+        and system_info.sw_version == "1.064"
+        and children is not None
+        and len(children) == 2
+        and all(
+            child.objtype == CIRCUIT_TYPE and child.subtype == "GLOW"
+            for child in children
+        )
+    )
+
+
 def _build_entities(
     coordinator: IntelliCenterCoordinator, candidates: Iterable[PoolObject]
 ) -> list[PoolLight]:
@@ -64,18 +109,13 @@ def _build_entities(
                 )
             )
         elif obj.is_a_light_show:
-            # Check if all child lights support color effects
-            children = coordinator.model.get_children(obj)
-            supports_color = all(
-                circuit_obj.supports_color_effects
-                for child in children
-                if (circuit_obj := coordinator.model[child[CIRCUIT_ATTR]]) is not None
-            )
             lights.append(
                 PoolLight(
                     coordinator,
                     obj,
-                    LIGHT_EFFECTS if supports_color else None,
+                    LIGHT_EFFECTS
+                    if _is_complete_color_light_group(coordinator, obj)
+                    else None,
                 )
             )
     return lights

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": [
-    "pyintellicenter>=0.1.21"
+    "pyintellicenter>=0.1.22"
   ],
   "version": "3.10.0b2",
   "zeroconf": [

--- a/custom_components/intellicenter/services.yaml
+++ b/custom_components/intellicenter/services.yaml
@@ -21,3 +21,9 @@ recall:
     entity:
       integration: intellicenter
       domain: light
+
+color_sync:
+  target:
+    entity:
+      integration: intellicenter
+      domain: light

--- a/custom_components/intellicenter/strings.json
+++ b/custom_components/intellicenter/strings.json
@@ -127,6 +127,10 @@
     "recall": {
       "name": "Recall MagicStream color",
       "description": "Recalls the saved color on a MagicStream light."
+    },
+    "color_sync": {
+      "name": "Synchronize light-group colors",
+      "description": "Synchronizes exactly two GloBrite lights in a complete IntelliCenter light group on firmware 1.064. The call waits for the physical action, a 60-second post-action observation, and a final controller read."
     }
   },
   "exceptions": {
@@ -144,6 +148,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "This command is available only for MagicStream lights."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync is available only on IntelliCenter firmware 1.064 for a complete light group with exactly two distinct GloBrite lights."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync failed before dispatch or IntelliCenter explicitly rejected it. No action was confirmed."
+    },
+    "light_group_command_uncertain": {
+      "message": "Color Sync dispatch started, but IntelliCenter returned no response. The action may have run. Inspect the lights and panel state before retrying."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter acknowledged or visibly started Color Sync, but authoritative completion was not confirmed. Inspect the lights and panel state before retrying."
     },
     "unknown_light_effect": {
       "message": "The requested light effect is not supported by this IntelliCenter light."

--- a/custom_components/intellicenter/translations/de.json
+++ b/custom_components/intellicenter/translations/de.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "MagicStream-Farbe abrufen",
       "description": "Ruft die gespeicherte Farbe einer MagicStream-Leuchte wieder auf."
+    },
+    "color_sync": {
+      "name": "Farben der Lichtgruppe synchronisieren",
+      "description": "Synchronisiert genau zwei GloBrite-Leuchten in einer vollständigen IntelliCenter-Lichtgruppe mit Firmware 1.064. Der Aufruf wartet auf die physische Aktion, eine 60-sekündige Beobachtung nach der Aktion und eine abschließende Abfrage des Controllers."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Dieser Befehl ist nur für MagicStream-Leuchten verfügbar."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync ist nur mit IntelliCenter-Firmware 1.064 für eine vollständige Lichtgruppe mit genau zwei verschiedenen GloBrite-Leuchten verfügbar."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync ist vor dem Senden fehlgeschlagen oder wurde von IntelliCenter ausdrücklich abgelehnt. Es wurde keine Aktion bestätigt."
+    },
+    "light_group_command_uncertain": {
+      "message": "Der Versand von Color Sync wurde begonnen, aber IntelliCenter hat nicht geantwortet. Die Aktion wurde möglicherweise ausgeführt. Prüfen Sie die Leuchten und den Bedienfeldstatus, bevor Sie es erneut versuchen."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter hat Color Sync bestätigt oder sichtbar gestartet, aber der zuverlässige Abschluss konnte nicht bestätigt werden. Prüfen Sie die Leuchten und den Bedienfeldstatus, bevor Sie es erneut versuchen."
     },
     "unknown_light_effect": {
       "message": "Der angeforderte Lichteffekt wird von dieser IntelliCenter-Leuchte nicht unterstützt."

--- a/custom_components/intellicenter/translations/en.json
+++ b/custom_components/intellicenter/translations/en.json
@@ -127,6 +127,10 @@
     "recall": {
       "name": "Recall MagicStream color",
       "description": "Recalls the saved color on a MagicStream light."
+    },
+    "color_sync": {
+      "name": "Synchronize light-group colors",
+      "description": "Synchronizes exactly two GloBrite lights in a complete IntelliCenter light group on firmware 1.064. The call waits for the physical action, a 60-second post-action observation, and a final controller read."
     }
   },
   "exceptions": {
@@ -144,6 +148,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "This command is available only for MagicStream lights."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync is available only on IntelliCenter firmware 1.064 for a complete light group with exactly two distinct GloBrite lights."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync failed before dispatch or IntelliCenter explicitly rejected it. No action was confirmed."
+    },
+    "light_group_command_uncertain": {
+      "message": "Color Sync dispatch started, but IntelliCenter returned no response. The action may have run. Inspect the lights and panel state before retrying."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter acknowledged or visibly started Color Sync, but authoritative completion was not confirmed. Inspect the lights and panel state before retrying."
     },
     "unknown_light_effect": {
       "message": "The requested light effect is not supported by this IntelliCenter light."

--- a/custom_components/intellicenter/translations/es.json
+++ b/custom_components/intellicenter/translations/es.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "Recuperar color de MagicStream",
       "description": "Recupera el color guardado de una luz MagicStream."
+    },
+    "color_sync": {
+      "name": "Sincronizar colores del grupo de luces",
+      "description": "Sincroniza exactamente dos luces GloBrite de un grupo de luces IntelliCenter completo con firmware 1.064. La llamada espera la acción física, una observación de 60 segundos posterior a la acción y una lectura final del controlador."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Este comando solo está disponible para luces MagicStream."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync solo está disponible con el firmware 1.064 de IntelliCenter para un grupo de luces completo con exactamente dos luces GloBrite distintas."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync falló antes del envío o IntelliCenter lo rechazó explícitamente. No se confirmó ninguna acción."
+    },
+    "light_group_command_uncertain": {
+      "message": "Se inició el envío de Color Sync, pero IntelliCenter no respondió. Es posible que la acción se haya ejecutado. Inspeccione las luces y el estado del panel antes de volver a intentarlo."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter confirmó o inició visiblemente Color Sync, pero no se pudo confirmar de forma fiable que finalizara. Inspeccione las luces y el estado del panel antes de volver a intentarlo."
     },
     "unknown_light_effect": {
       "message": "El efecto de luz solicitado no es compatible con esta luz IntelliCenter."

--- a/custom_components/intellicenter/translations/fr.json
+++ b/custom_components/intellicenter/translations/fr.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "Rappeler la couleur MagicStream",
       "description": "Rappelle la couleur enregistrée d'une lampe MagicStream."
+    },
+    "color_sync": {
+      "name": "Synchroniser les couleurs du groupe de lumières",
+      "description": "Synchronise exactement deux lumières GloBrite d'un groupe de lumières IntelliCenter complet avec le micrologiciel 1.064. L'appel attend l'action physique, une observation de 60 secondes après l'action et une lecture finale du contrôleur."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Cette commande n'est disponible que pour les lampes MagicStream."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync est disponible uniquement avec le micrologiciel IntelliCenter 1.064 pour un groupe de lumières complet comportant exactement deux lumières GloBrite distinctes."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync a échoué avant l'envoi ou IntelliCenter l'a explicitement rejeté. Aucune action n'a été confirmée."
+    },
+    "light_group_command_uncertain": {
+      "message": "L'envoi de Color Sync a commencé, mais IntelliCenter n'a renvoyé aucune réponse. L'action a peut-être été exécutée. Inspectez les lumières et l'état du panneau avant de réessayer."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter a confirmé ou démarré visiblement Color Sync, mais la fin fiable de l'opération n'a pas pu être confirmée. Inspectez les lumières et l'état du panneau avant de réessayer."
     },
     "unknown_light_effect": {
       "message": "L'effet lumineux demandé n'est pas pris en charge par cette lampe IntelliCenter."

--- a/custom_components/intellicenter/translations/it.json
+++ b/custom_components/intellicenter/translations/it.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "Richiama colore MagicStream",
       "description": "Richiama il colore salvato di una luce MagicStream."
+    },
+    "color_sync": {
+      "name": "Sincronizza i colori del gruppo luci",
+      "description": "Sincronizza esattamente due luci GloBrite di un gruppo luci IntelliCenter completo con firmware 1.064. La chiamata attende l'azione fisica, un'osservazione di 60 secondi dopo l'azione e una lettura finale del controller."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Questo comando è disponibile solo per le luci MagicStream."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync è disponibile solo con il firmware IntelliCenter 1.064 per un gruppo luci completo con esattamente due luci GloBrite distinte."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync non è riuscito prima dell'invio oppure IntelliCenter lo ha rifiutato esplicitamente. Non è stata confermata alcuna azione."
+    },
+    "light_group_command_uncertain": {
+      "message": "L'invio di Color Sync è iniziato, ma IntelliCenter non ha risposto. L'azione potrebbe essere stata eseguita. Controllare le luci e lo stato del pannello prima di riprovare."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter ha confermato o avviato visibilmente Color Sync, ma non è stato possibile confermare in modo affidabile il completamento. Controllare le luci e lo stato del pannello prima di riprovare."
     },
     "unknown_light_effect": {
       "message": "L'effetto luminoso richiesto non è supportato da questa luce IntelliCenter."

--- a/custom_components/intellicenter/translations/ja.json
+++ b/custom_components/intellicenter/translations/ja.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "MagicStream の色を呼び出し",
       "description": "MagicStream ライトに保存された色を呼び出します。"
+    },
+    "color_sync": {
+      "name": "ライトグループの色を同期",
+      "description": "ファームウェア 1.064 の IntelliCenter で、完全なライトグループ内の異なる 2 台の GloBrite ライトを同期します。この呼び出しは、実際の動作、動作後 60 秒間の監視、コントローラーの最終読み取りが完了するまで待機します。"
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "このコマンドは MagicStream ライトでのみ利用できます。"
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync は、IntelliCenter ファームウェア 1.064 で、異なる GloBrite ライトが正確に 2 台ある完全なライトグループに対してのみ使用できます。"
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync は送信前に失敗したか、IntelliCenter によって明示的に拒否されました。動作は確認されていません。"
+    },
+    "light_group_command_uncertain": {
+      "message": "Color Sync の送信は開始されましたが、IntelliCenter から応答がありませんでした。動作した可能性があります。再試行する前に、ライトとパネルの状態を確認してください。"
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter は Color Sync を確認または明らかに開始しましたが、確実な完了を確認できませんでした。再試行する前に、ライトとパネルの状態を確認してください。"
     },
     "unknown_light_effect": {
       "message": "指定されたライト効果は、この IntelliCenter ライトではサポートされていません。"

--- a/custom_components/intellicenter/translations/ko.json
+++ b/custom_components/intellicenter/translations/ko.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "MagicStream 색상 불러오기",
       "description": "MagicStream 조명에 저장된 색상을 불러옵니다."
+    },
+    "color_sync": {
+      "name": "조명 그룹 색상 동기화",
+      "description": "펌웨어 1.064를 실행하는 IntelliCenter의 완전한 조명 그룹에서 서로 다른 GloBrite 조명 두 개를 정확히 동기화합니다. 이 호출은 실제 동작, 동작 후 60초 관찰 및 최종 컨트롤러 읽기가 완료될 때까지 기다립니다."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "이 명령은 MagicStream 조명에서만 사용할 수 있습니다."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync는 IntelliCenter 펌웨어 1.064에서 서로 다른 GloBrite 조명이 정확히 두 개인 완전한 조명 그룹에만 사용할 수 있습니다."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync가 전송 전에 실패했거나 IntelliCenter가 명시적으로 거부했습니다. 확인된 동작이 없습니다."
+    },
+    "light_group_command_uncertain": {
+      "message": "Color Sync 전송이 시작되었지만 IntelliCenter가 응답하지 않았습니다. 동작이 실행되었을 수 있습니다. 다시 시도하기 전에 조명과 패널 상태를 확인하십시오."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter가 Color Sync를 확인했거나 눈에 띄게 시작했지만 신뢰할 수 있는 완료를 확인하지 못했습니다. 다시 시도하기 전에 조명과 패널 상태를 확인하십시오."
     },
     "unknown_light_effect": {
       "message": "요청한 조명 효과는 이 IntelliCenter 조명에서 지원되지 않습니다."

--- a/custom_components/intellicenter/translations/nl.json
+++ b/custom_components/intellicenter/translations/nl.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "MagicStream-kleur oproepen",
       "description": "Roept de opgeslagen kleur van een MagicStream-lamp op."
+    },
+    "color_sync": {
+      "name": "Kleuren van lichtgroep synchroniseren",
+      "description": "Synchroniseert precies twee GloBrite-lampen in een complete IntelliCenter-lichtgroep met firmware 1.064. De aanroep wacht op de fysieke actie, een observatie van 60 seconden na de actie en een laatste uitlezing van de controller."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Deze opdracht is alleen beschikbaar voor MagicStream-lampen."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync is alleen beschikbaar met IntelliCenter-firmware 1.064 voor een complete lichtgroep met precies twee verschillende GloBrite-lampen."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync is vóór verzending mislukt of IntelliCenter heeft de opdracht expliciet geweigerd. Er is geen actie bevestigd."
+    },
+    "light_group_command_uncertain": {
+      "message": "De verzending van Color Sync is gestart, maar IntelliCenter heeft niet gereageerd. De actie is mogelijk uitgevoerd. Controleer de lampen en de paneelstatus voordat u het opnieuw probeert."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter heeft Color Sync bevestigd of zichtbaar gestart, maar de betrouwbare voltooiing kon niet worden bevestigd. Controleer de lampen en de paneelstatus voordat u het opnieuw probeert."
     },
     "unknown_light_effect": {
       "message": "Het gevraagde lichteffect wordt niet ondersteund door deze IntelliCenter-lamp."

--- a/custom_components/intellicenter/translations/pt.json
+++ b/custom_components/intellicenter/translations/pt.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "Recuperar cor do MagicStream",
       "description": "Recupera a cor salva de uma luz MagicStream."
+    },
+    "color_sync": {
+      "name": "Sincronizar cores do grupo de luzes",
+      "description": "Sincroniza exatamente duas luzes GloBrite de um grupo de luzes IntelliCenter completo com o firmware 1.064. A chamada aguarda a ação física, uma observação de 60 segundos após a ação e uma leitura final do controlador."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Este comando está disponível apenas para luzes MagicStream."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync está disponível apenas com o firmware 1.064 do IntelliCenter para um grupo de luzes completo com exatamente duas luzes GloBrite distintas."
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync falhou antes do envio ou o IntelliCenter o rejeitou explicitamente. Nenhuma ação foi confirmada."
+    },
+    "light_group_command_uncertain": {
+      "message": "O envio de Color Sync foi iniciado, mas o IntelliCenter não respondeu. A ação pode ter sido executada. Inspecione as luzes e o estado do painel antes de tentar novamente."
+    },
+    "light_group_command_incomplete": {
+      "message": "O IntelliCenter confirmou ou iniciou visivelmente o Color Sync, mas não foi possível confirmar a conclusão de forma confiável. Inspecione as luzes e o estado do painel antes de tentar novamente."
     },
     "unknown_light_effect": {
       "message": "O efeito de luz solicitado não é suportado por esta luz IntelliCenter."

--- a/custom_components/intellicenter/translations/ru.json
+++ b/custom_components/intellicenter/translations/ru.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "Вызвать цвет MagicStream",
       "description": "Вызывает сохраненный цвет светильника MagicStream."
+    },
+    "color_sync": {
+      "name": "Синхронизировать цвета группы освещения",
+      "description": "Синхронизирует ровно два разных светильника GloBrite в полной группе освещения IntelliCenter с прошивкой 1.064. Вызов ожидает физическое действие, 60-секундное наблюдение после действия и окончательное чтение данных контроллера."
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "Эта команда доступна только для светильников MagicStream."
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync доступна только с прошивкой IntelliCenter 1.064 для полной группы освещения, содержащей ровно два разных светильника GloBrite."
+    },
+    "light_group_command_failed": {
+      "message": "Сбой Color Sync произошёл до отправки либо IntelliCenter явно отклонил команду. Выполнение действия не подтверждено."
+    },
+    "light_group_command_uncertain": {
+      "message": "Отправка Color Sync началась, но IntelliCenter не ответил. Возможно, действие было выполнено. Перед повторной попыткой проверьте светильники и состояние панели."
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter подтвердил или явно начал Color Sync, но достоверное завершение подтвердить не удалось. Перед повторной попыткой проверьте светильники и состояние панели."
     },
     "unknown_light_effect": {
       "message": "Запрошенный световой эффект не поддерживается этим светильником IntelliCenter."

--- a/custom_components/intellicenter/translations/zh-Hans.json
+++ b/custom_components/intellicenter/translations/zh-Hans.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "调用 MagicStream 颜色",
       "description": "调用 MagicStream 灯已保存的颜色。"
+    },
+    "color_sync": {
+      "name": "同步灯光组颜色",
+      "description": "在固件版本为 1.064 的 IntelliCenter 上，同步完整灯光组中恰好两个不同的 GloBrite 灯。此调用会等待实际操作、操作后的 60 秒观察和最终控制器读取完成。"
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "此命令仅适用于 MagicStream 灯。"
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync 仅适用于运行 IntelliCenter 固件 1.064 且包含恰好两个不同 GloBrite 灯的完整灯光组。"
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync 在发送前失败，或被 IntelliCenter 明确拒绝。未确认任何操作。"
+    },
+    "light_group_command_uncertain": {
+      "message": "Color Sync 已开始发送，但 IntelliCenter 未返回响应。操作可能已运行。重试前请检查灯光和面板状态。"
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter 已确认或明显启动 Color Sync，但未能确认操作可靠完成。重试前请检查灯光和面板状态。"
     },
     "unknown_light_effect": {
       "message": "此 IntelliCenter 灯不支持所请求的灯光效果。"

--- a/custom_components/intellicenter/translations/zh-Hant.json
+++ b/custom_components/intellicenter/translations/zh-Hant.json
@@ -126,6 +126,10 @@
     "recall": {
       "name": "叫出 MagicStream 顏色",
       "description": "叫出 MagicStream 燈已儲存的顏色。"
+    },
+    "color_sync": {
+      "name": "同步燈光群組色彩",
+      "description": "在韌體版本為 1.064 的 IntelliCenter 上，同步完整燈光群組中恰好兩個不同的 GloBrite 燈。此呼叫會等待實際動作、動作後的 60 秒觀察及最終控制器讀取完成。"
     }
   },
   "exceptions": {
@@ -143,6 +147,18 @@
     },
     "magicstream_command_unsupported": {
       "message": "此命令僅適用於 MagicStream 燈。"
+    },
+    "light_group_command_unsupported": {
+      "message": "Color Sync 僅適用於執行 IntelliCenter 韌體 1.064 且包含恰好兩個不同 GloBrite 燈的完整燈光群組。"
+    },
+    "light_group_command_failed": {
+      "message": "Color Sync 在傳送前失敗，或被 IntelliCenter 明確拒絕。未確認任何動作。"
+    },
+    "light_group_command_uncertain": {
+      "message": "Color Sync 已開始傳送，但 IntelliCenter 未回應。動作可能已執行。重試前請檢查燈光與面板狀態。"
+    },
+    "light_group_command_incomplete": {
+      "message": "IntelliCenter 已確認或明顯啟動 Color Sync，但無法確認操作可靠完成。重試前請檢查燈光與面板狀態。"
     },
     "unknown_light_effect": {
       "message": "此 IntelliCenter 燈不支援所要求的燈光效果。"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.1.21",
+    "pyintellicenter>=0.1.22",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from pyintellicenter import (
     BODY_TYPE,
     CHEM_TYPE,
+    CIRCGRP_TYPE,
     CIRCUIT_TYPE,
     HEATER_TYPE,
     PMPCIRC_TYPE,
@@ -287,6 +288,65 @@ def pool_model(pool_model_data: list[dict[str, Any]]) -> PoolModel:
 
 
 @pytest.fixture
+def complete_light_group_model() -> PoolModel:
+    """Return a real two-member GloBrite light-group topology."""
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    model.add_objects(
+        [
+            {
+                "objnam": "GROUP",
+                "params": {
+                    "OBJTYP": CIRCUIT_TYPE,
+                    "SUBTYP": "LITSHO",
+                    "SNAME": "Color Group",
+                    "STATUS": "OFF",
+                    "USE": "WHITER",
+                },
+            },
+            {
+                "objnam": "GROUP_ROW_2",
+                "params": {
+                    "OBJTYP": CIRCGRP_TYPE,
+                    "PARENT": "GROUP",
+                    "CIRCUIT": "GLOW2",
+                    "LISTORD": "2",
+                },
+            },
+            {
+                "objnam": "GROUP_ROW_1",
+                "params": {
+                    "OBJTYP": CIRCGRP_TYPE,
+                    "PARENT": "GROUP",
+                    "CIRCUIT": "GLOW1",
+                    "LISTORD": "1",
+                },
+            },
+            {
+                "objnam": "GLOW1",
+                "params": {
+                    "OBJTYP": CIRCUIT_TYPE,
+                    "SUBTYP": "GLOW",
+                    "SNAME": "GloBrite One",
+                    "STATUS": "OFF",
+                    "USE": "WHITER",
+                },
+            },
+            {
+                "objnam": "GLOW2",
+                "params": {
+                    "OBJTYP": CIRCUIT_TYPE,
+                    "SUBTYP": "GLOW",
+                    "SNAME": "GloBrite Two",
+                    "STATUS": "OFF",
+                    "USE": "WHITER",
+                },
+            },
+        ]
+    )
+    return model
+
+
+@pytest.fixture
 def pool_object_light() -> PoolObject:
     """Return a PoolObject representing an IntelliBrite light."""
     return PoolObject(
@@ -429,7 +489,23 @@ def mock_coordinator(
 
     # Configure controller with all convenience methods
     mock_controller = MagicMock()
+    real_model_controller = ICModelController("192.0.2.1", pool_model)
+
+    def get_circuit_group_members(parent_objnam: str) -> list[PoolObject]:
+        """Delegate membership lookup to the real controller and active model."""
+        real_model_controller._model = mock_coord.model
+        return real_model_controller.get_circuit_group_members(parent_objnam)
+
+    def get_circuits_in_group(group_objnam: str) -> list[PoolObject]:
+        """Delegate circuit resolution to the real controller and active model."""
+        real_model_controller._model = mock_coord.model
+        return real_model_controller.get_circuits_in_group(group_objnam)
+
     mock_controller.request_changes = AsyncMock()
+    mock_controller.get_circuit_group_members = MagicMock(
+        side_effect=get_circuit_group_members
+    )
+    mock_controller.get_circuits_in_group = MagicMock(side_effect=get_circuits_in_group)
     # Convenience methods from pyintellicenter v0.1.2
     mock_controller.set_vacation_mode = AsyncMock()
     mock_controller.set_ph_setpoint = AsyncMock()
@@ -490,6 +566,27 @@ def mock_coordinator(
     mock_coord.connected = True
 
     return mock_coord
+
+
+@pytest.fixture
+def complete_group_light(
+    complete_light_group_model: PoolModel,
+    mock_coordinator: MagicMock,
+) -> Any:
+    """Return the parent entity for the evidence-backed Color Sync topology."""
+    from custom_components.intellicenter.light import _build_entities
+
+    mock_coordinator.model = complete_light_group_model
+    system_info = MagicMock()
+    system_info.sw_version = "1.064"
+    mock_coordinator.system_info = system_info
+    return next(
+        entity
+        for entity in _build_entities(
+            mock_coordinator, list(complete_light_group_model)
+        )
+        if entity._pool_object.objnam == "GROUP"
+    )
 
 
 @pytest.fixture

--- a/tests/test_dynamic_entities.py
+++ b/tests/test_dynamic_entities.py
@@ -15,11 +15,14 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+from homeassistant.components.light.const import LightEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from pyintellicenter import (
     CHEM_TYPE,
+    CIRCGRP_TYPE,
+    CIRCUIT_TYPE,
     PMPCIRC_TYPE,
     PUMP_TYPE,
     SENSE_TYPE,
@@ -410,6 +413,105 @@ async def test_setup_pool_entities_dedups_across_calls(
     added.clear()
     state["listener"]([pool_model["CHEM1"]])
     assert added == []
+
+
+async def test_light_group_parent_refreshes_when_members_arrive_later(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A parent built first gains and loses effects without replacement."""
+    from custom_components.intellicenter.light import _build_entities
+
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    parent = model.add_object(
+        "GROUP",
+        {
+            "OBJTYP": CIRCUIT_TYPE,
+            "SUBTYP": "LITSHO",
+            "SNAME": "Color Group",
+            "STATUS": "OFF",
+            "USE": "WHITER",
+        },
+    )
+    assert parent is not None
+    mock_coordinator.model = model
+    state = _capture_listener(mock_coordinator)
+    entry = MagicMock()
+    entry.runtime_data = mock_coordinator
+    entry.async_on_unload = MagicMock()
+
+    added: list[Any] = []
+    async_setup_pool_entities(entry, added.extend, _build_entities)
+
+    assert len(added) == 1
+    parent_entity = added[0]
+    assert parent_entity._pool_object is parent
+    assert parent_entity.effect_list is None
+    assert not parent_entity.supported_features & LightEntityFeature.EFFECT
+    parent_entity.hass = hass
+    parent_entity.async_write_ha_state = MagicMock()
+
+    added.clear()
+    later_objects = (
+        (
+            "GLOW1",
+            {
+                "OBJTYP": CIRCUIT_TYPE,
+                "SUBTYP": "GLOW",
+                "SNAME": "GloBrite One",
+                "STATUS": "OFF",
+                "USE": "WHITER",
+            },
+        ),
+        (
+            "GLOW2",
+            {
+                "OBJTYP": CIRCUIT_TYPE,
+                "SUBTYP": "GLOW",
+                "SNAME": "GloBrite Two",
+                "STATUS": "OFF",
+                "USE": "WHITER",
+            },
+        ),
+        (
+            "GROUP_ROW_1",
+            {
+                "OBJTYP": CIRCGRP_TYPE,
+                "PARENT": "GROUP",
+                "CIRCUIT": "GLOW1",
+                "LISTORD": "1",
+            },
+        ),
+        (
+            "GROUP_ROW_2",
+            {
+                "OBJTYP": CIRCGRP_TYPE,
+                "PARENT": "GROUP",
+                "CIRCUIT": "GLOW2",
+                "LISTORD": "2",
+            },
+        ),
+    )
+    for objnam, params in later_objects:
+        candidate = model.add_object(objnam, params)
+        assert candidate is not None
+        state["listener"]([candidate])
+
+    assert {entity._pool_object.objnam for entity in added} == {"GLOW1", "GLOW2"}
+    assert all(entity is not parent_entity for entity in added)
+    assert parent_entity.effect_list is not None
+    assert parent_entity.supported_features & LightEntityFeature.EFFECT
+    parent_entity.async_write_ha_state.assert_called_once_with()
+
+    row = model["GROUP_ROW_2"]
+    assert row is not None
+    row.update({"CIRCUIT": "MISSING"})
+    mock_coordinator.data = {"GROUP_ROW_2": {"CIRCUIT": "MISSING"}}
+    parent_entity._handle_coordinator_update()
+
+    assert parent_entity.effect_list is None
+    assert not parent_entity.supported_features & LightEntityFeature.EFFECT
+    assert parent_entity.async_write_ha_state.call_count == 2
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/test_library_contract.py
+++ b/tests/test_library_contract.py
@@ -63,6 +63,7 @@ CONTROLLER_METHODS = (
     "is_vacation_mode",
     "refresh_pump_circuit_speed",
     "request_changes",
+    "run_light_group_sync",
     "set_alkalinity",
     "set_calcium_hardness",
     "set_chlorinator_output",
@@ -85,6 +86,7 @@ REQUIRED_SYMBOLS = (
     "ICModelController",
     "ICConnectionHandler",
     "ICConnectionError",
+    "ICLightGroupError",
     "ICTimeoutError",
     "ICSystemInfo",
     "PoolModel",
@@ -116,6 +118,34 @@ def test_controller_methods_exist_and_callable() -> None:
         f"ICModelController is missing methods the integration calls: {missing}. "
         "This is library/integration contract drift that mocked tests cannot catch."
     )
+
+
+def test_light_group_error_contract_is_available() -> None:
+    """The installed library exposes certainty metadata consumed by the service."""
+    error_type = pyintellicenter.ICLightGroupError
+    assert callable(pyintellicenter.ICModelController.run_light_group_sync)
+    assert issubclass(error_type, pyintellicenter.ICError)
+
+    error = error_type(
+        "failed",
+        phase="terminal",
+        response_received=True,
+        acknowledged=True,
+        onset_seen=True,
+    )
+    assert error.phase == "terminal"
+    assert error.dispatch_started is True
+    assert error.response_received is True
+    assert error.acknowledged is True
+    assert error.onset_seen is True
+
+
+def test_only_scoped_light_group_writer_exists() -> None:
+    """The installed controller does not expose speculative group writers."""
+    controller = pyintellicenter.ICModelController
+    assert not hasattr(controller, "run_light_group_command")
+    assert not hasattr(controller, "run_light_group_swim")
+    assert not hasattr(controller, "set_light_group_member_position")
 
 
 def test_light_effects_includes_sam_show() -> None:

--- a/tests/test_library_contract.py
+++ b/tests/test_library_contract.py
@@ -46,6 +46,8 @@ CONTROLLER_METHODS = (
     "body_supports_cooling",
     "get_chem_alerts",
     "get_chlorinator_output",
+    "get_circuit_group_members",
+    "get_circuits_in_group",
     "get_pump_circuit_speed",
     "get_saturation_index",
     "get_schedule_circuit",
@@ -140,6 +142,15 @@ def test_chemistry_and_manual_heat_attributes_are_tracked() -> None:
     assert "CHLOR" not in DEFAULT_ATTRIBUTES_MAP[pyintellicenter.CHEM_TYPE]
     assert MANHT_ATTR not in DEFAULT_ATTRIBUTES_MAP[pyintellicenter.BODY_TYPE]
     assert MANHT_ATTR in DEFAULT_ATTRIBUTES_MAP[pyintellicenter.SYSTEM_TYPE]
+
+
+def test_circuit_group_membership_rows_track_only_relationship_fields() -> None:
+    """Circuit-group rows retain only their real relationship attributes."""
+    assert DEFAULT_ATTRIBUTES_MAP[pyintellicenter.CIRCGRP_TYPE] == {
+        pyintellicenter.PARENT_ATTR,
+        pyintellicenter.CIRCUIT_ATTR,
+        pyintellicenter.LISTORD_ATTR,
+    }
 
 
 def test_roadmap_attributes_are_tracked() -> None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,6 +1,7 @@
 """Test the Pentair IntelliCenter light platform."""
 
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_EFFECT
 from homeassistant.components.light.const import ColorMode
@@ -12,10 +13,14 @@ from pyintellicenter import (
     CIRCUIT_TYPE,
     LIGHT_EFFECTS,
     STATUS_ATTR,
+    USE_ATTR,
+    ICError,
+    ICLightGroupError,
     PoolModel,
     PoolObject,
 )
 import pytest
+import yaml
 
 from custom_components.intellicenter import light as light_platform
 from custom_components.intellicenter.const import LIMIT_ATTR
@@ -23,6 +28,13 @@ from custom_components.intellicenter.coordinator import DEFAULT_ATTRIBUTES_MAP
 from custom_components.intellicenter.light import PoolLight, _build_entities
 
 pytestmark = pytest.mark.asyncio
+
+_SERVICES_YAML = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "intellicenter"
+    / "services.yaml"
+)
 
 
 def _make_light_group_model(
@@ -75,6 +87,43 @@ def _set_firmware(mock_coordinator: MagicMock, version: str | None) -> None:
     mock_coordinator.system_info = system_info
 
 
+def _group_light_for_model(
+    mock_coordinator: MagicMock,
+    model: PoolModel,
+    firmware: str | None = "1.064",
+) -> PoolLight:
+    """Return the parent entity for a supplied group topology."""
+    mock_coordinator.model = model
+    _set_firmware(mock_coordinator, firmware)
+    return next(
+        entity
+        for entity in _build_entities(mock_coordinator, list(model))
+        if entity._pool_object.objnam == "GROUP"
+    )
+
+
+def _color_sync_state(light: PoolLight) -> tuple[object, ...]:
+    """Capture every entity/model value Color Sync must leave untouched."""
+    return (
+        light.effect,
+        light.effect_list,
+        light._optimistic_state,
+        light._pool_object[STATUS_ATTR],
+        light._pool_object[USE_ATTR],
+    )
+
+
+async def _assert_color_sync_error(
+    light: PoolLight, translation_key: str
+) -> HomeAssistantError:
+    """Assert one translated Color Sync failure and return it."""
+    with pytest.raises(HomeAssistantError) as raised:
+        await light.async_color_sync()
+    assert raised.value.translation_domain == "intellicenter"
+    assert raised.value.translation_key == translation_key
+    return raised.value
+
+
 async def test_coordinator_tracks_light_limit() -> None:
     """The model must request LIMIT or brightness never reaches entities."""
     assert LIMIT_ATTR in DEFAULT_ATTRIBUTES_MAP[CIRCUIT_TYPE]
@@ -113,6 +162,7 @@ async def test_light_setup_creates_entities(
         "thumper",
         "hold",
         "recall",
+        "color_sync",
     ]
 
     # Should create entities for:
@@ -1020,3 +1070,241 @@ async def test_magicstream_service_refuses_other_light_subtypes(
 
     assert err.value.translation_key == "magicstream_command_unsupported"
     mock_coordinator.controller.request_changes.assert_not_awaited()
+
+
+async def test_color_sync_service_metadata_has_only_an_entity_target() -> None:
+    """Color Sync metadata exposes no arguments beyond the light target."""
+    services = yaml.safe_load(_SERVICES_YAML.read_text(encoding="utf-8"))
+
+    assert set(services) == {"capture", "thumper", "hold", "recall", "color_sync"}
+    assert services["color_sync"] == {
+        "target": {
+            "entity": {
+                "integration": "intellicenter",
+                "domain": "light",
+            }
+        }
+    }
+
+
+async def test_color_sync_calls_dedicated_library_helper_without_state_mutation(
+    complete_group_light: PoolLight,
+    mock_coordinator: MagicMock,
+) -> None:
+    """The service awaits only the scoped helper and invents no entity state."""
+    sync = AsyncMock(return_value={"command": "SetParamList"})
+    mock_coordinator.controller.run_light_group_sync = sync
+    before = _color_sync_state(complete_group_light)
+
+    await complete_group_light.async_color_sync()
+
+    sync.assert_awaited_once_with("GROUP")
+    mock_coordinator.controller.request_changes.assert_not_awaited()
+    assert _color_sync_state(complete_group_light) == before
+
+
+@pytest.mark.parametrize("subtype", ("LIGHT", "INTELLI", "MAGIC2", "CIRCGRP"))
+async def test_color_sync_rejects_ordinary_non_group_entities_before_library_call(
+    mock_coordinator: MagicMock,
+    subtype: str,
+) -> None:
+    """Ordinary light-like entities cannot invoke the group writer."""
+    sync = AsyncMock()
+    mock_coordinator.controller.run_light_group_sync = sync
+    _set_firmware(mock_coordinator, "1.064")
+    light = PoolLight(
+        mock_coordinator,
+        PoolObject(
+            "LIGHT",
+            {
+                "OBJTYP": CIRCUIT_TYPE,
+                "SUBTYP": subtype,
+                "SNAME": subtype,
+                "STATUS": "OFF",
+                "USE": "WHITER",
+            },
+        ),
+        LIGHT_EFFECTS,
+    )
+
+    await _assert_color_sync_error(light, "light_group_command_unsupported")
+
+    sync.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("member_refs", "child_shapes"),
+    [
+        ((), {}),
+        (("GLOW1",), {"GLOW1": (CIRCUIT_TYPE, "GLOW")}),
+        (
+            ("GLOW1", "GLOW2", "GLOW3"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "GLOW2": (CIRCUIT_TYPE, "GLOW"),
+                "GLOW3": (CIRCUIT_TYPE, "GLOW"),
+            },
+        ),
+        (("MISSING1", "MISSING2"), {}),
+        (("GLOW1", "GLOW1"), {"GLOW1": (CIRCUIT_TYPE, "GLOW")}),
+        (
+            ("GLOW1", "PLAIN"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "PLAIN": (CIRCUIT_TYPE, "LIGHT"),
+            },
+        ),
+        (
+            ("LIGHT1", "LIGHT2"),
+            {
+                "LIGHT1": (CIRCUIT_TYPE, "INTELLI"),
+                "LIGHT2": (CIRCUIT_TYPE, "INTELLI"),
+            },
+        ),
+        (
+            ("LIGHT1", "LIGHT2"),
+            {
+                "LIGHT1": (CIRCUIT_TYPE, "MAGIC2"),
+                "LIGHT2": (CIRCUIT_TYPE, "MAGIC2"),
+            },
+        ),
+        (
+            ("GLOW1", "NOT_A_CIRCUIT"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "NOT_A_CIRCUIT": (BODY_TYPE, "GLOW"),
+            },
+        ),
+    ],
+    ids=(
+        "zero",
+        "one",
+        "three",
+        "missing",
+        "duplicate",
+        "mixed",
+        "intellibrite",
+        "magicstream",
+        "non-circuit-glow",
+    ),
+)
+async def test_color_sync_rejects_unsupported_group_topologies_before_library_call(
+    mock_coordinator: MagicMock,
+    member_refs: tuple[str, ...],
+    child_shapes: dict[str, tuple[str, str]],
+) -> None:
+    """Every topology outside the evidence-backed pair is rejected locally."""
+    sync = AsyncMock()
+    mock_coordinator.controller.run_light_group_sync = sync
+    light = _group_light_for_model(
+        mock_coordinator,
+        _make_light_group_model(member_refs, child_shapes),
+    )
+
+    await _assert_color_sync_error(light, "light_group_command_unsupported")
+
+    sync.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "firmware",
+    (None, "1.063", "1.065", "IC: 1.064", "1.064 ", "1.064-build7"),
+)
+async def test_color_sync_rejects_non_exact_firmware_before_library_call(
+    complete_light_group_model: PoolModel,
+    mock_coordinator: MagicMock,
+    firmware: str | None,
+) -> None:
+    """Semantic version lookalikes never widen the service's raw token gate."""
+    sync = AsyncMock()
+    mock_coordinator.controller.run_light_group_sync = sync
+    light = _group_light_for_model(
+        mock_coordinator, complete_light_group_model, firmware
+    )
+
+    await _assert_color_sync_error(light, "light_group_command_unsupported")
+
+    sync.assert_not_awaited()
+
+
+async def test_color_sync_maps_library_value_error_to_unsupported(
+    complete_group_light: PoolLight,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A topology race caught by the library remains an unsupported outcome."""
+    sync = AsyncMock(side_effect=ValueError("topology changed"))
+    mock_coordinator.controller.run_light_group_sync = sync
+    before = _color_sync_state(complete_group_light)
+
+    await _assert_color_sync_error(
+        complete_group_light, "light_group_command_unsupported"
+    )
+
+    sync.assert_awaited_once_with("GROUP")
+    assert _color_sync_state(complete_group_light) == before
+
+
+async def test_color_sync_maps_ordinary_library_error_to_failed(
+    complete_group_light: PoolLight,
+    mock_coordinator: MagicMock,
+) -> None:
+    """An ordinary pre-dispatch library failure reports definite failure."""
+    sync = AsyncMock(side_effect=ICError("pre-dispatch failure"))
+    mock_coordinator.controller.run_light_group_sync = sync
+    before = _color_sync_state(complete_group_light)
+
+    await _assert_color_sync_error(complete_group_light, "light_group_command_failed")
+
+    sync.assert_awaited_once_with("GROUP")
+    assert _color_sync_state(complete_group_light) == before
+
+
+@pytest.mark.parametrize(
+    (
+        "response_received",
+        "acknowledged",
+        "onset_seen",
+        "translation_key",
+    ),
+    [
+        (True, False, False, "light_group_command_failed"),
+        (False, False, False, "light_group_command_uncertain"),
+        (False, True, False, "light_group_command_incomplete"),
+        (False, False, True, "light_group_command_incomplete"),
+    ],
+    ids=("explicit-rejection", "no-response", "acknowledged", "onset"),
+)
+async def test_color_sync_maps_lifecycle_certainty_with_started_precedence(
+    complete_group_light: PoolLight,
+    mock_coordinator: MagicMock,
+    response_received: bool,
+    acknowledged: bool,
+    onset_seen: bool,
+    translation_key: str,
+) -> None:
+    """Acknowledgement/onset take precedence over rejection or uncertainty."""
+    library_error = ICLightGroupError(
+        "lifecycle failed",
+        phase="acknowledgement",
+        response_received=response_received,
+        acknowledged=acknowledged,
+        onset_seen=onset_seen,
+    )
+    sync = AsyncMock(side_effect=library_error)
+    mock_coordinator.controller.run_light_group_sync = sync
+    before = _color_sync_state(complete_group_light)
+
+    raised = await _assert_color_sync_error(complete_group_light, translation_key)
+
+    sync.assert_awaited_once_with("GROUP")
+    assert raised.__cause__ is library_error
+    assert _color_sync_state(complete_group_light) == before
+
+
+async def test_only_color_sync_group_action_is_exposed() -> None:
+    """Set, Swim, and member-position actions remain outside integration scope."""
+    services = yaml.safe_load(_SERVICES_YAML.read_text(encoding="utf-8"))
+    assert {"color_set", "color_swim", "member_position"}.isdisjoint(services)
+    assert not hasattr(PoolLight, "async_color_set")
+    assert not hasattr(PoolLight, "async_color_swim")
+    assert not any("member" in name and "position" in name for name in dir(PoolLight))

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -7,6 +7,8 @@ from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from pyintellicenter import (
+    BODY_TYPE,
+    CIRCGRP_TYPE,
     CIRCUIT_TYPE,
     LIGHT_EFFECTS,
     STATUS_ATTR,
@@ -15,11 +17,62 @@ from pyintellicenter import (
 )
 import pytest
 
+from custom_components.intellicenter import light as light_platform
 from custom_components.intellicenter.const import LIMIT_ATTR
 from custom_components.intellicenter.coordinator import DEFAULT_ATTRIBUTES_MAP
-from custom_components.intellicenter.light import PoolLight
+from custom_components.intellicenter.light import PoolLight, _build_entities
 
 pytestmark = pytest.mark.asyncio
+
+
+def _make_light_group_model(
+    member_refs: tuple[str, ...],
+    child_shapes: dict[str, tuple[str, str]],
+) -> PoolModel:
+    """Build one light-show parent with real membership rows and children."""
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    model.add_object(
+        "GROUP",
+        {
+            "OBJTYP": CIRCUIT_TYPE,
+            "SUBTYP": "LITSHO",
+            "SNAME": "Color Group",
+            "STATUS": "OFF",
+            "USE": "WHITER",
+        },
+    )
+    for index, circuit_ref in enumerate(member_refs, start=1):
+        model.add_object(
+            f"GROUP_ROW_{index}",
+            {
+                "OBJTYP": CIRCGRP_TYPE,
+                "PARENT": "GROUP",
+                "CIRCUIT": circuit_ref,
+                "LISTORD": str(index),
+            },
+        )
+    for objnam, (objtype, subtype) in child_shapes.items():
+        model.add_object(
+            objnam,
+            {
+                "OBJTYP": objtype,
+                "SUBTYP": subtype,
+                "SNAME": objnam,
+                "STATUS": "OFF",
+                "USE": "WHITER",
+            },
+        )
+    return model
+
+
+def _set_firmware(mock_coordinator: MagicMock, version: str | None) -> None:
+    """Set the cached raw firmware token used by the local action gate."""
+    if version is None:
+        mock_coordinator.system_info = None
+        return
+    system_info = MagicMock()
+    system_info.sw_version = version
+    mock_coordinator.system_info = system_info
 
 
 async def test_coordinator_tracks_light_limit() -> None:
@@ -288,6 +341,238 @@ async def test_light_show_entity(
 
     assert light_show.name == "Party Show"
     assert light_show.is_on is False
+
+
+async def test_complete_light_group_builds_parent_and_children_without_rows(
+    complete_light_group_model: PoolModel,
+    mock_coordinator: MagicMock,
+) -> None:
+    """A complete real topology creates one parent plus ordinary child lights."""
+    mock_coordinator.model = complete_light_group_model
+
+    entities = _build_entities(mock_coordinator, list(complete_light_group_model))
+    objnams = [entity._pool_object.objnam for entity in entities]
+
+    assert objnams.count("GROUP") == 1
+    assert {"GLOW1", "GLOW2"} <= set(objnams)
+    assert {"GROUP_ROW_1", "GROUP_ROW_2"}.isdisjoint(objnams)
+
+    parent = complete_light_group_model["GROUP"]
+    assert parent is not None
+    children = light_platform._complete_light_group_children(mock_coordinator, parent)
+    assert children is not None
+    assert [child.objnam for child in children] == ["GLOW1", "GLOW2"]
+
+    group_entity = next(
+        entity for entity in entities if entity._pool_object.objnam == "GROUP"
+    )
+    assert group_entity.effect_list is not None
+
+
+@pytest.mark.parametrize(
+    (
+        "member_refs",
+        "child_shapes",
+        "expected_complete",
+        "expected_effects",
+    ),
+    [
+        ((), {}, False, False),
+        (("GLOW1",), {"GLOW1": (CIRCUIT_TYPE, "GLOW")}, True, True),
+        (
+            ("GLOW1", "GLOW2", "GLOW3"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "GLOW2": (CIRCUIT_TYPE, "GLOW"),
+                "GLOW3": (CIRCUIT_TYPE, "GLOW"),
+            },
+            True,
+            True,
+        ),
+        (("MISSING",), {}, False, False),
+        (("GLOW1", "GLOW1"), {"GLOW1": (CIRCUIT_TYPE, "GLOW")}, False, False),
+        (
+            ("GLOW1", "PLAIN"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "PLAIN": (CIRCUIT_TYPE, "LIGHT"),
+            },
+            True,
+            False,
+        ),
+    ],
+    ids=("zero", "one", "three", "missing", "duplicate", "mixed"),
+)
+async def test_light_group_requires_complete_non_vacuous_membership(
+    mock_coordinator: MagicMock,
+    member_refs: tuple[str, ...],
+    child_shapes: dict[str, tuple[str, str]],
+    expected_complete: bool,
+    expected_effects: bool,
+) -> None:
+    """Incomplete groups retain their parent but never gain effects vacuously."""
+    model = _make_light_group_model(member_refs, child_shapes)
+    mock_coordinator.model = model
+    parent = model["GROUP"]
+    assert parent is not None
+
+    children = light_platform._complete_light_group_children(mock_coordinator, parent)
+    assert (children is not None) is expected_complete
+    assert (
+        light_platform._is_complete_color_light_group(mock_coordinator, parent)
+        is expected_effects
+    )
+
+    entities = _build_entities(mock_coordinator, list(model))
+    group_entities = [
+        entity for entity in entities if entity._pool_object.objnam == "GROUP"
+    ]
+    assert len(group_entities) == 1
+    assert (group_entities[0].effect_list is not None) is expected_effects
+    assert all(entity._pool_object.objtype != CIRCGRP_TYPE for entity in entities)
+
+
+async def test_legacy_standalone_group_row_never_creates_an_entity(
+    mock_coordinator: MagicMock,
+) -> None:
+    """A compatibility-only standalone row resolves children but is not a light."""
+    model = PoolModel(DEFAULT_ATTRIBUTES_MAP)
+    for objnam in ("GLOW1", "GLOW2"):
+        model.add_object(
+            objnam,
+            {
+                "OBJTYP": CIRCUIT_TYPE,
+                "SUBTYP": "GLOW",
+                "SNAME": objnam,
+                "STATUS": "OFF",
+            },
+        )
+    model.add_object(
+        "LEGACY_ROW",
+        {
+            "OBJTYP": CIRCGRP_TYPE,
+            "CIRCUIT": "GLOW1 GLOW2",
+        },
+    )
+    mock_coordinator.model = model
+
+    assert [
+        circuit.objnam
+        for circuit in mock_coordinator.controller.get_circuits_in_group("LEGACY_ROW")
+    ] == ["GLOW1", "GLOW2"]
+    assert {
+        entity._pool_object.objnam
+        for entity in _build_entities(mock_coordinator, list(model))
+    } == {"GLOW1", "GLOW2"}
+
+
+@pytest.mark.parametrize("subtype", ("INTELLI", "MAGIC2"))
+async def test_complete_non_glow_color_group_keeps_effects_but_rejects_sync(
+    mock_coordinator: MagicMock,
+    subtype: str,
+) -> None:
+    """Broad read/display effects do not widen the evidence-scoped action gate."""
+    model = _make_light_group_model(
+        ("LIGHT1", "LIGHT2"),
+        {
+            "LIGHT1": (CIRCUIT_TYPE, subtype),
+            "LIGHT2": (CIRCUIT_TYPE, subtype),
+        },
+    )
+    mock_coordinator.model = model
+    _set_firmware(mock_coordinator, "1.064")
+    parent = model["GROUP"]
+    assert parent is not None
+
+    assert light_platform._is_complete_color_light_group(mock_coordinator, parent)
+    assert not light_platform._is_color_sync_eligible(mock_coordinator, parent)
+
+
+@pytest.mark.parametrize(
+    "version",
+    (None, "1.063", "1.065", "IC: 1.064", "1.064 ", "1.064-build7"),
+)
+async def test_color_sync_group_rejects_non_exact_raw_firmware(
+    complete_light_group_model: PoolModel,
+    mock_coordinator: MagicMock,
+    version: str | None,
+) -> None:
+    """Only the captured raw firmware token is eligible for the writer."""
+    mock_coordinator.model = complete_light_group_model
+    _set_firmware(mock_coordinator, version)
+    parent = complete_light_group_model["GROUP"]
+    assert parent is not None
+
+    assert not light_platform._is_color_sync_eligible(mock_coordinator, parent)
+
+
+async def test_color_sync_group_accepts_exact_raw_firmware_and_two_glow_children(
+    complete_light_group_model: PoolModel,
+    mock_coordinator: MagicMock,
+) -> None:
+    """The local action gate matches the only evidence-backed topology."""
+    mock_coordinator.model = complete_light_group_model
+    _set_firmware(mock_coordinator, "1.064")
+    parent = complete_light_group_model["GROUP"]
+    assert parent is not None
+
+    assert light_platform._is_color_sync_eligible(mock_coordinator, parent)
+
+
+@pytest.mark.parametrize("member_count", (0, 1, 3))
+async def test_color_sync_group_rejects_wrong_member_count(
+    mock_coordinator: MagicMock,
+    member_count: int,
+) -> None:
+    """Color Sync requires exactly two distinct resolved members."""
+    objnams = tuple(f"GLOW{index}" for index in range(member_count))
+    model = _make_light_group_model(
+        objnams,
+        dict.fromkeys(objnams, (CIRCUIT_TYPE, "GLOW")),
+    )
+    mock_coordinator.model = model
+    _set_firmware(mock_coordinator, "1.064")
+    parent = model["GROUP"]
+    assert parent is not None
+
+    assert not light_platform._is_color_sync_eligible(mock_coordinator, parent)
+
+
+@pytest.mark.parametrize(
+    ("member_refs", "child_shapes"),
+    [
+        (("MISSING1", "MISSING2"), {}),
+        (("GLOW1", "GLOW1"), {"GLOW1": (CIRCUIT_TYPE, "GLOW")}),
+        (
+            ("GLOW1", "PLAIN"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "PLAIN": (CIRCUIT_TYPE, "LIGHT"),
+            },
+        ),
+        (
+            ("GLOW1", "NOT_A_CIRCUIT"),
+            {
+                "GLOW1": (CIRCUIT_TYPE, "GLOW"),
+                "NOT_A_CIRCUIT": (BODY_TYPE, "GLOW"),
+            },
+        ),
+    ],
+    ids=("missing", "duplicate", "mixed", "non-circuit-glow"),
+)
+async def test_color_sync_group_rejects_malformed_or_unsupported_children(
+    mock_coordinator: MagicMock,
+    member_refs: tuple[str, ...],
+    child_shapes: dict[str, tuple[str, str]],
+) -> None:
+    """Missing, duplicate, mixed, and fake GLOW children are never eligible."""
+    model = _make_light_group_model(member_refs, child_shapes)
+    mock_coordinator.model = model
+    _set_firmware(mock_coordinator, "1.064")
+    parent = model["GROUP"]
+    assert parent is not None
+
+    assert not light_platform._is_color_sync_eligible(mock_coordinator, parent)
 
 
 async def test_light_is_not_updated_by_other_objects(

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.1.21" },
+    { name = "pyintellicenter", specifier = ">=0.1.22" },
 ]
 
 [package.metadata.requires-dev]
@@ -1756,16 +1756,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.21"
+version = "0.1.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/b9/cd03ebbab62a27a77c7309b9c94fe4deceec2dcb24b7a3f3cf7ef119568a/pyintellicenter-0.1.21.tar.gz", hash = "sha256:591c6fc845acbae4a33ac1bb5546e1ba18b694b016fdc028d55063ed28492c85", size = 53766, upload-time = "2026-07-12T19:21:51.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/26/bc4045ae41d2c383086d557b4a9636b9b6131197ec2c31cb2e031332f032/pyintellicenter-0.1.22.tar.gz", hash = "sha256:0a9c32f37805d5de1a85240c68a708f11de2c0f559c0f229b6c88a3bb371d5b0", size = 66257, upload-time = "2026-07-16T00:59:43.718Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0a/ede6822128ffd55d300c8217dd39580e1a8b0fd3848371a142dc634f9228/pyintellicenter-0.1.21-py3-none-any.whl", hash = "sha256:0dead9f6d2d973f44d8ed0d20c4930fc669b4b46ec3f9bc9ebdcc0dfc823a129", size = 67595, upload-time = "2026-07-12T19:21:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/69/79/496c2c11ae9214effddcb7e91ec2984180b70b7c3c9871bc261a3d1f0018/pyintellicenter-0.1.22-py3-none-any.whl", hash = "sha256:eb9d7871d2be9c01954fd331feb2ea4a78bb9c8cc65ddc37e39e6bb1309374af", size = 80913, upload-time = "2026-07-16T00:59:42.417Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Integration side of issue #93 — consumes the new **pyintellicenter 0.1.22** light-group model and exposes the fail-closed **Color Sync** action to Home Assistant. **Merge target only — no release** (version stays `3.10.0b2`, CHANGELOG under `[Unreleased]`).

- Bump pin `pyintellicenter>=0.1.21` → `>=0.1.22` (manifest.json, pyproject.toml, uv.lock — lock carries the real published 0.1.22 hashes).
- Consume real `CIRCUIT` light-group parents + `CIRCGRP` membership rows; stop deriving duplicate entities from membership rows.
- New `intellicenter.color_sync` entity service for complete two-`GLOW` groups on firmware `1.064`.
- Map the library's `ICLightGroupError` certainty API to user-facing errors (unsupported / uncertain / incomplete / failed); full i18n across 12 locales.
- Refresh cross-object group capability in place (`async_refresh_model_context`) as membership/children arrive.

## Test plan
- `uv sync --frozen` resolves **pyintellicenter 0.1.22** from PyPI
- `ruff` clean · `mypy` clean (15 files) · **547 tests pass**

## Related
- Library: joyfulhouse/pyintellicenter#48 (released as **v0.1.22**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)