### PR TITLE
docs: preserve issues #92/#93 discovery evidence and designs

### DIFF
--- a/docs/superpowers/evidence/2026-07-14-light-group-protocol.md
+++ b/docs/superpowers/evidence/2026-07-14-light-group-protocol.md
@@ -1,0 +1,241 @@
+# Evidence: Light Group Protocol Discovery (Issue #93)
+
+**Date:** 2026-07-14 to 2026-07-15
+**Firmware:** `1.064`
+**Scope:** Color Sync, Color Set, Color Swim, and light-group member positioning
+
+This record contains only sanitized protocol facts. It deliberately excludes
+network endpoints, object and equipment identifiers, friendly names, browser
+headers and cookies, message identifiers, credentials, and raw frames.
+
+## Baseline and Target Topology
+
+Independent passive reads over TCP and WebSocket produced the same baseline:
+
+- the controller was in `SERVICE=AUTO`;
+- exactly one complete `CIRCUIT/SUBTYP=LITSHO` parent qualified for discovery;
+- two `CIRCGRP` membership rows referenced that parent;
+- both rows resolved to distinct `CIRCUIT/SUBTYP=GLOW` children; and
+- the parent, rows, and children were identical across transports.
+
+The non-empty, fully resolved membership remained mandatory throughout
+discovery. No result establishes that the `LITSHO` subtype alone is a safe
+capability predicate.
+
+## Official Web App Actions
+
+The deployed official client asset inspected during discovery was
+`bundle.web.js` with SHA-256
+`933e2fc35fd5e5fe26477f0199873bedaf4c266d510f6e8259e3684da18317fd`.
+Each accepted official run used the exact mixed-case command
+`SetParamList`, contained one parent object, and supplied only the dedicated
+action parameter shown below. Neither `ACT` nor `STATUS` appeared in an action
+request.
+
+| Action | Accepted runs | Parent params | Response |
+| --- | --- | --- | --- |
+| Sync | 3 and 4 | `{"SYNC": "ON"}` | correlated `200` |
+| Set | 2 and 3 | `{"SET": "ON"}` | correlated `200` |
+| Swim | 1 and 2 | `{"SWIM": "ON"}` | correlated `200` |
+
+All six accepted runs produced the same semantic lifecycle, although the
+leading notification order and even the action-active attribute depended on
+the receiving client:
+
+1. the official browser connection reported parent `SWIM=ON`, while the
+   simultaneous local observer reported parent `SYNC=ON`;
+2. the parent and both referenced children reported `STATUS=ON`; and
+3. the official browser later reported parent `SWIM=OFF`, while the local
+   observer later reported parent `SYNC=OFF`.
+
+The field-name difference was repeatable for every accepted Sync, Set, and
+Swim run. Completion therefore cannot depend on a universal action-active key
+or a fixed leading order. A production contract must establish the sender-side
+field for its own subscription path, observe its post-command `ON` edge, and
+later observe the matching `OFF` edge. A `200` response or an initial action
+echo alone is not completion.
+
+Fresh reads after each accepted action found only three persistent changes:
+the parent and its two children changed from `STATUS=OFF` to `STATUS=ON`.
+Membership rows and all other inventory remained unchanged. Each accepted run
+was restored through the official UI and checked twice against its starting
+snapshot. Measured browser action-active durations were 36.199 and 36.370
+seconds for Sync, 102.975 and 103.112 seconds for Set, and 75.719 and 75.413
+seconds for Swim. The official observer window was 180 seconds. These two
+runs per action establish firmware-specific observations, not a general
+lighting-program duration.
+
+Official Sync runs 1 and 2 and Set run 1 were excluded because an unrelated
+generic circuit changed during their observation windows. Those runs cannot
+prove the collateral-change invariant and contributed no protocol conclusion.
+The later accepted runs started from a restored baseline and repeated the
+official contract twice per action.
+
+## Member-Position Gate
+
+The exact official client bundle exposed no member-position writer:
+
+- light-group position chips were hidden;
+- membership-row `USE` was neither read nor written by the UI; and
+- no membership-row `ACT` or `LISTORD` write existed.
+
+Consequently there was no official operation from which to establish a safe
+writable field, a durable readable field, or a finite option table. No direct
+protocol write was guessed. Member-position replay was not performed, and the
+member-position helper and Home Assistant selects are omitted.
+
+## Local Replay Results
+
+Each initial replay began with the parent and both children `STATUS=OFF`, sent
+the same mixed-case command and one-object parameter payload once over a local
+transport, and used a 60-second experimental gate. Message identifiers and the
+cloud/local transport envelope necessarily differed, so this was semantic
+replay rather than byte-for-byte browser replay. A timed-out state-changing
+request was not retried. The accepted official Swim timings later proved that
+60 seconds was not a safe universal production bound.
+
+| Action | TCP | WebSocket | Decision after initial replay |
+| --- | --- | --- | --- |
+| Sync | correlated `200`; five target pushes completed the local-observer lifecycle | correlated `200`; the same five-push lifecycle completed | advance on both transports |
+| Set | correlated `200`; four leading target pushes, no terminal local `SYNC=OFF`, then persisted cross-group action flags | correlated `200`; the same four-push failure and persisted action flags | omit on both transports |
+| Swim | correlated `200`; four leading target pushes; a 60-second fresh read found all action flags `OFF` and all three target statuses `ON` | correlated `200`; four leading target pushes, then timeout with action flags stuck `ON` | advance TCP to a longer same-connection run; omit WebSocket |
+
+Each successful Sync observer sequence contained parent `STATUS=ON` and
+`SYNC=ON` in either leading order, both child `STATUS=ON` updates, and later
+parent `SYNC=OFF`. Each failed Set and WebSocket Swim sequence contained the
+same four leading updates but no terminal `SYNC=OFF`. TCP Swim also contained
+those four leading updates; its 60-second fresh read appeared to establish only
+the missing terminal state. The later 180-second run below disproved that
+provisional final-state conclusion. A read cannot substitute for a missing
+positive post-command onset.
+
+The Set failure left `SYNC`, `SET`, and `SWIM` persisted as `ON` on the target
+and on another group with `SUBTYP=CIRCGRP`. The WebSocket Swim failure left the
+same action flags stuck `ON`. The official UI completed Set cleanly, so this
+does not prove that the official Set action is intrinsically unsafe. It proves
+that the reproduced local request path is not safe or sufficiently understood
+for production.
+
+## Same-Connection Sender-Side Results
+
+A production-shaped harness subscribed and sent on the same connection, armed
+its observer before the single write, retained notifications that preceded the
+acknowledgement, observed for 180 seconds, and then performed fresh full
+inventory reads. It repeated the complete service, topology, action-flag, and
+target-prestate preflight immediately after subscription settling.
+
+| Action | Transport / prestate | Ack | Sender-side lifecycle | Fresh final state | Decision |
+| --- | --- | --- | --- | --- | --- |
+| Sync | TCP / all off | `200` at 0.002145 s | `SYNC=ON` at 0.219557 s; parent and children `STATUS=ON` at 1.255901–1.258996 s; `SYNC=OFF` at 35.286805 s | only the parent and two children changed to `STATUS=ON` | pass |
+| Sync | TCP / all on | `200` at 0.002399 s | `SYNC=ON` at 0.275896 s; `SYNC=OFF` at 36.238773 s; no status edge was required or emitted | full inventory equaled the all-on baseline | pass |
+| Sync | WebSocket / all off | `200` at 0.004273 s | `SYNC=ON` at 0.852700 s; parent and children `STATUS=ON` at 0.852716–0.852729 s; `SYNC=OFF` at 35.852674 s | only the parent and two children changed to `STATUS=ON` | pass |
+| Sync | WebSocket / all on | `200` at 0.010514 s | `SYNC=ON` at 0.765173 s; `SYNC=OFF` at 35.773954 s; no status edge was required or emitted | full inventory equaled the all-on baseline | pass |
+| Swim | TCP / all off | `200` at 0.008995 s | `SYNC=ON` at 0.593273 s; all target statuses `ON` at 0.602877–0.602899 s; `SYNC=OFF` at 74.567605 s; both children reverted to `STATUS=OFF` at 83.613525–83.614324 s | parent `STATUS=ON`, both children `STATUS=OFF` | fail and omit |
+
+The local sender-side active field was `SYNC` for both transports and both
+commands; the browser connection's different `SWIM` field therefore cannot be
+used by the library waiter. No run produced a collateral-group action-flag
+edge. Each passing Sync run had either exactly the expected three target
+status deltas from an all-off baseline or no persistent delta from an all-on
+baseline.
+
+The TCP Swim result is decisive. Its terminal `SYNC=OFF` edge was followed
+about nine seconds later by a mixed target state, so neither the terminal edge
+nor the earlier 60-second clean read represented a stable supported outcome.
+Swim was removed from the candidate matrix and no Swim-from-on write was
+performed. This limits further state-changing discovery after a supported
+contract had already failed.
+
+Between the first sender-side Sync series and its official restore, one
+unrelated generic circuit changed compared with the day-start snapshot. The
+settled baseline/final inventory stored inside each action run proves that the
+change did not occur during those action windows. Discovery nevertheless
+paused, restored the target by role, and established a new quiet gate: TCP and
+WebSocket snapshots at both ends of a 120-second interval were all identical
+and contained no pushes. The subsequent WebSocket Sync and TCP Swim runs used
+that baseline and retained their own per-run collateral comparisons.
+
+## Production Contract Result
+
+The same-connection gate passed only for Sync over TCP and WebSocket. The
+implementation contract is:
+
+- serialize the exact mixed-case `SetParamList` request with one fully
+  validated parent object and the dedicated `{"SYNC": "ON"}` parameter;
+- require a correlated `response == "200"`;
+- require firmware `1.064`, `SERVICE=AUTO`, exactly two distinct resolved
+  `GLOW` children, every relevant group action flag `OFF`, and a uniform
+  all-off or all-on target prestate;
+- establish scoped subscriptions, wait one second for initialization to settle,
+  then repeat the entire fresh preflight and require its projection to match the
+  first before the write;
+- assign enqueue-time notification sequence numbers, start the absolute
+  deadline immediately before transport initiation, and capture the causal
+  onset watermark immediately after synchronous TCP write returns or awaited
+  WebSocket send completes; retain pre-response notifications but never count
+  a frame processed during WebSocket send suspension as onset;
+- require a positive post-command/post-send-watermark `SYNC=ON` edge and start
+  the absolute completion deadline at the pre-send dispatch boundary;
+- require the later `SYNC=OFF` edge within a Sync-specific 60-second bound;
+- enforce the captured transition invariants from dispatch start onward: an all-on
+  target never leaves `ON`; an all-off target never returns to `OFF` after each
+  object reaches `ON`; normalized optional target `USE`, required `SET` and
+  `SWIM`, every unrelated circuit `STATUS`/normalized optional `USE`, group
+  topology, and system mode never deviate from baseline;
+- continue observing through a 60-second post-terminal quiet interval, then
+  perform one in-band fresh read that requires the target parent and children
+  `STATUS=ON`, all group flags `OFF`, every unrelated circuit
+  `STATUS`/normalized optional `USE` unchanged, the circuit
+  identity/type/subtype/normalized optional parent projection unchanged, and
+  all membership topology/normalized optional `USE` and system mode unchanged;
+- keep action flags as internal momentary monitoring data, separate from
+  persistent Home Assistant effects or entity state; and
+- reject Set and Swim, other firmware, other member counts/subtypes, mixed
+  target prestates, incomplete topology, and unsupported action tokens before
+  state-changing network I/O.
+
+The 60-second value is Sync-specific, not the disproved universal experimental
+gate: all six accepted official/sender-side Sync terminal observations were at
+or below 36.370 seconds. The 60-second post-terminal interval is also within
+the more than 143 seconds of clean post-terminal observation in every
+same-connection Sync run. It is intentionally much longer than the single
+9.045920-second late Swim failure. A missing onset or terminal edge is never
+replaced by a fresh read.
+
+The exact official request disproves the proposed
+`{"ACT": token, "STATUS": "ON"}` shape. Production code must not serialize
+that proposal.
+
+## Restoration and Final Invariants
+
+Every failed replay state was restored through a freshly reloaded official UI
+using the exact parent `{"STATUS": "OFF"}` operation. Each restore capture
+contained exactly one mixed-case `SetParamList` write, one parent object, and a
+correlated `200`. Earlier final reads matched the day-start baseline exactly.
+After the unrelated between-run circuit transition described above, both the
+WebSocket Sync restore and the mixed TCP Swim restore matched the new quiet
+baseline exactly over independent TCP and WebSocket reads. The controller
+remained in `SERVICE=AUTO`, membership did not change, every action flag was
+`OFF`, and the parent and both children were `STATUS=OFF`.
+
+## Staged Scope and Limitations
+
+The production candidate is Sync on TCP and WebSocket only. It includes no Set
+or Swim action and no member-position selects.
+
+These conclusions are intentionally narrow:
+
+- they were established on firmware `1.064` and one complete two-member
+  `LITSHO`/`GLOW` topology;
+- Sync passed from both uniform all-off and uniform all-on prestates on each
+  supported transport; mixed prestates remain unproven and must be rejected;
+- TCP Swim was tested only from all-off and failed its stable final-state gate;
+  no Swim prestate is supported;
+- `INTELLI`, `MAGIC2`, other member counts, and other firmware may still be
+  modeled by read helpers but are not eligible for this initial Sync writer;
+- official captures establish command semantics and firmware-specific
+  timings, not a general lighting-program duration;
+- a fresh read may verify Sync only after both sender-side edges and the
+  60-second post-terminal interval; it cannot replace a missing lifecycle
+  edge; and
+- an acknowledgement is never treated as proof of completion or safety.

--- a/docs/superpowers/plans/2026-07-14-light-group-protocol-discovery.md
+++ b/docs/superpowers/plans/2026-07-14-light-group-protocol-discovery.md
@@ -1,0 +1,503 @@
+# Light Group Protocol Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture and verify the exact IntelliCenter contracts for Color Sync, Color Set, Color Swim, and per-member light-group positioning before implementing issue #93.
+
+**Architecture:** Use a purpose-built raw `ICConnection` observer to preserve parent `CIRCUIT`, membership-row `CIRCGRP`, and referenced-child state without the library's current incorrect grouping helpers. Capture each official Web App request and response, prove completion and restoration with fresh reads, then replay only the captured request independently over TCP and WebSocket. Amend the approved design with exact facts and stop before production group-model or Home Assistant changes.
+
+**Tech Stack:** Python 3.13+, `pyintellicenter` raw `ICConnection`, asyncio, pytest, Chrome DevTools Protocol, IntelliCenter TCP 6681/WebSocket 6680, Markdown evidence.
+
+## Global Constraints
+
+- This is protocol discovery only. Do not correct `_mixins/circuit_group.py`, add public group helpers, change coordinator tracking, register Home Assistant services, or create selects in this plan.
+- Use external worktrees based on fetched commits: pyintellicenter `9ee8d55694c14713f39886866f21f68902b8ca7d`; evidence/spec work stays on integration branch `docs/issues-92-93-plans` descended from `0886531f27d338191d8ab1642b6480ded4a4f553`.
+- Never run `git worktree prune`, `git clean`, `git stash`, a reset command, or modify either primary checkout.
+- Require `INTELLICENTER_HOST`; never use a fallback host and never print endpoint, property name, object identifiers, group/member/equipment names, location/contact fields, PINs, credentials, or raw browser trace.
+- Keep captures outside Git in a mode-`0700` temporary directory with mode-`0600` files. Only sanitized, stable aliases enter repository evidence.
+- Use raw `ICConnection`, not `ICModelController`, `get_all_objects()`, the current grouping helpers, integration diagnostics, or existing live scripts. Current helpers misclassify membership rows and `get_all_objects()` prunes unsupported echoes.
+- Install notification callbacks before connecting. Use one observer at a time, `keepalive_interval=3600`, `notification_queue_size=1000`, and subscription batches below 50 aggregate attributes.
+- Select only a parent `CIRCUIT/SUBTYP=LITSHO` with non-empty membership where every `CIRCGRP.PARENT` row resolves, every singular `CIRCGRP.CIRCUIT` child resolves, and every child is a supported color light. Empty, mixed, missing, or unresolved membership aborts all write discovery.
+- The upstream `{ACT: SYNC|SET|SWIM, STATUS: ON}` shape is only a lead and remains explicitly unverified. Do not send it unless the official capture proves it exactly.
+- All initial actions and member-position changes occur through the official Web App. Replay only an exact captured local request; never translate a cloud request into a guessed local command.
+- The two issue tracks may build and test read-only tooling in parallel, but no #93 state-changing live phase may overlap a #92 live phase.
+- A passing action requires a correlated `response == "200"`, a repeatable authoritative completion signal within a bounded window, no unrelated equipment change, and successful restoration. A response, optimistic state, command echo, or physical observation alone is insufficient.
+- A passing member-position write requires a stable fresh read from a newly connected observer. A command echo is not state. Every option exposed later must have a captured protocol token.
+- Test TCP and WebSocket independently. If their contracts differ, record transport-specific support; future production code must gate by the active transport.
+- Abort on service/timeout mode, freeze protection, automation/schedule interference, unrelated actuator change, membership mutation, queue overflow, rejected/malformed response, connection loss, or inability to restore promptly.
+- Preserve existing ordinary parent on/off behavior and existing verified standard light effects. Sync/Set/Swim remain momentary actions, never invented persistent effects.
+- Group actions and member positioning are independently gated. Failure of member positioning does not block proven actions; no action or select implementation plan is written until amended evidence is reviewed.
+
+---
+
+### Task 1: Create the isolated discovery workspace
+
+**Files:**
+- No repository files changed.
+
+**Interfaces:**
+- Consumes: clean pyintellicenter base `9ee8d55694c14713f39886866f21f68902b8ca7d`.
+- Produces: external worktree `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-discovery-issue-93` on branch `discovery/issue-93-light-group-protocol` with a green baseline.
+
+- [ ] **Step 1: Confirm the target is unused**
+
+Run:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter \
+  branch --list discovery/issue-93-light-group-protocol
+test ! -e /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-discovery-issue-93
+```
+
+Expected: no branch output and `test` exits 0. Choose a new issue-specific branch/path rather than deleting unknown state if either is occupied.
+
+- [ ] **Step 2: Create the external worktree**
+
+Run:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter worktree add \
+  /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-discovery-issue-93 \
+  -b discovery/issue-93-light-group-protocol \
+  9ee8d55694c14713f39886866f21f68902b8ca7d
+```
+
+Expected: worktree created at the requested base.
+
+- [ ] **Step 3: Sync and verify the baseline**
+
+Run from the new worktree:
+
+```bash
+uv sync --frozen --extra dev
+uv run pytest -q
+```
+
+Expected: dependencies resolve without lock drift and all tests pass. Stop and report on failure.
+
+---
+
+### Task 2: Build a narrow topology-aware group observer
+
+**Files:**
+- Create: `scripts/capture_light_group_protocol.py`
+- Create: `tests/test_capture_light_group_protocol.py`
+
+**Interfaces:**
+- Consumes: raw `ICConnection` request/notification APIs and `COLOR_EFFECT_SUBTYPES`.
+- Produces:
+  - `sanitize_frame(frame: dict[str, Any], aliases: dict[str, str]) -> dict[str, Any]`
+  - `build_complete_light_groups(entries: list[dict[str, Any]]) -> list[LightGroupTarget]`
+  - `validate_capture_path(path: Path, repo_root: Path) -> None`
+  - `capture_phase(*, transport: Literal["tcp", "websocket"], label: str, seconds: int, output: Path) -> None`
+  - CLI: `python scripts/capture_light_group_protocol.py --transport {tcp,websocket} --label LABEL --seconds N --output ABSOLUTE_PATH`
+
+`LightGroupTarget` is a frozen dataclass with `parent_objnam: str`, `member_objnams: tuple[str, ...]`, and `child_objnams: tuple[str, ...]`. Members are ordered by numeric `LISTORD`, with malformed/missing values last in stable inventory order. This records the historical discovery observer only: all captured target rows had valid unique numeric orders, so the fallback was never evidence-bearing. The reviewed production model later adopts `objnam` as a total deterministic tiebreaker for duplicate/negative/malformed orders.
+
+- [ ] **Step 1: Write failing sanitizer and topology tests**
+
+Add these exact behavior tests, using helper entry factories where repetition would obscure assertions:
+
+```python
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.capture_light_group_protocol import (
+    LightGroupTarget,
+    build_complete_light_groups,
+    sanitize_frame,
+)
+
+
+def entry(objnam: str, **params: Any) -> dict[str, Any]:
+    return {"objnam": objnam, "params": params}
+
+
+def test_sanitize_frame_preserves_group_tokens_but_removes_private_data() -> None:
+    frame = {
+        "messageID": "9",
+        "response": "200",
+        "objectList": [{
+            "objnam": "GRP02",
+            "params": {
+                "OBJTYP": "CIRCUIT",
+                "SUBTYP": "LITSHO",
+                "SNAME": "private-group-name",
+                "ACT": "SYNC",
+                "STATUS": "ON",
+            },
+        }],
+    }
+
+    assert sanitize_frame(frame, {}) == {
+        "response": "200",
+        "objectList": [{
+            "objnam": "OBJECT_001",
+            "params": {
+                "OBJTYP": "CIRCUIT",
+                "SUBTYP": "LITSHO",
+                "ACT": "SYNC",
+                "STATUS": "ON",
+            },
+        }],
+    }
+
+
+def test_complete_group_orders_rows_and_resolves_every_child() -> None:
+    entries = [
+        entry("GRP02", OBJTYP="CIRCUIT", SUBTYP="LITSHO"),
+        entry("ROW02", OBJTYP="CIRCGRP", PARENT="GRP02", CIRCUIT="C0004", LISTORD="2"),
+        entry("ROW01", OBJTYP="CIRCGRP", PARENT="GRP02", CIRCUIT="C0002", LISTORD="1"),
+        entry("C0002", OBJTYP="CIRCUIT", SUBTYP="INTELLI"),
+        entry("C0004", OBJTYP="CIRCUIT", SUBTYP="GLOW"),
+    ]
+
+    assert build_complete_light_groups(entries) == [
+        LightGroupTarget("GRP02", ("ROW01", "ROW02"), ("C0002", "C0004"))
+    ]
+
+
+@pytest.mark.parametrize("entries", [
+    [entry("GRP02", OBJTYP="CIRCUIT", SUBTYP="LITSHO")],
+    [
+        entry("GRP02", OBJTYP="CIRCUIT", SUBTYP="LITSHO"),
+        entry("ROW01", OBJTYP="CIRCGRP", PARENT="GRP02", CIRCUIT="MISSING"),
+    ],
+    [
+        entry("GRP02", OBJTYP="CIRCUIT", SUBTYP="LITSHO"),
+        entry("ROW01", OBJTYP="CIRCGRP", PARENT="GRP02", CIRCUIT="PUMP01"),
+        entry("PUMP01", OBJTYP="PUMP", SUBTYP="VSF"),
+    ],
+])
+def test_incomplete_empty_or_mixed_group_is_not_a_target(entries: list[dict[str, Any]]) -> None:
+    assert build_complete_light_groups(entries) == []
+
+
+def test_observer_source_contains_no_write_command() -> None:
+    source = Path("scripts/capture_light_group_protocol.py").read_text()
+    assert "SETPARAMLIST" not in source.upper()
+    assert "request_changes" not in source
+```
+
+- [ ] **Step 2: Run tests and verify red**
+
+Run:
+
+```bash
+uv run pytest tests/test_capture_light_group_protocol.py -v
+```
+
+Expected: collection fails because the observer module does not exist.
+
+- [ ] **Step 3: Implement exact allowlists and topology validation**
+
+Use these query keys:
+
+```python
+PRIVATE_KEYS = frozenset({
+    "ADDRESS", "CITY", "COUNTRY", "EMAIL", "EMAIL2", "HNAME", "LOCX",
+    "LOCY", "NAME", "PASSWRD", "PHONE", "PHONE2", "PROPNAME", "SNAME",
+    "SOURCE", "STATE", "ZIP", "messageID",
+})
+REFERENCE_KEYS = frozenset({"objnam", "BODY", "CHILD", "CIRCUIT", "PARENT"})
+READ_KEYS_BY_TYPE = {
+    "SYSTEM": ("OBJTYP", "SUBTYP", "VER", "SERVICE"),
+    "CIRCUIT": (
+        "OBJTYP", "SUBTYP", "PARENT", "STATUS", "ACT", "USE", "SYNC",
+        "SWIM", "SET", "LISTORD", "LIMIT", "READY",
+    ),
+    "CIRCGRP": (
+        "OBJTYP", "SUBTYP", "PARENT", "CIRCUIT", "LISTORD", "USE", "DLY",
+        "ACT", "STATUS", "READY",
+    ),
+}
+```
+
+Implement stable `OBJECT_NNN` reference aliasing and the same outside-repository output validation described by the interfaces. `build_complete_light_groups()` must accept only real parent `CIRCUIT/SUBTYP=LITSHO` objects, require at least one row, require each row's singular non-whitespace `CIRCUIT` reference, resolve every child, and require every child `OBJTYP=CIRCUIT` with `SUBTYP` in `COLOR_EFFECT_SUBTYPES`. It must never treat an orphan/legacy row as a group.
+
+`capture_phase()` must fail when `INTELLICENTER_HOST` is absent, set the callback before connecting, enumerate only the three allowlisted types, choose exactly one complete target (fail safely on zero or multiple targets), subscribe to the aliased target's real parent/rows/children, record raw responses and ordered pushes only after sanitization, print only `READY {label} {transport}`, wait the bounded duration, and disconnect in `finally`. Output is absolute, outside Git, and opened mode `0o600`.
+
+- [ ] **Step 4: Run focused tests green**
+
+Run:
+
+```bash
+uv run pytest tests/test_capture_light_group_protocol.py -v
+uv run ruff check scripts/capture_light_group_protocol.py tests/test_capture_light_group_protocol.py
+uv run ruff format --check scripts/capture_light_group_protocol.py tests/test_capture_light_group_protocol.py
+```
+
+Expected: all tests pass and Ruff is clean.
+
+- [ ] **Step 5: Commit discovery tooling locally**
+
+Run:
+
+```bash
+git add scripts/capture_light_group_protocol.py tests/test_capture_light_group_protocol.py
+git commit -m "test: add safe light group protocol observer"
+```
+
+Expected: a local discovery commit, not a production/release PR.
+
+---
+
+### Task 3: Establish topology and invariant snapshots on both transports
+
+**Files:**
+- Raw, untracked: mode-`0700` temporary capture directory.
+
+**Interfaces:**
+- Consumes: Task 2 observer and private `.env` via `uv --env-file`.
+- Produces: independently captured TCP/WebSocket topology, target alias mapping held privately, and initial parent/member/child invariants.
+
+- [ ] **Step 1: Create a private capture directory**
+
+Run:
+
+```bash
+umask 077
+CAPTURE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/intellicenter-issue-93.XXXXXX")"
+chmod 700 "$CAPTURE_DIR"
+printf '%s\n' "$CAPTURE_DIR"
+```
+
+Expected: one private temporary directory path.
+
+- [ ] **Step 2: Confirm operational preconditions**
+
+Through read-only panel/Web App inspection, verify `SERVICE=AUTO`, no automation or schedule is changing the target lights, and the selected private group contains only intended color lights. Record privately the parent power/effect, membership order and row attributes, referenced child power/effect, and the visual state needed for restoration.
+
+- [ ] **Step 3: Capture independent passive baselines**
+
+Run sequentially, polling long-running sessions every 30 seconds or less:
+
+```bash
+uv run --env-file /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter/.env \
+  python scripts/capture_light_group_protocol.py \
+  --transport tcp --label inactive-tcp --seconds 30 \
+  --output "$CAPTURE_DIR/inactive-tcp.jsonl"
+
+uv run --env-file /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter/.env \
+  python scripts/capture_light_group_protocol.py \
+  --transport websocket --label inactive-websocket --seconds 30 \
+  --output "$CAPTURE_DIR/inactive-websocket.jsonl"
+```
+
+Expected: both runs choose the same logical aliased topology and make no equipment change.
+
+- [ ] **Step 4: Run privacy and topology gates**
+
+Run:
+
+```bash
+test "$(stat -f '%Lp' "$CAPTURE_DIR")" = 700
+find "$CAPTURE_DIR" -type f ! -perm 600 -print
+rg -n '"(ADDRESS|CITY|COUNTRY|EMAIL|EMAIL2|HNAME|LOCX|LOCY|NAME|PASSWRD|PHONE|PHONE2|PROPNAME|SNAME|SOURCE|STATE|ZIP|messageID)"' "$CAPTURE_DIR" && exit 1 || true
+```
+
+Expected: no permission/privacy output. Manually confirm membership is non-empty and identical across transports; all rows and children resolve; every child is a supported color light. Abort writes on any mismatch.
+
+---
+
+### Task 4: Capture and repeat official group actions
+
+**Files:**
+- Raw browser and observer traces: private capture directory only.
+
+**Interfaces:**
+- Consumes: official Web App session and Task 3 invariant snapshot.
+- Produces: exact official request/response/notification/fresh-read sequence for Sync, Set, and Swim, plus per-action restoration proof.
+
+In the same private shell that owns `CAPTURE_DIR`, define this launcher once:
+
+```bash
+capture_group_phase() {
+  label="$1"
+  uv run --env-file /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter/.env \
+    python scripts/capture_light_group_protocol.py \
+    --transport websocket --label "$label" --seconds 180 \
+    --output "$CAPTURE_DIR/$label.jsonl"
+}
+```
+
+Start one invocation in a PTY, wait for `READY`, perform only its named official UI action, and poll at intervals of 30 seconds or less.
+
+- [ ] **Step 1: Start official Web App frame capture**
+
+Use Chrome DevTools Protocol with an already authenticated official Web App session. Begin recording immediately before each action and retain privately only the outbound action frame, its correlated response, and minimum surrounding notifications. If the official request cannot be captured without credentials/PII, record the action gate as failed; do not infer a request from upstream source.
+
+- [ ] **Step 2: Capture Color Sync twice**
+
+For `official-sync-1` and `official-sync-2`, start a bounded observer, invoke Color Sync exactly once in the official UI, wait for completion, fresh-read parent/rows/children, then restore parent/member/child state through the official UI and verify against the invariant snapshot.
+
+Run separately:
+
+```bash
+capture_group_phase official-sync-1
+capture_group_phase official-sync-2
+```
+
+- [ ] **Step 3: Capture Color Set twice**
+
+Repeat the exact sequence for `official-set-1` and `official-set-2`, restoring before and after every run.
+
+Run separately:
+
+```bash
+capture_group_phase official-set-1
+capture_group_phase official-set-2
+```
+
+- [ ] **Step 4: Capture Color Swim twice**
+
+Repeat the exact sequence for `official-swim-1` and `official-swim-2`, restoring before and after every run.
+
+Run separately:
+
+```bash
+capture_group_phase official-swim-1
+capture_group_phase official-swim-2
+```
+
+- [ ] **Step 5: Classify action semantics before replay**
+
+For each action, record whether the request targets the parent or another object; whether it uses `ACT`, a dedicated `SYNC`/`SET`/`SWIM` key, or another command; whether `STATUS=ON` is required; whether the group may begin off; exact `200` acknowledgement; authoritative completion frame/fresh-read; duration bound; and every changed parent/row/child field. An action with no authoritative completion signal or unrelated change fails independently.
+
+---
+
+### Task 5: Verify member-position read/write and finite options
+
+**Files:**
+- Private capture traces only.
+
+**Interfaces:**
+- Consumes: official member-position UI and Task 3 target topology.
+- Produces: exact writable row/field, stable readable field, complete finite token map, notification/fresh-read contract, or an omitted-select result.
+
+Use the Task 4 `capture_group_phase` launcher with labels `member-original`, `member-option-N`, `member-repeat-1`, `member-repeat-2`, and `member-restored`. Replace `N` only with the one-based ordinal displayed in the private official UI option list; record the label-to-human-name mapping only in the private execution log.
+
+- [ ] **Step 1: Capture the original row position**
+
+Choose one member row through the private alias mapping. Record its current official UI option and raw readable attributes, change nothing, disconnect, reconnect with a fresh observer, and confirm the same readable token persists.
+
+- [ ] **Step 2: Capture every official UI option**
+
+One option at a time, invoke the official UI change, capture outbound request and correlated response, wait for a matching row push, disconnect/reconnect, and fresh-read the row. Restore the original option and verify before testing the next token. Build a complete human-label-to-token table; if any visible option lacks a stable token, the select gate fails.
+
+- [ ] **Step 3: Prove a second non-original value twice**
+
+Select one non-original option, perform and restore it twice, and require the same target, writable field, response, row push or fresh-read fallback, and persisted token. Reject transient action echoes.
+
+- [ ] **Step 4: Verify no collateral configuration changed**
+
+Fresh-query all membership rows and parent/children after restoration. Require membership, `LISTORD`, every other member position, parent power/effect, and child power/effect to match the invariant snapshot.
+
+---
+
+### Task 6: Replay only captured local contracts over TCP and WebSocket
+
+**Files:**
+- Private replay traces only.
+
+**Interfaces:**
+- Consumes: exact local requests and completion predicates from Tasks 4–5.
+- Produces: per-action/per-position transport support matrix.
+
+- [ ] **Step 1: Reject non-local or ambiguous requests**
+
+Do not replay cloud-only requests, requests with private authentication semantics, ambiguous targets, missing correlated `200` responses, or missing authoritative completion. Never convert the upstream proposed `{ACT: token, STATUS: ON}` lead into a request unless it exactly matches the official frame.
+
+- [ ] **Step 2: Replay Sync, Set, and Swim once over TCP**
+
+For each independently passing action: restore first, start the observer, send the exact captured local command once through `ICConnection.send_request()` over TCP, require the captured completion, fresh-read, and restore. A timeout is terminal; never retry a state-changing request.
+
+- [ ] **Step 3: Replay Sync, Set, and Swim once over WebSocket**
+
+Repeat from a restored invariant snapshot over WebSocket. Record any transport difference instead of normalizing it away.
+
+- [ ] **Step 4: Replay one member-position transition and restoration on each transport**
+
+Only if Task 5 passed, write the same proven non-original option once over TCP and once over WebSocket, with restoration between transports. Require a matching row push; when the captured transport produces no push, disconnect/reconnect and require a fresh read. Restore the original token and verify all group invariants.
+
+- [ ] **Step 5: Perform final restoration twice**
+
+Restore through the official UI and compare the full parent/member/child snapshot twice. Reload Home Assistant if it was deliberately unloaded for a single-client TCP limitation.
+
+---
+
+### Task 7: Sanitize, decide, and amend the approved specification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-14-light-group-actions-design.md`
+- Create only if useful: `docs/superpowers/evidence/2026-07-14-light-group-protocol.md`
+
+**Interfaces:**
+- Consumes: Tasks 3–6 results.
+- Produces: exact action payloads/acknowledgements/completion contracts, transport matrix, finite position mapping if proven, capability predicates, and the staged implementation scope.
+
+- [ ] **Step 1: Write sanitized evidence**
+
+Retain firmware `1.064`, exact field names/tokens, aliased topology, ordered response/notification/fresh-read deltas, repeat counts, duration bounds, transport, collateral-change checks, and restoration results. Remove endpoint, real object names, friendly names, browser headers/cookies, message IDs, credentials, and raw frames.
+
+- [ ] **Step 2: Decide each capability independently**
+
+For Sync, Set, and Swim, mark supported only when official capture, repeatability, local replay, authoritative completion, topology safety, and restoration all pass. Mark member positioning supported only when the writable/readable field, full finite option table, persisted fresh read, both transport results or explicit transport gate, and restoration pass.
+
+- [ ] **Step 3: Resolve remaining design facts**
+
+Update the spec with:
+
+- exact public command/position signatures and verified payloads;
+- acknowledgement and bounded completion predicates;
+- active transport capability predicate;
+- whether `LITSHO` alone is sufficient or complete membership remains mandatory;
+- whether row `USE` is the position field and its exact option tokens;
+- row push versus fresh-read behavior;
+- confirmation that existing standard group effects remain separate from momentary Sync/Set/Swim;
+- selected staged implementation plans and any omitted capability.
+
+- [ ] **Step 4: Run placeholder, privacy, and diff checks**
+
+Run from the integration planning worktree:
+
+```bash
+rg -n '\b(TBD|TODO|FIXME|XXX)\b|\.\.\.|<[^>]+>' \
+  docs/superpowers/specs/2026-07-14-light-group-actions-design.md \
+  docs/superpowers/evidence/2026-07-14-light-group-protocol.md 2>/dev/null || true
+rg -n '(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|PASSWRD|PROPNAME|EMAIL|PHONE|ADDRESS|messageID)' \
+  docs/superpowers/specs docs/superpowers/evidence 2>/dev/null && exit 1 || true
+git diff --check
+```
+
+Expected: no placeholder/privacy matches and a clean diff.
+
+- [ ] **Step 5: Commit only sanitized documentation**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-07-14-light-group-actions-design.md
+test ! -f docs/superpowers/evidence/2026-07-14-light-group-protocol.md || \
+  git add docs/superpowers/evidence/2026-07-14-light-group-protocol.md
+git diff --cached --check
+git commit -m "docs: record issue 93 protocol discovery"
+```
+
+Expected: no raw capture, `.env`, browser trace, or discovery script is staged in the integration worktree.
+
+- [ ] **Step 6: Stop for specification review**
+
+Report the independently passing capabilities, exact limitations, transport support, restoration result, and commit. Do not write or execute library/integration feature plans until this amended specification is reviewed.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** The plan uses the corrected parent/row/child model, rejects unsafe topology, captures official request/response/notifications, repeats all three actions, fresh-reads and restores every phase, enumerates finite member options, verifies TCP and WebSocket independently, treats action and select gates independently, sanitizes evidence, and stops before feature code.
+
+**2. Placeholder scan:** Unknown protocol values are evidence inputs, never guessed implementation blanks. Every unknown has an explicit capture method and a terminal omit/fail result. The plan does not send the upstream proposed payload unless official evidence matches it.
+
+**3. Type/interface consistency:** `LightGroupTarget` retains ordered rows and children; only raw `ICConnection` methods are used; action replay preserves the captured command instead of assuming `request_changes()`; member state requires push or disconnected fresh read; momentary commands remain separate from persistent standard effects.

--- a/docs/superpowers/plans/2026-07-14-system-delay-protocol-discovery.md
+++ b/docs/superpowers/plans/2026-07-14-system-delay-protocol-discovery.md
@@ -1,0 +1,552 @@
+# System Delay Protocol Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Determine, without speculative writes, whether IntelliCenter firmware 1.064 exposes a reliable active-delay signal and a distinct acknowledged command for cancelling heater-cooldown and valve-rotation delays (issue #92).
+
+**Architecture:** Build an issue-local, read-only observer around `ICConnection` so unsupported key echoes and ordered `NotifyList` frames remain visible on both TCP and WebSocket. Query `GetActiveStatusMessages` initially, at a bounded cadence no faster than every 15 seconds, and finally while retaining the push stream; correlate any non-empty answer with authoritative notifications. Identify the deployed official Web App bundle offline before considering any cancellation replay. The identified bundle contains no transient cancellation operation, so replay is now closed and only natural-delay read/push evidence remains. Record sanitized evidence and one decision-table result in the approved design spec; this plan deliberately produces no Home Assistant entity or production protocol helper.
+
+**Tech Stack:** Python 3.13+, `pyintellicenter` raw `ICConnection`, asyncio, pytest, Chrome DevTools Protocol, IntelliCenter TCP 6681/WebSocket 6680, Markdown evidence.
+
+## Global Constraints
+
+- This is protocol discovery only. Do not implement the binary sensor, button, coordinator tracking, or public controller helpers in this plan.
+- Use external worktrees based on fetched commits: pyintellicenter `9ee8d55694c14713f39886866f21f68902b8ca7d`; evidence/spec work stays on integration branch `docs/issues-92-93-plans` descended from `0886531f27d338191d8ab1642b6480ded4a4f553`.
+- Never run `git worktree prune`, `git clean`, `git stash`, a reset command, or modify either primary checkout.
+- Require `INTELLICENTER_HOST`; never supply a fallback host and never print the endpoint, property name, object identifiers, equipment names, location/contact fields, PINs, credentials, or raw browser trace.
+- Keep raw captures outside Git beneath a mode-`0700` temporary directory. Files are mode `0600`; only sanitized excerpts enter the repository.
+- Use `ICConnection`, not `ICModelController`, `PoolModel`, diagnostics output, or `get_all_objects()`. Those paths either request private fields or prune the unsupported `key == value` evidence this investigation needs.
+- Install the notification callback before connecting. Use one experimental protocol client at a time, `keepalive_interval=3600`, `notification_queue_size=1000`, and batches of at most 50 requested attributes.
+- All delay creation, official cancellation, and restoration occur through the official Web App/panel. Never create a delay by writing protocol attributes.
+- The two issue tracks may build and test read-only tooling in parallel, but no #92 state-changing live phase may overlap a #93 live phase.
+- Never replay either nodejs-poolController lead: its IntelliCenter v1 implementation sends no command, while its unverified WebSocket implementation writes `_5451.VALVE=OFF` and `_5451.HEATING=OFF`.
+- Reject any captured command that writes `CIRCUIT.DLY`, `HEATER.DLY`, `VALVE.DLY`, `SYSTEM.HEATING`, or `SYSTEM.VALVE`, even transiently.
+- A successful response requires a correlated response with `response == "200"` plus the captured authoritative state transition. A response alone, a command echo, or physical observation without readable state does not pass the state gate.
+- Abort on service/timeout mode, freeze protection, schedule/automation interference, unrelated actuator movement, flow loss, heater fault, queue overflow, connection loss, malformed/rejected response, membership/configuration mutation, or failed restoration.
+- Cancellation can stop a pump or begin valve movement immediately. Keep an operator able to use the physical panel throughout every state-changing phase.
+- The button gate is closed for the identified asset/firmware, leaving only sensor-only or no feature. No implementation plan is written until the natural-delay evidence is added to the spec and reviewed.
+
+---
+
+## Execution Status (2026-07-15)
+
+- The isolated observer is implemented and committed at
+  `959fe2c35c487e065286119e55387e2fe02c983d` on
+  `discovery/issue-92-delay-protocol`. Focused tests, the full 481-test suite,
+  Ruff, formatting, mypy, lock drift, and diff checks passed.
+- The observer now permits only `GetParamList`, `RequestParamList`, and
+  `GetActiveStatusMessages`; it records initial, periodic, and final active
+  status responses, retains `NotifyList`, skips missed polling slots instead of
+  bursting, and privacy-aliases/resource-bounds nested answers and labels.
+- Inactive TCP and WebSocket `GetActiveStatusMessages` calls each returned a
+  correlated `200` with an empty answer. Command existence is proven on
+  firmware `1.064`; active schema and push delivery are not.
+- Offline inspection of official `bundle.web.js` SHA-256
+  `933e2fc35fd5e5fe26477f0199873bedaf4c266d510f6e8259e3684da18317fd`
+  found only persistent heater/valve delay settings and no transient cancel
+  operation. The button gate failed; Tasks 4 cancellation phases and Task 5
+  replay are permanently skipped for this asset/firmware evidence.
+- The only open live work is two operator-coordinated natural heater-cooldown
+  captures covering both candidate transports, each long enough to cover active
+  -> inactive, followed by two valve-delay captures covering both transports
+  before any generic system-delay claim. Until those sanitized results pass
+  adversarial review, no #92 production plan or PR exists.
+
+---
+
+### Task 1: Create the isolated discovery workspace
+
+**Files:**
+- No repository files changed.
+
+**Interfaces:**
+- Consumes: clean pyintellicenter base `9ee8d55694c14713f39886866f21f68902b8ca7d`.
+- Produces: external worktree `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-discovery-issue-92` on branch `discovery/issue-92-delay-protocol` with a green baseline.
+
+- [x] **Step 1: Confirm the target is unused without pruning existing metadata**
+
+Run:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter \
+  branch --list discovery/issue-92-delay-protocol
+test ! -e /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-discovery-issue-92
+```
+
+Expected: no branch output and `test` exits 0. If either check fails, choose a new issue-specific branch/path and record it in the execution log; do not delete or reuse unknown state.
+
+- [x] **Step 2: Create the external worktree**
+
+Run:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter worktree add \
+  /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-discovery-issue-92 \
+  -b discovery/issue-92-delay-protocol \
+  9ee8d55694c14713f39886866f21f68902b8ca7d
+```
+
+Expected: the new worktree is created at the requested commit.
+
+- [x] **Step 3: Sync and verify the baseline**
+
+Run from the new worktree:
+
+```bash
+uv sync --frozen --extra dev
+uv run pytest -q
+```
+
+Expected: dependency sync has no lock drift and the full suite passes. Stop and report if it fails.
+
+---
+
+### Task 2: Build a narrow read-only delay observer (completed)
+
+**Files:**
+- Create: `scripts/capture_delay_protocol.py`
+- Create: `tests/test_capture_delay_protocol.py`
+
+**Interfaces:**
+- Consumes: `ICConnection(host, transport=..., keepalive_interval=3600, notification_queue_size=1000)`, `set_notification_callback()`, and `send_request()`.
+- Produces:
+  - `sanitize_frame(frame: dict[str, Any], aliases: dict[str, str], answer_aliases: dict[tuple[str, str], str] | None = None) -> dict[str, Any]`
+  - `validate_capture_path(path: Path, repo_root: Path) -> None`
+  - `capture_phase(*, transport: Literal["tcp", "websocket"], label: str, seconds: int, output: Path) -> None`
+  - CLI: `python scripts/capture_delay_protocol.py --transport {tcp,websocket} --label LABEL --seconds N --output ABSOLUTE_PATH`
+
+- [x] **Step 1: Write failing safety tests**
+
+Add tests that prove the observer preserves protocol evidence while removing private data:
+
+Also cover nested `GetActiveStatusMessages.answer` dictionaries/lists,
+identifier/reference aliasing, answer key/value token alias stability, malformed
+scalars, depth/container/global-node budgets, fixed safe label patterns, read-only
+command facade enforcement, mode-`0600` output, bounded query cadence, missed-slot
+skipping, cleanup, and exception-message privacy.
+
+```python
+from pathlib import Path
+
+import pytest
+
+from scripts.capture_delay_protocol import sanitize_frame, validate_capture_path
+
+
+def test_sanitize_frame_aliases_identifiers_and_removes_private_fields() -> None:
+    frame = {
+        "messageID": "17",
+        "response": "200",
+        "objectList": [{
+            "objnam": "_5451",
+            "params": {
+                "OBJTYP": "SYSTEM",
+                "SNAME": "private-id",
+                "PROPNAME": "private-property",
+                "PASSWRD": "1234",
+                "DLY": "DLY",
+                "SERVICE": "AUTO",
+            },
+        }],
+    }
+
+    aliases: dict[str, str] = {}
+    sanitized = sanitize_frame(frame, aliases)
+
+    assert sanitized == {
+        "response": "200",
+        "objectList": [{
+            "objnam": "OBJECT_001",
+            "params": {
+                "OBJTYP": "SYSTEM",
+                "DLY": "DLY",
+                "SERVICE": "AUTO",
+            },
+        }],
+    }
+
+
+def test_validate_capture_path_rejects_repository_output(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(ValueError, match="outside the repository"):
+        validate_capture_path(repo / "capture.jsonl", repo)
+
+
+def test_observer_source_contains_no_mutation_command() -> None:
+    source = Path("scripts/capture_delay_protocol.py").read_text()
+    assert "SETPARAMLIST" not in source.upper()
+    assert "request_changes" not in source
+```
+
+- [x] **Step 2: Run the tests and verify red**
+
+Run:
+
+```bash
+uv run pytest tests/test_capture_delay_protocol.py -v
+```
+
+Expected: collection fails because `scripts.capture_delay_protocol` does not exist.
+
+- [x] **Step 3: Implement the safety boundary and exact allowlists**
+
+The script must define these constants exactly; private keys are removed rather than masked so their presence cannot reveal installation shape:
+
+```python
+PRIVATE_KEYS = frozenset({
+    "ADDRESS", "CITY", "COUNTRY", "EMAIL", "EMAIL2", "HNAME", "LOCX",
+    "LOCY", "NAME", "PASSWRD", "PHONE", "PHONE2", "PROPNAME", "SNAME",
+    "SOURCE", "STATE", "ZIP", "messageID",
+})
+REFERENCE_KEYS = frozenset({"objnam", "BODY", "CHILD", "CIRCUIT", "HEATER", "PARENT"})
+READ_KEYS_BY_TYPE = {
+    "SYSTEM": (
+        "OBJTYP", "SUBTYP", "VER", "SERVICE", "READY", "STATUS", "MODE",
+        "HEATING", "VALVE", "ACT", "ACT3", "ACT4", "VACTIM", "VACFLO",
+    ),
+    "BODY": (
+        "OBJTYP", "SUBTYP", "STATUS", "MODE", "HTMODE", "HTSRC", "HEATER",
+        "LOTMP", "HITMP", "SETTMP", "ACT1", "ACT2", "ACT3", "ACT4",
+        "BOOST", "MANHT", "READY", "TEMP", "LSTTMP",
+    ),
+    "CIRCUIT": (
+        "OBJTYP", "SUBTYP", "STATUS", "BODY", "FEATR", "FREEZE", "DLY",
+        "READY", "TIME", "TIMOUT", "DNTSTP", "USE", "ACT", "PARENT",
+        "CIRCUIT",
+    ),
+    "CIRCGRP": (
+        "OBJTYP", "SUBTYP", "STATUS", "DLY", "READY", "USE", "ACT",
+        "PARENT", "CIRCUIT",
+    ),
+    "HEATER": (
+        "OBJTYP", "SUBTYP", "STATUS", "BODY", "DLY", "HEATING", "HTMODE",
+        "MODE", "START", "STOP", "TIME", "TIMOUT", "READY",
+    ),
+    "VALVE": (
+        "OBJTYP", "SUBTYP", "ASSIGN", "CIRCUIT", "DLY", "READY", "STATUS",
+    ),
+    "PUMP": (
+        "OBJTYP", "SUBTYP", "STATUS", "BODY", "RPM", "GPM", "PWR", "READY",
+    ),
+}
+```
+
+Implement `sanitize_frame()` as a recursive copy that drops `PRIVATE_KEYS`, assigns stable `OBJECT_NNN` aliases for every non-null reference (`"00000"` remains unchanged), and preserves every other key/value including placeholder echoes. Implement `validate_capture_path()` by resolving both paths and raising when the output is equal to or beneath `repo_root`.
+
+`capture_phase()` must:
+
+1. fail before connecting when `INTELLICENTER_HOST` is absent;
+2. set the callback before `connect()`;
+3. enumerate only `OBJTYP`, `SUBTYP`, and `PARENT` to identify relevant objects;
+4. query each relevant type with its allowlist using raw `GetParamList`;
+5. subscribe to explicit discovered object names with `RequestParamList`, in batches below 50 aggregate keys;
+6. issue read-only `GetActiveStatusMessages` once before `READY`, periodically
+   no faster than every 15 seconds without catch-up bursts, and once at normal
+   completion;
+7. write sanitized UTC timestamp, monotonic offset, fixed-pattern label,
+   transport, event kind, and sanitized frame as JSONL;
+8. print only `READY {label} {transport}` after subscription and the initial
+   active-status read;
+9. wait for the bounded duration and always disconnect in `finally`.
+
+Open output with mode `0o600` and refuse relative paths. Do not log response representations or exception arguments because they can contain frames.
+
+- [x] **Step 4: Run focused tests green**
+
+Run:
+
+```bash
+uv run pytest tests/test_capture_delay_protocol.py -v
+uv run ruff check scripts/capture_delay_protocol.py tests/test_capture_delay_protocol.py
+uv run ruff format --check scripts/capture_delay_protocol.py tests/test_capture_delay_protocol.py
+```
+
+Expected: tests pass and Ruff reports clean files.
+
+- [x] **Step 5: Commit discovery tooling locally**
+
+Run:
+
+```bash
+git add scripts/capture_delay_protocol.py tests/test_capture_delay_protocol.py
+git commit -m "test: capture active system status messages"
+```
+
+Expected: commit `959fe2c35c487e065286119e55387e2fe02c983d` on the discovery branch. This commit is evidence tooling, not a production or release PR.
+
+---
+
+### Task 3: Establish the passive baseline on both transports (completed)
+
+**Files:**
+- Raw, untracked: mode-`0700` temporary capture directory.
+- No committed evidence yet.
+
+**Interfaces:**
+- Consumes: Task 2 CLI and the ignored pyintellicenter `.env` through `uv --env-file`.
+- Produces: sanitized inactive TCP/WebSocket inventory and subscription traces, plus a recorded invariant snapshot.
+
+- [x] **Step 1: Create a private capture directory**
+
+Run:
+
+```bash
+umask 077
+CAPTURE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/intellicenter-issue-92.XXXXXX")"
+chmod 700 "$CAPTURE_DIR"
+printf '%s\n' "$CAPTURE_DIR"
+```
+
+Expected: one temporary directory path; preserve it only in the private execution log.
+
+- [x] **Step 2: Confirm operational preconditions through read-only UI/panel inspection**
+
+Verify and record privately: panel `SERVICE=AUTO`; no freeze protection, active schedule transition, cleaner cycle, or unrelated automation; expected flow and heater health; and an operator is present. Unload Home Assistant only if its TCP client prevents the observer from connecting, and record that it must be reloaded during restoration.
+
+- [x] **Step 3: Capture inactive baselines independently**
+
+Run each command in its own terminal session and poll output at intervals no longer than 30 seconds:
+
+```bash
+uv run --env-file /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter/.env \
+  python scripts/capture_delay_protocol.py \
+  --transport tcp --label inactive-tcp --seconds 30 \
+  --output "$CAPTURE_DIR/inactive-tcp.jsonl"
+
+uv run --env-file /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter/.env \
+  python scripts/capture_delay_protocol.py \
+  --transport websocket --label inactive-websocket --seconds 30 \
+  --output "$CAPTURE_DIR/inactive-websocket.jsonl"
+```
+
+Observed: each printed only its `READY` line and exited 0. Both active-status
+responses were correlated `200` with empty answers; no equipment changed.
+
+- [x] **Step 4: Run the privacy and structural gate**
+
+Run:
+
+```bash
+test "$(stat -f '%Lp' "$CAPTURE_DIR")" = 700
+find "$CAPTURE_DIR" -type f ! -perm 600 -print
+rg -n '"(ADDRESS|CITY|COUNTRY|EMAIL|EMAIL2|HNAME|LOCX|LOCY|NAME|PASSWRD|PHONE|PHONE2|PROPNAME|SNAME|SOURCE|STATE|ZIP|messageID)"' "$CAPTURE_DIR" && exit 1 || true
+```
+
+Expected: no `find` or `rg` matches. Manually confirm aliases are stable and both transports report exactly one aliased `SYSTEM` object. Stop if the inventory is ambiguous.
+
+---
+
+### Task 4: Capture natural delay transitions; cancellation gate closed
+
+**Files:**
+- Sanitized observer traces: private capture directory until analysis.
+
+**Interfaces:**
+- Consumes: official UI/panel, Task 3 invariant snapshot, observer CLI.
+- Produces: repeated heater and valve inactive-to-active-to-natural traces with
+  active-status response/push correlation and restoration proof. It produces no
+  cancellation trace because that independent gate has already failed.
+
+In the same private shell that owns `CAPTURE_DIR`, define this launcher once:
+
+```bash
+capture_delay_phase() {
+  transport="$1"
+  label="$2"
+  seconds="$3"
+  uv run --env-file /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter/.env \
+    python scripts/capture_delay_protocol.py \
+    --transport "$transport" --label "$label" --seconds "$seconds" \
+    --output "$CAPTURE_DIR/$label-$transport.jsonl"
+}
+```
+
+The execution agent starts one listed invocation in a PTY, waits for `READY`, performs only that step's official UI actions, and polls at intervals of 30 seconds or less until completion.
+
+- [x] **Step 1: Resolve the official Web App cancellation gate offline**
+
+The deployed `bundle.web.js` asset with SHA-256
+`933e2fc35fd5e5fe26477f0199873bedaf4c266d510f6e8259e3684da18317fd`
+contains no transient `Cancel Systems Delay` operation. Its only related writers
+change persistent heater/valve delay enables or durations, which this plan
+forbids. Record the failed button gate and do not invoke, capture, or replay a
+state-changing cancellation candidate.
+
+- [ ] **Step 2: Record heater-only natural completion twice**
+
+For runs `heater-natural-1` and `heater-natural-2`, start the observer for a duration longer than the configured cooldown, create normal heater demand only within the operator-approved settings, end demand through the official UI, allow the delay to complete naturally, and fresh-query the same objects at completion. Do not raise a setpoint beyond the operator-approved value merely to force firing.
+
+Run separately:
+
+```bash
+capture_delay_phase tcp heater-natural-1 900
+capture_delay_phase websocket heater-natural-2 900
+```
+
+Expected: two independent physical runs establish repeatability while covering
+both candidate transports. Each contains the complete inactive -> active ->
+inactive sequence or proves no readable active signal exists. A transport
+difference requires a transport-scoped capability; it must not be generalized
+away. These cross-transport single observations are not enough to claim a
+transport-scoped capability: if they diverge, select unsupported/no capability
+for this plan and require a separately amended, reviewed plan with repeated
+runs inside each affected transport before reconsidering scoped support.
+
+- [x] **Step 3: Skip heater cancellation captures**
+
+Skipped because Step 1 failed the independent button gate. Do not manufacture a
+local equivalent from persistent settings.
+
+- [ ] **Step 4: Repeat natural runs twice for a valve-only delay**
+
+Perform `valve-natural-1` and `valve-natural-2` through the official UI. Reject
+the run if heater cooldown and valve rotation cannot be isolated or an unrelated
+circuit moves. Correlate every non-empty active-status answer with the retained
+`NotifyList`; query-only data does not pass the push-driven production sensor
+gate.
+
+Run separately:
+
+```bash
+capture_delay_phase tcp valve-natural-1 600
+capture_delay_phase websocket valve-natural-2 600
+```
+
+Expected: two independent valve runs establish repeatability while covering
+both candidate transports. A generic system-delay sensor may claim valve
+coverage only if both transports produce the same authoritative push/model
+mapping. If they diverge, omit valve coverage here; one observation per
+transport cannot justify scoped support without a separately amended, reviewed
+within-transport repeat plan.
+
+- [x] **Step 5: Skip simultaneous cancellation**
+
+Skipped because no cancellation command passed Step 1. Natural simultaneous
+delays are not needed to decide the initial per-type sensor gate.
+
+- [ ] **Step 6: Restore and verify twice**
+
+Through the official UI, restore bodies, circuits, heater modes, setpoints, group/light states, Home Assistant loading state, and every delay configuration value. Fresh-query the invariant snapshot twice, excluding only naturally volatile temperature/RPM/GPM/power telemetry.
+
+Expected: both comparisons match. A mismatch fails the discovery run and blocks replay.
+
+---
+
+### Task 5: Replay only a proven local non-mutating cancellation contract (skipped)
+
+**Files:**
+- Private replay traces only.
+
+**Interfaces:**
+- Consumes: the failed official bundle gate from Task 4.
+- Produces: explicit “not replayable locally; no command exists in the identified
+  asset” result.
+
+No step below is authorized: Task 4 produced no exact transient command,
+acknowledgement predicate, or completion predicate. The persistent-setting
+writes remain forbidden.
+
+- [x] **Step 1: Classify the official request offline**
+
+Rejected: no transient request exists in the identified official asset. Continue
+to Task 6 with only sensor-only/no-feature outcomes available.
+
+- [x] **Step 2: Replay once over TCP (skipped)**
+
+Not run. Step 1 did not produce a command, so no TCP state-changing request is
+permitted.
+
+- [x] **Step 3: Restore, then replay once over WebSocket (skipped)**
+
+Not run. Step 1 did not produce a command, so no WebSocket state-changing
+request is permitted.
+
+- [x] **Step 4: Perform final restoration (not applicable; no replay occurred)**
+
+No replay state existed to restore. The passive baseline remained unchanged.
+
+---
+
+### Task 6: Sanitize, decide, and amend the approved specification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-14-system-delay-status-cancel-design.md`
+- Create only if useful: `docs/superpowers/evidence/2026-07-14-system-delay-protocol.md`
+
+**Interfaces:**
+- Consumes: Tasks 3–5 traces.
+- Produces: sanitized state/command contract, firmware and transport scope, passive capability predicate, selected decision-table row, and an explicit next-plan boundary.
+
+- [ ] **Step 1: Write the sanitized evidence summary**
+
+Record exact field names and tokens, aliased targets, ordered state deltas, response code predicate, completion predicate, repeat counts, supported delay types, firmware `1.064`, tested transports, configuration invariants, and restoration result. Do not include raw frames, endpoint, object names, property/equipment names, browser headers/cookies, message IDs, or credentials.
+
+- [ ] **Step 2: Select exactly one decision-table result**
+
+Choose sensor-only or unsupported; both button-bearing outcomes are already
+eliminated for the identified asset/firmware. A sensor requires one durable
+readable inactive/active mapping, a corresponding authoritative push/model
+signal, repeat coverage for every claimed delay type, and an independent passive
+capability predicate. If any predicate is absent, omit the entity even if an
+active query happened to return useful data.
+
+- [ ] **Step 3: Update the design from conditional language to captured facts**
+
+Add a dated `Discovery Result` section to the spec with the selected result and exact future public interfaces, or state that issue #92 is unsupported on firmware 1.064 and why. Explicitly retain the disproved `DLY`, `HEATING`, and `VALVE` regression guards.
+
+- [ ] **Step 4: Run evidence privacy and diff checks**
+
+Run from the integration planning worktree:
+
+```bash
+rg -n '\b(TBD|TODO|FIXME|XXX)\b|\.\.\.|<[^>]+>' \
+  docs/superpowers/specs/2026-07-14-system-delay-status-cancel-design.md \
+  docs/superpowers/evidence/2026-07-14-system-delay-protocol.md 2>/dev/null || true
+rg -n '(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|PASSWRD|PROPNAME|EMAIL|PHONE|ADDRESS|messageID)' \
+  docs/superpowers/specs docs/superpowers/evidence 2>/dev/null && exit 1 || true
+git diff --check
+```
+
+Expected: no placeholder/privacy match and a clean diff check.
+
+- [ ] **Step 5: Commit only sanitized documentation**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-07-14-system-delay-status-cancel-design.md
+test ! -f docs/superpowers/evidence/2026-07-14-system-delay-protocol.md || \
+  git add docs/superpowers/evidence/2026-07-14-system-delay-protocol.md
+git diff --cached --check
+git commit -m "docs: record issue 92 protocol discovery"
+```
+
+Expected: no raw capture/tooling file is staged.
+
+- [ ] **Step 6: Stop for specification review**
+
+Report the selected decision, exact evidence limitations, restoration status, and commit. Do not write or execute a feature implementation plan until this amended specification is reviewed.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** The plan records the independently failed cancellation
+gate and forbids every replay/configuration write. Remaining work separately
+observes repeated natural heater and valve transitions, correlates bounded
+`GetActiveStatusMessages` reads with retained pushes, verifies both transports,
+establishes passive setup predicates independently, restores normal UI state,
+sanitizes evidence, selects sensor-only or unsupported, and stops before feature
+implementation.
+
+**2. Placeholder scan:** Every branch has an explicit terminal result. The plan
+contains no speculative command value and deliberately refuses to manufacture
+one; no replay input passed the official asset gate.
+
+**3. Type/interface consistency:** The observer uses public `ICConnection`
+methods, raw read-only `GetParamList`/`RequestParamList`/
+`GetActiveStatusMessages`, explicit `Literal["tcp", "websocket"]`, stable object
+and answer alias dictionaries, and bounded resource/cadence guards. Later steps
+never substitute `request_changes()` for an unknown command and never treat a
+`200` acknowledgement as active state.

--- a/docs/superpowers/plans/2026-07-15-light-group-model-color-sync.md
+++ b/docs/superpowers/plans/2026-07-15-light-group-model-color-sync.md
@@ -1,0 +1,1615 @@
+# Light Group Modeling and Color Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct pyintellicenter's real parent/membership-row group model and expose the verified Color Sync action on complete IntelliCenter light-group entities over TCP and WebSocket in Home Assistant.
+
+**Architecture:** Keep group identity and control on the parent `CIRCUIT/SUBTYP=LITSHO`; treat `OBJTYP=CIRCGRP` objects only as ordered membership rows. A dedicated `run_light_group_sync(group_objnam)` method captures one live connection, establishes an exclusive controller mutation lifecycle, installs a raw enqueue-time sequenced observer before the first fresh projection, starts the monotonic deadline inside the request lock immediately before transport initiation, and captures a separate causal onset watermark immediately after the transport accepts the send. One wildcard `GetParamList` request fetches the complete safety projection with a fixed key set below the protocol ceiling; exact-object subscriptions are split into bounded batches. The helper sends the exact mixed-case command once, requires sender-side `SYNC=ON` and `SYNC=OFF` by the dispatch-start 60-second deadline, observes the complete safety projection for another 60 seconds, and performs a mandatory final in-band read on that same connection. Home Assistant adds one momentary `color_sync` entity service to the existing parent light, maps action certainty from a phase-aware error, and never turns the action into an effect or optimistic state.
+
+**Tech Stack:** Python 3.13/3.14, asyncio, pyintellicenter TCP/WebSocket transports, pytest/pytest-asyncio, Ruff, mypy, Home Assistant 2026.5.4, HACS/hassfest, uv, GitHub Actions, PyPI.
+
+## Global Constraints
+
+- Implement in two isolated feature worktrees based on freshly fetched upstream commits. The known anchors on 2026-07-15 are pyintellicenter `origin/main=9ee8d55694c14713f39886866f21f68902b8ca7d` and intellicenter `origin/main=4f943e90a715997e8db1c50a7613c3aa843a86c5`; if either upstream moved, record the new fetched commit and re-run the baseline before editing.
+- This plan ships only Color Sync. The public library API is exactly `async def run_light_group_sync(group_objnam: str) -> dict[str, Any]`; do not add a generic action-token API, Color Set, Color Swim, a member-position writer, or a member-position select.
+- The action request is exactly mixed-case `SetParamList`, one parent object, and only `{"SYNC": "ON"}`. Do not route it through uppercase `SETPARAMLIST`, `request_changes()`, the coalescing serializer, `ACT`, `STATUS`, `SET`, or `SWIM`.
+- Same-connection evidence on firmware `1.064` passed Sync from uniform `OFF` and uniform `ON` prestates over TCP and WebSocket. The sender-side action field is `SYNC`; terminal observations ranged from 35.286805 to 36.238773 seconds with no collateral projection change.
+- Gate the action capability to the exact evidence envelope: fresh firmware exactly `1.064`, one real `CIRCUIT/LITSHO` parent, and exactly two distinct resolved `CIRCUIT/GLOW` children. The general read helpers may continue to classify `INTELLI` and `MAGIC2` as color-capable and may read groups of other cardinalities, but the state-changing Sync helper and Home Assistant service must reject them until separately captured.
+- The 60-second action deadline starts at the pre-send hook, not before lock acquisition or after acknowledgement. Both positive post-watermark onset and terminal must occur by that deadline. After terminal, observe for a separate mandatory 60-second interval, then perform a mandatory in-band final projection read. The rejected TCP Swim replay regressed 9.046 seconds after its apparent terminal, so the full minute is an intentionally conservative state-changing safety gate.
+- Accept only uniform target prestates: parent and every resolved child all `OFF`, or all `ON`. Reject mixed, missing, or noncanonical status before the write. Sync's expected final power projection is parent plus every child `ON` for either accepted prestate.
+- Before the write require exactly one cached/fresh `SYSTEM`, `VER=1.064`, `SERVICE=AUTO`, a real `CIRCUIT/LITSHO` parent, exactly two membership rows, both child references resolved and distinct, both children `CIRCUIT/GLOW`, and every `SYNC`/`SET`/`SWIM` flag on every group parent `OFF`.
+- Build the topology and fixed wildcard projection request synchronously, install the raw observer, and only then fetch the first complete fresh safety projection. Until that first response becomes the validated baseline, the tracker stores projected frames in a bounded pre-baseline buffer and fails closed on overflow; baseline installation replays the buffer in sequence. Subscribe to the exact discovered projection in batches of at most `MAX_ATTRIBUTES_PER_QUERY`, validate every subscription initialization response against the baseline, wait the empirically exercised one-second settle, and repeat the complete wildcard `GetParamList` preflight. The observer is active before both the first read and subscription. The settled projection must exactly equal the first baseline, and any projected notification or subscription-initialization deviation after baseline installation rejects before the write even if a later frame or second read restores the original value.
+- Do not classify action edges from a boolean arm. A connection-owned monotonic notification sequence is assigned at enqueue time. Under the connection request lock, an internal before-write hook records the event-loop time immediately before TCP `transport.write()` or initiation of WebSocket `send()` and starts the 60-second deadline. A separate after-write hook captures the current sequence immediately after synchronous TCP `transport.write()` returns or awaited WebSocket `send()` completes. Only notifications whose sequence is strictly greater than that post-send watermark are eligible action edges. This excludes frames received while the request waits behind another connection request and, conservatively, frames processed while WebSocket `send()` is suspended; those ambiguous frames still undergo invariant checks but never prove onset.
+- Retain eligible post-send-watermark notifications that precede the correlated acknowledgement. A response `200`, command echo, initial `ON`, status alone, or a final fresh read without a positive causal onset is not completion.
+- From dispatch start until observer removal, enforce every normalized projected invariant monotonically: an all-on target object may never report `OFF`; an all-off target object may not return to `OFF` after it first reports `ON`; every circuit `OBJTYP`/`SUBTYP` and normalized optional `PARENT` plus every target optional `USE`/required `SET`/`SWIM` stay at baseline; every unrelated `CIRCUIT` `STATUS`/optional `USE` stays at baseline; every non-target group flag, every membership row's topology/optional `USE`, and `SYSTEM` firmware/service stay at baseline. Target `SYNC` may make only the qualifying post-watermark `OFF -> ON -> OFF` lifecycle and may not re-enter `ON` after terminal. A transient violation is final even if a later frame restores the value.
+- The final projection is fetched with the same wildcard `GetParamList` on the exact captured connection after the full 60-second post-terminal observation interval. It includes normalized optional `PARENT`/`USE` plus required identity/status fields for every `CIRCUIT`, topology/optional `USE` for every membership row, all group flags, and system firmware/service. Missing, key-echo, and protocol null-reference representations for optional fields normalize to one absence value and are compared to baseline; mandatory topology/status/action fields never accept placeholders. The final projection must exactly satisfy those baseline invariants plus target parent/two-child `STATUS=ON` and target `SYNC=OFF`; it never substitutes for onset or terminal edges.
+- Never retry a state-changing request and never issue an automatic recovery/off command after timeout or protocol failure. Surface ambiguity to the caller and leave physical inspection/recovery to the user.
+- The action observer must be enqueue-time and additive. It must not replace Home Assistant's model callback, process stale frames already in the callback queue, or remain registered after success, error, disconnect, reconnect, cancellation, or timeout. Immediately after capturing the connection, synchronously capture that exact generation's one-shot close future and race it against subscription settling and every lifecycle/observation wait so disconnect never sleeps until a generic deadline or disappears behind same-instance reconnect. Because observer state survives transport replacement, the registered closure checks `connection_closed.done()` before forwarding every frame; once closed, no new-generation frame can mutate or complete the old tracker. In any simultaneous wait tie, closure wins before response/edge processing.
+- One controller-wide mutation lifecycle lock must cover both fresh preflights, subscription/settling, write, terminal wait, post-terminal observation, and final read. Sync marks its lifecycle pending before awaiting that lock, so already-started public `SetParamList` work drains before preflight, while every later case-insensitive public `SetParamList` call—including `request_changes()` and coalesced flushes—fails immediately with an ordinary pre-dispatch `ICError` instead of waiting up to two minutes. A second Sync likewise fails busy before dispatch. The private captured-connection unlocked primitive is used only by Sync while it owns the lifecycle. A caller that directly constructs and writes through a separate raw `ICConnection` is outside the controller boundary; document that boundary. Read-only requests, keepalives, and model notifications continue through the connection request lock. An urgent physical-panel action remains possible but causes Sync to fail if it changes a projected invariant.
+- After dispatch begins, replace generic protocol/timeout outcomes with `ICLightGroupError(ICError)` carrying `phase`, an always-true `dispatch_started`, `response_received`, `acknowledged`, and `onset_seen`. Unsupported cached topology raises `ValueError`; all network/projection/busy failures known to occur before dispatch remain ordinary `ICError` subclasses. `phase` names the gate that failed, not the latest edge seen, so `phase="acknowledgement"` may truthfully coexist with `onset_seen=True` when a push precedes a missing response. Home Assistant must distinguish unsupported, prewrite/explicit rejection, dispatched-with-no-response uncertainty, and acknowledged-or-started incomplete outcomes.
+- Membership rows remain model-only. Track only `PARENT`, singular `CIRCUIT`, and `LISTORD` in the Home Assistant coordinator; never create a row-derived entity or expose row `SNAME`, `STATUS`, `USE`, or action flags as durable entity state.
+- Preserve direct compatibility for an exact legacy standalone `CIRCGRP` fixture passed to `get_circuits_in_group()`, but never enumerate that artificial row as a real group or color-light group.
+- Do not edit the evidence or design documents while executing this plan. Do not include private hosts, object identifiers, equipment names, raw frames, credentials, or discovery captures in either repository.
+- Once the library API and focused contract tests are stable, integration implementation may proceed in parallel using a temporary uncommitted editable install of the pyintellicenter feature worktree. Never commit a path/git dependency. Regenerating and committing the integration dependency lock and opening the integration PR must wait for a maintainer-confirmed pyintellicenter merge and published `0.1.22` PyPI artifact.
+- Opening feature/release PRs is planned work. Merging PRs, creating tags, and publishing PyPI or GitHub releases are explicit user/maintainer checkpoints; stop and request confirmation at each checkpoint rather than treating those actions as authorized implementation steps. A later separately approved release PR advances the integration from `3.10.0b2` to `3.10.0b3`.
+
+---
+
+## File Structure
+
+### pyintellicenter repository
+
+- Create `src/pyintellicenter/_light_group.py`: private topology/projection dataclasses, exact query construction, snapshot validation, and the Sync lifecycle tracker.
+- Modify `src/pyintellicenter/_mixins/circuit_group.py`: corrected public read helpers plus the dedicated `run_light_group_sync()` orchestration method.
+- Modify `src/pyintellicenter/_mixins/_base.py`: static-only declarations for the connection-bound send helper, mutation lock, connection, and transport used by the mixin.
+- Modify `src/pyintellicenter/connection.py`: connection-owned monotonic enqueue sequencing, raw observer fanout, internal pre-send deadline/post-send watermark hooks under the request lock, and an awaitable connection-closed signal shared by TCP and WebSocket.
+- Modify `src/pyintellicenter/controller.py`: controller-wide mutation lock and a captured-connection send primitive; drain already-started writers and fail later direct/coalesced writes during Sync.
+- Modify `src/pyintellicenter/exceptions.py` and `src/pyintellicenter/__init__.py`: add/export phase-aware `ICLightGroupError` and later prepare version `0.1.22` for maintainer-approved publication.
+- Create `tests/test_circuit_group.py`: real topology, ordering, malformed rows, color detection, and legacy compatibility.
+- Create `tests/test_light_group_sync.py`: exact-two-member preflight, exact command, phase-aware errors, both transports/prestates, split dispatch-start deadline/post-send watermark, 60-second observation, complete transient invariants, final projection, locking, and cleanup.
+- Modify `tests/test_connection.py`: observer fanout, stale-queue exclusion, removal, exception isolation, and close signaling.
+- Modify `tests/test_controller.py`: captured-connection sends and fail-fast mutation-isolation regressions.
+- Modify `tests/test_typing_public_api.py`: downstream type visibility for `run_light_group_sync()` and `ICLightGroupError`.
+- Modify `docs/API.md`, `docs/USAGE.md`, `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`: corrected public contract, user guidance, changelog, and release metadata.
+
+### intellicenter repository
+
+- Modify `custom_components/intellicenter/coordinator.py`: correct membership-row tracking keys.
+- Modify `custom_components/intellicenter/light.py`: complete-group preflight, `color_sync` registration, and `PoolLight.async_color_sync()`.
+- Modify `custom_components/intellicenter/services.yaml`: one `color_sync` light entity service.
+- Modify `custom_components/intellicenter/strings.json` and all 12 files under `custom_components/intellicenter/translations/`: service copy plus unsupported, failed/rejected, uncertain-dispatch, and incomplete-action translations.
+- Modify `custom_components/intellicenter/manifest.json`, `pyproject.toml`, and `uv.lock`: require/relock released pyintellicenter `0.1.22`; later advance integration release metadata to `3.10.0b3`.
+- Modify `tests/conftest.py`, `tests/test_light.py`, `tests/test_library_contract.py`, and `tests/test_versions.py`: real topology fixtures, entity/service behavior, installed library contract, and dependency/version drift.
+- Modify `README.md` and `CHANGELOG.md`: document Color Sync as a blocking momentary action and the corrected group model.
+
+---
+
+### Task 1: Create isolated implementation worktrees and capture green baselines
+
+**Files:**
+- No repository files changed.
+
+**Interfaces:**
+- Consumes: fetched upstream commits described in Global Constraints.
+- Produces: `/Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-issue-93-sync` on `feature/issue-93-light-group-sync` and `/Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter-issue-93-sync` on the same branch name.
+
+- [ ] **Step 1: Fetch without touching either primary checkout's worktree state**
+
+Run:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter fetch origin
+git -C /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter fetch origin
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter rev-parse origin/main
+git -C /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter rev-parse origin/main
+```
+
+Expected: two commit IDs. Record them in the implementation log; do not reset either primary checkout.
+
+- [ ] **Step 2: Verify branch/path availability and create worktrees**
+
+Run:
+
+```bash
+test ! -e /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-issue-93-sync
+test ! -e /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter-issue-93-sync
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter branch --list feature/issue-93-light-group-sync
+git -C /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter branch --list feature/issue-93-light-group-sync
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter worktree add \
+  /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-issue-93-sync \
+  -b feature/issue-93-light-group-sync origin/main
+git -C /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter worktree add \
+  /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter-issue-93-sync \
+  -b feature/issue-93-light-group-sync origin/main
+```
+
+Expected: both preflight commands are silent and both worktrees are created. If a path or branch exists, inspect and choose a new issue-specific name rather than deleting unknown work.
+
+- [ ] **Step 3: Establish the pyintellicenter baseline**
+
+Run from the pyintellicenter worktree:
+
+```bash
+uv sync --frozen --extra dev
+uv run pytest -q
+uv run ruff check src tests scripts
+uv run ruff format --check src tests scripts
+uv run mypy src
+```
+
+Expected: the complete existing suite passes and all static gates are clean.
+
+- [ ] **Step 4: Establish the integration baseline**
+
+Run from the intellicenter worktree:
+
+```bash
+uv sync --frozen
+uv run pytest tests/ -q
+uv run ruff check custom_components/
+uv run ruff format --check custom_components/
+uv run mypy custom_components/intellicenter/
+uv run bandit -r custom_components/intellicenter/ -ll
+```
+
+Expected: the complete existing suite passes and all static/security gates are clean. Stop and diagnose any baseline failure before feature edits.
+
+---
+
+### Task 2: Correct the pyintellicenter parent/row group model
+
+**Files:**
+- Create: `tests/test_circuit_group.py`
+- Modify: `src/pyintellicenter/_mixins/circuit_group.py`
+- Modify: `docs/API.md`
+
+**Interfaces:**
+- Consumes: `PoolModel`, `PoolObject`, `CIRCUIT_TYPE`, `CIRCGRP_TYPE`, `PARENT_ATTR`, `CIRCUIT_ATTR`, `LISTORD_ATTR`.
+- Produces:
+  - `get_circuit_groups() -> list[PoolObject]`
+  - `get_circuit_group_members(parent_objnam: str) -> list[PoolObject]`
+  - `get_circuits_in_group(group_or_row_objnam: str) -> list[PoolObject]`
+  - `circuit_group_has_color_lights(parent_objnam: str) -> bool`
+  - `get_color_light_groups() -> list[PoolObject]`
+
+- [ ] **Step 1: Write failing real-topology and compatibility tests**
+
+Create focused tests with these exact assertions:
+
+```python
+def add_real_group(model: PoolModel) -> None:
+    model.add_object("GROUP", {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO"})
+    model.add_object(
+        "ROW_B",
+        {"OBJTYP": "CIRCGRP", "PARENT": "GROUP", "CIRCUIT": "CHILD_B", "LISTORD": "2"},
+    )
+    model.add_object(
+        "ROW_BAD",
+        {"OBJTYP": "CIRCGRP", "PARENT": "GROUP", "CIRCUIT": "MISSING", "LISTORD": "bad"},
+    )
+    model.add_object(
+        "ROW_A",
+        {"OBJTYP": "CIRCGRP", "PARENT": "GROUP", "CIRCUIT": "CHILD_A", "LISTORD": "1"},
+    )
+    model.add_object("CHILD_A", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    model.add_object("CHILD_B", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+
+
+def test_real_group_enumerates_parent_not_members(controller: ICModelController) -> None:
+    add_real_group(controller.model)
+    controller.model.add_object(
+        "PLAIN_PARENT", {"OBJTYP": "CIRCUIT", "SUBTYP": "CIRCGRP"}
+    )
+    controller.model.add_object(
+        "ORPHAN", {"OBJTYP": "CIRCGRP", "CIRCUIT": "CHILD_A"}
+    )
+
+    assert [obj.objnam for obj in controller.get_circuit_groups()] == [
+        "GROUP",
+        "PLAIN_PARENT",
+    ]
+
+
+def test_members_are_numeric_order_then_stable_malformed_tail(
+    controller: ICModelController,
+) -> None:
+    add_real_group(controller.model)
+    assert [obj.objnam for obj in controller.get_circuit_group_members("GROUP")] == [
+        "ROW_A",
+        "ROW_B",
+        "ROW_BAD",
+    ]
+
+
+def test_parent_and_real_row_resolve_ordered_sibling_children(
+    controller: ICModelController,
+) -> None:
+    add_real_group(controller.model)
+    assert [obj.objnam for obj in controller.get_circuits_in_group("GROUP")] == [
+        "CHILD_A",
+        "CHILD_B",
+    ]
+    assert [obj.objnam for obj in controller.get_circuits_in_group("ROW_B")] == [
+        "CHILD_A",
+        "CHILD_B",
+    ]
+
+
+def test_legacy_standalone_row_resolves_directly_but_is_never_enumerated(
+    controller: ICModelController,
+) -> None:
+    controller.model.add_object("A", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    controller.model.add_object("B", {"OBJTYP": "CIRCUIT", "SUBTYP": "LIGHT"})
+    controller.model.add_object(
+        "LEGACY", {"OBJTYP": "CIRCGRP", "CIRCUIT": "A B"}
+    )
+
+    assert [obj.objnam for obj in controller.get_circuits_in_group("LEGACY")] == [
+        "A",
+        "B",
+    ]
+    assert controller.get_circuit_groups() == []
+    assert controller.get_color_light_groups() == []
+
+
+def test_color_group_results_are_real_parents(controller: ICModelController) -> None:
+    add_real_group(controller.model)
+    assert controller.circuit_group_has_color_lights("GROUP") is True
+    assert [obj.objnam for obj in controller.get_color_light_groups()] == ["GROUP"]
+```
+
+Add cases for missing parent, wrong parent type/subtype, missing/non-string references, missing children, nonnumeric/negative `LISTORD`, duplicate valid orders, multiple malformed orders inserted in reverse object-name order, and a group containing only non-color lights. Missing references are skipped by the read helper; strict command eligibility is tested separately.
+
+- [ ] **Step 2: Run the focused file and verify red**
+
+Run:
+
+```bash
+uv run pytest tests/test_circuit_group.py -v
+```
+
+Expected: failures show the current implementation returns membership rows as groups and does not aggregate sibling rows.
+
+- [ ] **Step 3: Implement the minimal corrected helpers**
+
+Use a private parent subtype set and a total numeric/object-name sort. Negative,
+missing, and malformed values sort after valid orders; duplicate valid orders and
+multiple malformed rows use `objnam` as the deterministic tiebreaker rather than
+depending on model insertion order:
+
+```python
+_GROUP_PARENT_SUBTYPES = frozenset({"CIRCGRP", "LITSHO"})
+
+
+def _member_order(member: PoolObject) -> tuple[int, int, str]:
+    value = member[LISTORD_ATTR]
+    try:
+        order = int(value)
+    except (TypeError, ValueError):
+        return (1, 0, member.objnam)
+    if order < 0:
+        return (1, 0, member.objnam)
+    return (0, order, member.objnam)
+```
+
+Implement enumeration and membership exactly as follows:
+
+```python
+def get_circuit_groups(self) -> list[PoolObject]:
+    return [
+        obj
+        for obj in self._model
+        if obj.objtype == CIRCUIT_TYPE and obj.subtype in _GROUP_PARENT_SUBTYPES
+    ]
+
+
+def get_circuit_group_members(self, parent_objnam: str) -> list[PoolObject]:
+    return sorted(
+        (
+            obj
+            for obj in self._model.get_by_type(CIRCGRP_TYPE)
+            if obj[PARENT_ATTR] == parent_objnam
+        ),
+        key=_member_order,
+    )
+```
+
+For `get_circuits_in_group()`, branch on the addressed object:
+
+1. A real parent `CIRCUIT` uses its ordered membership rows.
+2. A real `CIRCGRP` row with a non-empty string `PARENT` resolves that parent and all siblings.
+3. A standalone legacy `CIRCGRP` row without `PARENT` splits its string `CIRCUIT` value and resolves existing references in listed order.
+4. Every other shape returns `[]`.
+
+For real rows, accept only a singular non-whitespace string `CIRCUIT`; skip a missing child safely. `circuit_group_has_color_lights()` remains an `any(child.supports_color_effects)` read query. `get_color_light_groups()` filters only the real parents returned by `get_circuit_groups()`.
+
+- [ ] **Step 4: Update the API reference with the corrected object roles**
+
+Replace the circuit-group example with:
+
+```python
+# Parent CIRCUIT objects are groups; CIRCGRP objects are membership rows.
+groups = controller.get_circuit_groups()
+rows = controller.get_circuit_group_members(groups[0].objnam)
+children = controller.get_circuits_in_group(groups[0].objnam)
+color_groups = controller.get_color_light_groups()
+```
+
+State explicitly that the legacy standalone row behavior exists only for direct `get_circuits_in_group()` compatibility and is not group enumeration.
+
+- [ ] **Step 5: Run the focused and existing controller tests green**
+
+Run:
+
+```bash
+uv run pytest tests/test_circuit_group.py tests/test_controller.py -q
+uv run ruff check src/pyintellicenter/_mixins/circuit_group.py tests/test_circuit_group.py
+uv run ruff format --check src/pyintellicenter/_mixins/circuit_group.py tests/test_circuit_group.py
+```
+
+Expected: all pass. Replace the obsolete row-enumeration assertions in `tests/test_controller.py`; do not preserve two contradictory group contracts.
+
+- [ ] **Step 6: Commit the model correction**
+
+```bash
+git add src/pyintellicenter/_mixins/circuit_group.py tests/test_circuit_group.py tests/test_controller.py docs/API.md
+git commit -m "fix: model circuit group parents and membership rows"
+```
+
+---
+
+### Task 3: Add connection-owned raw observer sequencing, split dispatch timing/watermark hooks, and generation-bound close signaling
+
+**Files:**
+- Modify: `src/pyintellicenter/connection.py`
+- Modify: `tests/test_connection.py`
+
+**Interfaces:**
+- Consumes: the existing primary `NotificationCallback` queue.
+- Produces:
+  - `NotificationObserver = Callable[[int, dict[str, Any]], None]` (typing-only alias)
+  - `BeforeWriteCallback = Callable[[int, float], None]` (private typing alias for pre-send sequence plus monotonic dispatch-start time)
+  - `AfterWriteCallback = Callable[[int], None]` (private typing alias for the causal post-send notification watermark)
+  - `ICConnection.add_notification_observer(observer: NotificationObserver) -> Callable[[], None]`
+  - `ICConnection.send_request(..., _before_write_callback: BeforeWriteCallback | None = None, _after_write_callback: AfterWriteCallback | None = None) -> dict[str, Any]`
+  - `ICConnection._capture_closed_future() -> asyncio.Future[None]` (internal, one-shot, bound synchronously to the current connection generation)
+- Invariant: one sequence state belongs to the exact `ICConnection`, survives protocol transport replacement, and increments before raw observer fanout and the primary callback queue. While holding `_request_lock`, the before-write callback receives `(current_sequence, asyncio.get_running_loop().time())` immediately before the TCP write or WebSocket send invocation and starts the deadline. The after-write callback receives the then-current sequence immediately after synchronous TCP `transport.write()` returns or awaited WebSocket `send()` completes; that second value, not the pre-send sequence, is the onset watermark. Later queue consumption never reinvokes raw observers. Every `asyncio.timeout_at()`/`call_at()` deadline uses the same event-loop clock domain.
+
+- [ ] **Step 1: Write failing observer and close-signal tests**
+
+Add tests that prove all of these behaviors:
+
+```python
+@pytest.mark.asyncio
+async def test_notification_observer_does_not_replace_primary_callback() -> None:
+    primary = MagicMock()
+    observer = MagicMock()
+    connection = ICConnection("host")
+    protocol = ICProtocol(
+        notification_callback=primary,
+        notification_observer_state=connection._notification_observer_state,
+    )
+    protocol.connection_made(MagicMock())
+    connection._protocol = protocol
+
+    remove = connection.add_notification_observer(observer)
+    message = {"command": "NotifyList", "objectList": []}
+    protocol._handle_notification(message)
+
+    observer.assert_called_once_with(1, message)
+    await asyncio.sleep(0)
+    primary.assert_called_once_with(message)
+    remove()
+
+
+@pytest.mark.asyncio
+async def test_observer_added_after_enqueue_never_sees_stale_queued_frame() -> None:
+    primary = MagicMock()
+    connection = ICConnection("host")
+    protocol = ICProtocol(
+        notification_callback=primary,
+        notification_observer_state=connection._notification_observer_state,
+    )
+    protocol.connection_made(MagicMock())
+    connection._protocol = protocol
+    stale = {"command": "NotifyList", "objectList": [{"objnam": "OLD", "params": {}}]}
+    fresh = {"command": "NotifyList", "objectList": [{"objnam": "NEW", "params": {}}]}
+    protocol._handle_notification(stale)
+
+    observer = MagicMock()
+    connection.add_notification_observer(observer)
+    await asyncio.sleep(0)
+    observer.assert_not_called()
+
+    protocol._handle_notification(fresh)
+    observer.assert_called_once_with(2, fresh)
+```
+
+Also assert removal is idempotent, one failing observer does not block another observer or the primary callback, an observer works when the primary callback is `None`, sequences increase across every accepted notification, replacing a TCP/WebSocket protocol on the same `ICConnection` does not reset the sequence, and both transports receive the same connection-owned observer state. For closure generations, capture the future synchronously while connected and prove it completes for unexpected disconnect, explicit `disconnect()`, `_abort_connection()`, and failed connect. Then reconnect the same `ICConnection` immediately: the old captured future must remain done, `_capture_closed_future()` must return a distinct pending future for the new generation, and no late waiter may miss the old close.
+
+Add transport-level unit tests whose fake event-loop clock and fake writer record event order. Direct access to the internal `connection._request_lock` is intentional in this substrate test; coordinate with `asyncio.Event` barriers, never timing sleeps. The test must (1) acquire that lock, (2) start a request task, (3) enqueue an unrelated notification and record its sequence while the request is blocked, (4) release the lock, (5) await the request, and (6) assert the pre-send sequence is at least that notification's sequence. For TCP, `_before_write_callback(sequence, started_at)` must run while `_request_lock` is owned immediately before `transport.write(packet)`, and `_after_write_callback(sequence)` immediately after it returns with no scheduling yield; a later notification gets a strictly greater sequence than the post-write watermark. For WebSocket, the before hook runs immediately before invocation of `ws.send(packet)` and the after hook only after the awaited send completes. Use barriers inside fake `ws.send()` to enqueue a notification during its suspension and prove its sequence is greater than the pre-send sequence but less than or equal to the after-send watermark. Assert `started_at` is the running loop's clock value sampled at the pre-send point. Deliberately offset a monkeypatched `time.monotonic()` and prove it has no effect on `timeout_at()` boundaries.
+
+For both transports, add a before-callback-that-raises case proving `transport.write()`/`ws.send()` and the after callback are never invoked, the pending request ID/future is cleared without an unhandled-future warning, `_request_lock` is released, and the next request succeeds. Add an after-callback-that-raises case proving the transport was invoked exactly once, pending state and lock still clean up, and the next request succeeds; this is a post-initiation failure, never evidence that no write occurred.
+
+- [ ] **Step 2: Run focused tests and verify red**
+
+```bash
+uv run pytest tests/test_connection.py -k "observer or closed or before_write or after_write or watermark" -v
+```
+
+Expected: sequenced observers, the split write callbacks, and the generation-bound close future are missing.
+
+- [ ] **Step 3: Implement additive enqueue-time fanout**
+
+Add a private `_NotificationObserverState` owned by `ICConnection` with `sequence: int = 0` and one mutable observer list. Pass that exact state into each newly created `ICProtocol`/`ICWebSocketTransport`; never initialize or reset sequence in a transport. At the start of `_handle_notification()`, before checking the primary callback or queue, increment the shared sequence and execute a tuple snapshot:
+
+```python
+state = self._notification_observer_state
+sequence = state.sequence = state.sequence + 1
+for observer in tuple(state.observers):
+    try:
+        observer(sequence, msg)
+    except Exception:
+        _LOGGER.exception("Error in notification observer")
+```
+
+Then run the existing primary-callback queue path unchanged. `add_notification_observer()` appends once to the connection state and returns an idempotent closure that removes only that observer. This ordering is the stale-frame guarantee: old queued frames are delivered only by `_notification_consumer()`, which invokes the primary callback and never re-runs observer fanout.
+
+- [ ] **Step 4: Add separate pre-send deadline and post-send watermark hooks**
+
+Make `_before_write_callback` and `_after_write_callback` private named keyword-only parameters at every internal `send_request()` layer so neither can leak into the serialized protocol object. Sample `started_at = asyncio.get_running_loop().time()` and read the connection state's current sequence only after acquiring `_request_lock`. Put both hooks inside the existing pending-request `try/finally`, after pending state is installed.
+
+In TCP, invoke `_before_write_callback(sequence, started_at)` synchronously immediately before `self._transport.write(packet)`, then read the sequence again and invoke `_after_write_callback(sequence)` synchronously immediately after `write()` returns. In WebSocket, invoke the before hook immediately before `await self._ws.send(packet)`, then read the sequence again and invoke the after hook only after that await returns. A before-hook exception prevents transport initiation; an after-hook exception is post-initiation. The normal finalizer clears pending state in either case. The pre-send time starts the deadline and intentionally bounds a stalled WebSocket send. The post-send sequence is the conservative causal onset watermark and intentionally excludes any frame processed while the WebSocket send await was suspended. Do not record the time before request-lock acquisition, and never mix it with `time.monotonic()`; compute action and observation deadlines with the running loop clock and enforce them with `asyncio.timeout_at()` in that same domain.
+
+- [ ] **Step 5: Implement a one-shot per-generation close future without changing public disconnect callbacks**
+
+Store `self._closed_future: asyncio.Future[None] | None`. Immediately before each real connect attempt, create a fresh future from the running loop and never clear or reuse an older one. Complete the current future idempotently on failed connect, `_on_disconnect()`, `_abort_connection()`, and explicit `disconnect()`. Add:
+
+```python
+def _capture_closed_future(self) -> asyncio.Future[None]:
+    """Return the one-shot close future for the current live generation."""
+    future = self._closed_future
+    if future is None or not self.connected:
+        raise ICConnectionError("Connection is not live")
+    return future
+```
+
+The action captures this object synchronously before any scheduling yield and never cancels the shared future when it stops racing it. A same-instance reconnect replaces only `self._closed_future`; already captured generation futures remain completed forever. Do not make a deliberate `disconnect()` invoke the user's existing unexpected-disconnect callback; the future is a separate internal lifecycle signal.
+
+- [ ] **Step 6: Run connection regression gates green**
+
+```bash
+uv run pytest tests/test_connection.py tests/test_dead_link_detection.py tests/test_reconnect_hardening.py -q
+uv run ruff check src/pyintellicenter/connection.py tests/test_connection.py
+uv run ruff format --check src/pyintellicenter/connection.py tests/test_connection.py
+uv run mypy src/pyintellicenter/connection.py
+```
+
+Expected: observer tests and every existing connection/reconnect test pass.
+
+- [ ] **Step 7: Commit the observer substrate**
+
+```bash
+git add src/pyintellicenter/connection.py tests/test_connection.py
+git commit -m "feat: add sequenced notification observers"
+```
+
+---
+
+### Task 4: Establish a fail-fast exclusive mutation lifecycle and bind requests to one connection
+
+**Files:**
+- Modify: `src/pyintellicenter/controller.py`
+- Modify: `src/pyintellicenter/_mixins/_base.py`
+- Modify: `tests/test_controller.py`
+
+**Interfaces:**
+- Consumes: `ICConnection.send_request()` and the existing `_coalesce_lock`.
+- Produces:
+  - `ICBaseController._mutation_lock: asyncio.Lock`
+  - `ICBaseController._mutation_owner: asyncio.Task[Any] | None` plus an internal owner-recording lifecycle context manager
+  - `ICBaseController._light_group_mutation_pending: bool` plus a Sync-only context that marks pending before it waits for already-started writers
+  - `ICBaseController._light_group_mutation_lease: object | None`, a fresh opaque identity yielded only by the active Sync context
+  - `_send_cmd_on_connection_unlocked(connection: ICConnection, cmd: str, extra: dict[str, Any] | None = None, *, _mutation_lease: object, request_timeout: float | None = None, _before_write_callback: BeforeWriteCallback | None = None, _after_write_callback: AfterWriteCallback | None = None) -> dict[str, Any]`
+- Invariant: public `send_cmd()` acquires `_mutation_lock` whenever `cmd.casefold() == "setparamlist"`; `request_changes()` and `_flush_pending_changes()` inherit that coverage. Sync marks `_light_group_mutation_pending` before awaiting the same lock. Object writes already started before that mark drain first; every later public object write and second Sync fails immediately with an ordinary `ICError` rather than remaining queued through the long lifecycle. The captured-connection primitive is private and requires identity with the one active opaque lease plus pending/locked/connection checks. The owner may explicitly delegate one request task by passing that lease; a child task is never mistaken for the lock-owning task, and no caller can use a missing, stale, or merely equal token.
+
+- [ ] **Step 1: Write failing connection-identity and mutation-order tests**
+
+Add tests proving:
+
+1. With the exact active lease, `_send_cmd_on_connection_unlocked(old_connection, ...)` raises `ICConnectionError` if `self._connection is not old_connection`, without sending on either connection.
+2. Public raw `send_cmd("SETPARAMLIST", ...)`, `send_cmd("SetParamList", ...)`, `send_cmd("setparamlist", ...)`, and `send_cmd("sEtPaRaMlIsT", ...)` each fail immediately with an ordinary `ICError` and perform no I/O while `_light_group_mutation_pending` is true.
+3. A direct `request_changes()` and coalesced `set_circuit_state()` propagate that busy failure. Both `_queue_property_change()` and `_queue_batch_changes()` check pending synchronously before creating/appending a request or mutating `_pending_changes`; a later convenience writer therefore fails before it can wait on `_coalesce_lock`, and pending changes/futures are not leaked or silently replayed later.
+4. A public writer that acquired the lifecycle before Sync began completes normally; Sync sets pending before waiting, drains that already-started writer, and then acquires the lifecycle. No writer that starts after the pending mark can join the queue.
+5. Read-only `send_cmd("GetParamList", ...)` does not take the mutation lock and remains governed by the connection request lock.
+6. Two ordinary writes outside a pending Sync retain the existing batching and request-order behavior.
+7. Calling `_send_cmd_on_connection_unlocked()` without the lifecycle lock/pending flag or with a missing, wrong, copied, or stale lease fails before network I/O; the explicitly delegated state-changing child task succeeds only with the exact active lease. A source scan finds no production caller except `run_light_group_sync()`.
+8. Directly invoking a separately constructed `ICConnection.send_request()` is demonstrably outside this controller lock and is documented as such rather than claimed safe.
+9. Cancellation while Sync is waiting for an already-started writer clears `_light_group_mutation_pending`; cancellation after ownership cancels/awaits every delegated child before invalidating the lease, then releases lease, owner, lock, and pending state exactly once.
+10. Give each `_PendingRequest` an owned deep-enough copy of its proposed object/attribute changes and pass the initiating request into `_flush_pending_changes(owner_request)` from both queue helpers. When busy failure reaches the flush, every future captured in that flush completes with the same `ICError`, pending collections remain empty, and nothing is replayed after Sync. Catch `ICError` plus `OSError`, not only selected subclasses. If the flush-owner is cancelled after it detached the batch, cancel/consume the owner's own future, complete only captured peer futures with a stable ordinary `ICError` that states delivery is unknown, then re-raise the owner's `CancelledError`; never requeue/retry a possibly dispatched batch. Barrier-test at least two coalesced callers for both busy and post-initiation cancellation paths and assert no orphan-future warning.
+11. Hold `_coalesce_lock`, mark Sync pending, and invoke each queue helper. Each must raise before touching `_pending_changes`/`_pending_requests`, complete before either lock is released, and leave nothing that can be sent afterward. Separately, admit a second request before the pending mark while another flush holds `_coalesce_lock`, cancel it before detachment, and prove cancellation synchronously removes that exact request, rebuilds `_pending_changes` in original admission order from surviving request-owned changes, consumes its future, and prevents its value from appearing in any post-Sync batch. Cover same-object/same-attribute latest-wins rollback as well as distinct objects.
+
+Use `asyncio.Event` barriers rather than sleeps for acquisition and fail-fast assertions. Explicitly prove the busy public writer task completes with `ICError` before the held lifecycle is released; a test that merely observes no transport call is insufficient because it could hide unintended queuing.
+
+- [ ] **Step 2: Run focused tests and verify red**
+
+```bash
+uv run pytest tests/test_controller.py -k "mutation_lifecycle or send_cmd_on_connection" -v
+```
+
+Expected: the new lock/helper do not exist and supported object mutations send immediately.
+
+- [ ] **Step 3: Add the Sync-only captured-connection primitive without routing public sends through it**
+
+Initialize `_mutation_lock`, `_mutation_owner = None`, `_light_group_mutation_pending = False`, and `_light_group_mutation_lease = None` in `ICBaseController.__init__()`. Add a normal private async context manager that acquires the lock, records `asyncio.current_task()` as owner, and clears ownership before releasing in `finally`. Add a separate Sync-only context manager that rejects if pending is already true, sets pending synchronously before awaiting the lock, records ownership after acquisition, creates/stores one fresh opaque `object()` lease, and yields that exact lease. It clears pending on acquisition failure/cancellation; after acquisition its caller must cancel/await delegated children before context exit, which invalidates the lease before clearing owner and releasing the lock. Keep public `send_cmd()` on a normal current-connection request path. Implement the separate Sync-only `_send_cmd_on_connection_unlocked()` with the same `_RequestContext` metrics and `ICResponseError -> ICCommandError` translation, but first require `self._light_group_mutation_pending`, `self._mutation_lock.locked()`, and `self._light_group_mutation_lease is _mutation_lease`, then verify identity and connectivity before sending:
+
+```python
+if self._connection is not connection or not connection.connected:
+    raise ICConnectionError("Connection changed or is not connected")
+```
+
+Do not expose the lease, either write callback, or timeout passthrough on public `send_cmd()`. Forward the exact active lease, both hooks, and real `ICConnection.send_request(request_timeout=...)` parameter only through the Sync-only helper and connection API, never inside the serialized `extra`. This lets the owner explicitly authorize its one child request task without weakening the lifecycle boundary and guarantees every lifecycle request uses the same instance and response bound even if reconnection replaces `self._connection`.
+
+- [ ] **Step 4: Apply the mutation lock without creating re-entrant acquisition**
+
+Public `send_cmd()` checks `_light_group_mutation_pending` and raises an ordinary `ICError("Color Sync mutation lifecycle is in progress")` before I/O whenever `cmd.casefold() == "setparamlist"`; otherwise it wraps that writer's normal request path in the owner-recording mutation context. The check and uncontended lock acquisition contain no intervening event-loop yield. Leave `request_changes()` routing unchanged.
+
+At the very start of both `_queue_property_change()` and `_queue_batch_changes()`, before constructing a future or changing either pending collection, perform the same synchronous pending check and raise the same busy `ICError`. Extend `_PendingRequest` with its normalized owned changes. Keep the request list as the attribution source of truth and rebuild `_pending_changes` by replaying surviving request changes in admission order whenever a still-pending caller is canceled; this preserves latest-wins semantics without retaining the canceled override.
+
+Wrap each queue helper's flush/future waits in `CancelledError` cleanup. If its request is still present in `self._pending_requests`, synchronously remove it, rebuild the aggregate without any scheduling yield, cancel/consume its future, and re-raise. If an active flush already detached the request, cancel/consume only that caller's future and let the active flush finish its possibly dispatched batch and resolve peers; never requeue it. This pre-detachment path is part of Color Sync isolation because otherwise a canceled admitted mutation can survive the pending boundary and replay after the long lifecycle.
+
+Pass each queue helper's initiating `_PendingRequest` to `_flush_pending_changes()`. Broaden its error fanout to catch `ICError` and `OSError`, setting that exception on every future captured by the flush so fail-fast busy behavior cannot strand coalesced callers. Handle `CancelledError` separately after capture: cancel/consume the initiating future, resolve only captured peer futures with a stable uncertainty `ICError`, then re-raise cancellation, with no requeue or retry. The Sync helper enters `_light_group_mutation_lifecycle() as mutation_lease` across its complete lifecycle and passes that lease to `_send_cmd_on_connection_unlocked()` for both fresh preflights, subscription batches, the single delegated write task, and final read.
+
+Document the boundary on `send_cmd()`: case-insensitive `SetParamList` is the only object-writer command supported by this controller. Same-controller writers invoked after Color Sync begins fail fast and must be retried deliberately; they are never delayed and replayed after Sync. Read-only commands continue. A caller using an arbitrary undocumented vendor command through public `send_cmd()` or a separately constructed raw `ICConnection` receives no mutation-isolation guarantee.
+
+Declare the exact host members in `_mixins/_base.py` under `TYPE_CHECKING`:
+
+```python
+_connection: ICConnection | None
+_mutation_lock: asyncio.Lock
+_mutation_owner: asyncio.Task[Any] | None
+_light_group_mutation_pending: bool
+_light_group_mutation_lease: object | None
+
+def _mutation_lifecycle(self) -> AbstractAsyncContextManager[None]:
+    raise NotImplementedError
+
+def _light_group_mutation_lifecycle(self) -> AbstractAsyncContextManager[object]:
+    raise NotImplementedError
+
+@property
+def transport(self) -> TransportType:
+    raise NotImplementedError
+
+async def _send_cmd_on_connection_unlocked(
+    self,
+    connection: ICConnection,
+    cmd: str,
+    extra: dict[str, Any] | None = None,
+    *,
+    _mutation_lease: object,
+    request_timeout: float | None = None,
+    _before_write_callback: BeforeWriteCallback | None = None,
+    _after_write_callback: AfterWriteCallback | None = None,
+) -> dict[str, Any]:
+    raise NotImplementedError
+```
+
+- [ ] **Step 5: Run controller/coalescing/type gates green**
+
+```bash
+uv run pytest tests/test_controller.py tests/test_controller_namespace_compat.py tests/test_typing_public_api.py -q
+uv run ruff check src/pyintellicenter/controller.py src/pyintellicenter/_mixins/_base.py tests/test_controller.py
+uv run ruff format --check src/pyintellicenter/controller.py src/pyintellicenter/_mixins/_base.py tests/test_controller.py
+uv run mypy src
+```
+
+Expected: all pass; type checking still sees `ICModelController` as concrete.
+
+Also run:
+
+```bash
+rg -n '_send_cmd_on_connection_unlocked\(' src/pyintellicenter
+```
+
+Expected: only the method declaration/definition and the dedicated Color Sync mixin call sites; public `send_cmd()`, `request_changes()`, and coalescing never call the unlocked escape hatch.
+
+- [ ] **Step 6: Commit the mutation boundary**
+
+```bash
+git add src/pyintellicenter/controller.py src/pyintellicenter/_mixins/_base.py tests/test_controller.py
+git commit -m "fix: isolate controller mutation lifecycles"
+```
+
+---
+
+### Task 5: Implement the production-shaped Color Sync lifecycle
+
+**Files:**
+- Create: `src/pyintellicenter/_light_group.py`
+- Create: `tests/test_light_group_sync.py`
+- Modify: `src/pyintellicenter/_mixins/circuit_group.py`
+- Modify: `src/pyintellicenter/exceptions.py`
+- Modify: `src/pyintellicenter/__init__.py`
+- Modify: `tests/test_typing_public_api.py`
+
+**Interfaces:**
+- Consumes: corrected group helpers, sequenced observer/pre-send deadline/post-send watermark hooks, `ICConnection._capture_closed_future()`, `_light_group_mutation_lifecycle()`, `_send_cmd_on_connection_unlocked()`, and the existing controller `MAX_ATTRIBUTES_PER_QUERY = 50`.
+- Produces:
+  - `ICLightGroupError(ICError)` carrying `phase`, `dispatch_started`, `response_received`, `acknowledged`, and `onset_seen` for every failure after write/send initiation.
+  - `run_light_group_sync(group_objnam: str) -> dict[str, Any]`.
+  - Private `LightGroupTopology`, `LightGroupProjection`, `LightGroupSyncTracker`, `build_projection_query()`, `build_subscription_batches()`, `parse_projection()`, `validate_initial_projection()`, and `validate_final_projection()` in `_light_group.py`.
+- Tracker wakeups: a one-shot first-failure signal set synchronously by the raw observer, a one-shot `write_started` signal set only after the pre-send hook's validation succeeds, a separate one-shot `watermark_ready` signal set by the post-send hook, and monotonic onset/terminal signals. Every lifecycle await races these signals with the captured generation-close future instead of discovering violations only at a later deadline.
+- Constants: `SUBSCRIPTION_SETTLE_SECONDS = 1.0`, `SYNC_ACTION_DEADLINE_SECONDS = 60.0`, `SYNC_POST_TERMINAL_OBSERVATION_SECONDS = 60.0`, `MAX_PREBASELINE_NOTIFICATIONS = 1000`, action flags `("SYNC", "SET", "SWIM")`, supported firmware exact raw token `"1.064"`, supported action-child subtype `"GLOW"`, and supported action-child count `2`. The one-second settle is the value exercised by every accepted sender-side run, not a generalized firmware guarantee; firmware comparison deliberately does not trim or normalize an unobserved representation.
+
+- [ ] **Step 1: Build a deterministic scripted-connection test fixture**
+
+In `tests/test_light_group_sync.py`, create a `ScriptedConnection` that records `(command, kwargs)` calls, stores sequenced observers, returns independently supplied initial/settled/final wildcard `GetParamList` projections plus independently supplied `RequestParamList` batch initializations, and invokes both write callbacks at the scripted transport boundaries. It can suspend WebSocket send between callbacks and emit a sequenced frame in that gap. It must also emit a notification in the same scripted transport turn as the first response, while a request is blocked, during the one-second settle, before acknowledgement, during post-terminal observation, and during the final read; it returns a synchronously captured one-shot close future and can complete closure, tracker failure, and a request response in the same event-loop turn. Build a model/system-info pair for raw firmware token `1.064` with one `SYSTEM`, one `CIRCUIT/LITSHO` target, exactly two ordered `CIRCGRP` rows, exactly two distinct `CIRCUIT/GLOW` children, one unrelated parentless ordinary circuit with unsupported `PARENT`/`USE`, one other group parent, and one row belonging to that other group.
+
+The fake must not infer success or advance clocks implicitly. Its scripted projections contain every mandatory field the production parser requires: system `OBJTYP/VER/SERVICE`; every `CIRCUIT` object's `OBJTYP/SUBTYP/STATUS`; `SYNC/SET/SWIM` on every real group parent; and every `CIRCGRP` row's `OBJTYP/PARENT/CIRCUIT/LISTORD`. Circuit `PARENT`/`USE` and row `USE` are optional normalized fields. Happy fixtures deliberately mix omission, `key == value`, and `"00000"` null-reference representations on not-applicable ordinary-circuit fields and on membership-row `USE`, while retaining real values where the firmware supplies them. Exercise those row-`USE` spellings independently in the first/second/final wildcard responses, `RequestParamList` initialization responses, and `NotifyList` frames. Missing-field tests remove mandatory fields deliberately. Row `PARENT` has explicit missing/key-echo/`"00000"` negatives in full wildcard and subscription-initialization responses; a partial `NotifyList` may omit it, but if present its key-echo/`"00000"` spellings fail. This proves it is never normalized as optional without misreading partial updates.
+
+- [ ] **Step 2: Write the failing happy-path matrix**
+
+Parameterize TCP/WebSocket and uniform `OFF`/`ON` baselines. For `OFF`, emit parent `SYNC=ON`, target parent/child statuses in varying leading order, then `SYNC=OFF`; for `ON`, emit only `SYNC=ON` and `SYNC=OFF`. Monkeypatch the settle and post-terminal observation constants to `0` in fast matrix tests. Separate deterministic clock tests assert the production deadline is exactly `before_write_time + 60.0` and the final read is not eligible until exactly `terminal_time + 60.0`; never make the suite sleep for a real minute.
+
+Assert:
+
+```python
+scripted_ack = {
+    "messageID": "4",
+    "response": "200",
+    "opaqueVendorField": {"kept": True},
+}
+connection.action_response = scripted_ack
+ack = await controller.run_light_group_sync("GROUP")
+assert ack == scripted_ack
+assert [call.command for call in connection.calls] == [
+    "GetParamList",
+    "RequestParamList",
+    "GetParamList",
+    "SetParamList",
+    "GetParamList",
+]
+assert connection.calls[3].kwargs == {
+    "objectList": [{"objnam": "GROUP", "params": {"SYNC": "ON"}}]
+}
+assert connection.observers == []
+```
+
+Also assert each snapshot call is the exact wildcard request with `condition=""`, one `objnam="INCR"` entry, and the fixed union of only `OBJTYP`, `SUBTYP`, `PARENT`, `CIRCUIT`, `LISTORD`, `STATUS`, `USE`, `SYNC`, `SET`, `SWIM`, `VER`, and `SERVICE`. Its 12-key request is below `MAX_ATTRIBUTES_PER_QUERY` regardless of installation size. Assert every exact-object subscription batch is at most 50 aggregate keys and the batches cover every required object/key exactly once. Assert `request_changes` and `_queue_property_change` were not called, and the helper never writes `ACT`, `STATUS`, `SET`, or `SWIM`.
+
+- [ ] **Step 3: Write failing pre-I/O and pre-write rejection tests**
+
+Before any network I/O, reject with `ValueError` when cached firmware is absent/not the exact raw token `1.064`, the target is missing, is a membership row, is `CIRCUIT/SUBTYP=CIRCGRP`, is an ordinary light, has one/three/zero rows rather than exactly two, has duplicate child references, has a missing child, resolves the same child twice, or contains any child whose object type/subtype is not exact `CIRCUIT/GLOW`. Explicitly test raw variants such as `"IC: 1.064"`, `"1.064 "`, and `"1.064-build"` that a display/parser path might interpret semantically; the writer still rejects them because no state-changing capture covers those wire representations. Do not use `parse_ic_version()` for this writer gate.
+
+After the first fresh `GetParamList` but before `SetParamList`, reject with an ordinary pre-dispatch `ICError` (never `ICLightGroupError`) when:
+
+- zero or multiple systems appear;
+- `VER` is not exactly `1.064` or `SERVICE` is not exactly `AUTO`;
+- target/member/child object type or subtype mismatches the cached topology or child count is not exactly two;
+- target statuses are mixed, missing, or noncanonical;
+- any group action flag is missing or not `OFF`;
+- any `CIRCUIT` is missing mandatory `OBJTYP`/`SUBTYP`/`STATUS`, any row is missing mandatory `OBJTYP`/`PARENT`/`CIRCUIT`/`LISTORD`, or the wildcard response omits/duplicates a required object or reveals fresh topology different from the cached model; optional circuit `PARENT`/`USE` and row `USE` may be absent/key-echo/null-reference and normalize to one absence value. Parameterize first, second, and final wildcard responses so row `USE` omission/key-echo/`"00000"` normalize equal while a real value is preserved and compared; at each gate, a row `PARENT` that is missing, key-echoed, or `"00000"` fails as mandatory;
+- any wildcard object entry is malformed, duplicated, lacks a nonempty string `objnam`, or lacks a real non-placeholder string `OBJTYP`; in particular, reject an unknown entry whose type is absent/ambiguous because relevance cannot be excluded, while a well-formed explicit unrelated type may remain outside the projection;
+- `RequestParamList` rejects any exact-object subscription batch, or its initialization `objectList` is missing/non-list/empty/duplicate/unexpected, omits or placeholders a mandatory key, contains a malformed optional value, fails required coverage, or differs from the normalized baseline slice; absence/key-echo/null-reference is accepted only for the declared optional fields. Explicit row fixtures prove `USE` omission/key-echo/`"00000"` normalize equal and a real value is retained, while row `PARENT` missing/key-echo/`"00000"` is rejected;
+- a projected notification changes any baseline value between the first read and write, including a value that changes back before the second read;
+- after the one-second settle, the second complete fresh projection differs from the first in any field, including a one-field mismatch with no notification.
+
+Every case asserts no `SetParamList` call and no `ICLightGroupError`. Assert the exact second-preflight mismatch raises ordinary `ICError` with a stable preflight-mismatch message. Add pre-baseline tests proving the observer is already installed when the first request starts: a differing notification accepted after the first response frame but before its awaiting task resumes is buffered and rejects after baseline installation; an equal repeated value is harmless; more than `MAX_PREBASELINE_NOTIFICATIONS` fails closed without dropping evidence. A notification that introduces an unknown `CIRCUIT`, `CIRCGRP`, or `SYSTEM` (or an unknown object with projected keys but no trustworthy type) is an irreversible prewrite failure even if it disappears before the second snapshot. A cached irrelevant object remains ignored while its tracked type is irrelevant, including partial updates that omit `OBJTYP`; an explicit transition into `CIRCUIT`, `CIRCGRP`, or `SYSTEM` fails irreversibly even if the same frame or a later frame restores the old type. Include a race where a projected change arrives while the write request waits behind `_request_lock`: `_before_write_callback` detects the recorded prewrite failure, raises before transport initiation, leaves `write_started` false, and produces an ordinary pre-dispatch `ICError`.
+
+Add raw-observer parser cases for a missing/non-list `NotifyList.objectList`, non-dict entries, missing/non-string object names, malformed parameters on any entry whose relevance cannot be excluded, placeholders in mandatory projected fields, malformed optional values, and duplicate relevant entries within one frame. Optional circuit `PARENT`/`USE` and row `USE` sentinel updates normalize before comparison rather than failing merely because the firmware echoed an unsupported key. Explicitly cover row `USE` omitted from a partial update and present as key echo, `"00000"`, or a real value, both before write and after dispatch; equivalent absence spellings remain equal, while a changed real value fails. At both phases, row `PARENT` missing from a full initialization/projection or present as key echo/`"00000"` fails as mandatory rather than normalizing. Process entries in wire order: a relevant value that changes and restores later in the same frame remains an irreversible failure. Cover each malformed class both before write and after dispatch and assert the first-failure signal wakes the lifecycle without waiting for a settle/action/observation deadline.
+
+- [ ] **Step 4: Write failing action deadline, invariant, error-metadata, and final-projection tests**
+
+Cover each authoritative gate independently:
+
+- a notification received while `SetParamList` waits for the connection request lock is excluded by the later post-send watermark;
+- on TCP, a notification after synchronous `transport.write()` returns but before acknowledgement is retained;
+- on WebSocket, a frame processed while `ws.send()` is suspended is sequence-ordered and checked for invariant violations but cannot qualify as onset because the post-send callback has not established the causal watermark; a later `SYNC=OFF` alone still fails for missing onset, while a fresh `SYNC=ON` strictly after the post-send watermark can qualify;
+- the before callback's event-loop time is the sole deadline origin and the after callback's sequence is the sole onset-watermark origin; request-lock wait time is excluded while WebSocket send-await time is included only in the deadline;
+- status/onset leading order varies without failure;
+- `SYNC=OFF` before a post-arm `SYNC=ON` never completes;
+- acknowledgement without onset by `write_started_at + 60` fails in phase `onset`;
+- onset without terminal by the same absolute deadline fails in phase `terminal`; acknowledgement latency never extends it;
+- the state-changing request passes `request_timeout=SYNC_ACTION_DEADLINE_SECONDS` rather than inheriting the connection's 30-second default; a scripted response at 45 seconds can still succeed when onset/terminal also meet the absolute deadline, while no response by 60 seconds fails in `acknowledgement`;
+- a WebSocket `send()` that stalls after the pre-send hook cannot outlive `write_started_at + 60`; the outer action deadline wakes, cancels/awaits the request task, and reports phase `acknowledgement` with `dispatch_started=True` and no response;
+- an all-on target parent/child reporting `STATUS=OFF` fails immediately;
+- an all-off target object may repeat `OFF` before it reaches `ON`, but `ON -> OFF` fails immediately;
+- target parent/child `USE` changes and target `SET`/`SWIM` changes fail immediately;
+- after terminal, any target `SYNC=ON` re-entry fails immediately even if a later `SYNC=OFF` and final read look clean;
+- any unrelated `CIRCUIT` `PARENT`, `STATUS`, or `USE` change fails immediately, including a legitimate schedule/panel transition; document this conservative false-failure boundary rather than relaxing causal safety;
+- any non-target group `SYNC`/`SET`/`SWIM`, any row `PARENT/CIRCUIT/LISTORD/USE`, or system `OBJTYP/VER/SERVICE` change fails immediately;
+- a post-dispatch notification introducing an unknown relevant object/topology fails irreversibly even if a later remove/restore leaves the final wildcard inventory equal to baseline;
+- each transient violation remains failed after an exact restore frame and a clean final read;
+- repeated values that exactly equal allowed current/baseline values remain harmless;
+- the second fresh preflight occurs only after the one-second subscription settle and must exactly match the first projection;
+- the final `GetParamList` does not occur before the full 60-second post-terminal observation interval ends;
+- final projection is mandatory even after clean pushes;
+- final mismatch in any projected system, required `CIRCUIT OBJTYP/SUBTYP/STATUS`, normalized optional circuit `PARENT/USE`, group flag, required row topology, or normalized optional row `USE` field fails in phase `final_projection`; final row `USE` omission/key-echo/`"00000"` remains equal to baseline absence, a real-value difference fails, and final row `PARENT` missing/key-echo/`"00000"` fails as mandatory;
+- a clean final projection cannot replace missing onset or terminal;
+- a final read on a replaced connection is rejected;
+- first wildcard read, each subscription initialization batch, the second preflight, action response, and final projection all race the captured close future; a simultaneous clean response and close always chooses close;
+- disconnect/reconnect during subscription settling, onset wait, terminal wait, or post-terminal observation wakes the waiter immediately and preserves the applicable pre/post-dispatch phase/certainty metadata; explicitly test both rapid same-instance reconnect and real controller replacement while Sync owns the lifecycle, prove the synchronously captured old-generation future completes permanently, emit an immediate qualifying `SYNC` frame on the new generation, and prove the observer rejects/ignores it and closure wins every wait tie;
+- an unsafe notification during the final read wins over an otherwise clean response, proving invariants remain live until observer removal;
+- an invariant failure during the first wildcard read, any subscription batch, settle, second preflight, action response, onset, terminal, observation, or final read wakes immediately; when failure and success become ready together, failure wins, and when closure is also ready, closure wins;
+- cancellation removes the observer and releases `_mutation_owner`, `_mutation_lock`, and `_light_group_mutation_pending` exactly once;
+- timeout removes the observer, sends no retry, and sends no recovery write;
+- a second Sync and an ordinary `request_changes()` both fail busy before dispatch while the first Sync owns the lifecycle; neither waits nor sends later, while a read-only request remains live.
+
+For `ICLightGroupError`, assert every metadata combination separately:
+
+| Scenario | `phase` | `dispatch_started` | `response_received` | `acknowledged` | `onset_seen` |
+| --- | --- | --- | --- | --- | --- |
+| write/send initiated, no correlated response | `acknowledgement` | `True` | `False` | `False` | `False` |
+| explicit non-200 response | `acknowledgement` | `True` | `True` | `False` | `False` |
+| onset push but response never arrives | `acknowledgement` | `True` | `False` | `False` | `True` |
+| 200 acknowledgement but no onset | `onset` | `True` | `True` | `True` | `False` |
+| onset but no terminal | `terminal` | `True` | `True` | `True` | `True` |
+| invariant violation after terminal | `observation` | `True` | `True` | `True` | `True` |
+| final projection mismatch | `final_projection` | `True` | `True` | `True` | `True` |
+
+Here `phase` names the response/lifecycle gate that failed. A qualifying post-send-watermark onset can precede the correlated response, so the third row intentionally remains `phase="acknowledgement"`; Home Assistant's `acknowledged or onset_seen` precedence maps it to visibly-started/incomplete rather than uncertain delivery.
+
+Use `asyncio.Event` barriers and injected/fake event-loop clock values to prove ordering. Do not use wall-clock sleeps except a single `await asyncio.sleep(0)` scheduling yield. At every tie assert the precedence `connection closed` > `tracker failed` > `operation succeeded`.
+
+- [ ] **Step 5: Run the new tests and verify red**
+
+```bash
+uv run pytest tests/test_light_group_sync.py tests/test_typing_public_api.py -v
+```
+
+Expected: the module, exception, and public helper are absent.
+
+- [ ] **Step 6: Implement strict topology and projection objects**
+
+In `_light_group.py`, use frozen dataclasses whose fields are immutable tuples. `LightGroupTopology` owns the system objnam, target parent objnam, exactly two ordered target row entries, exactly two ordered distinct target children, all known `CIRCUIT` objnams, all real group-parent objnams, all membership-row objnams, and a stable `(objnam, objtype)` inventory for every cached object so notifications can distinguish known irrelevant objects from new topology. `LightGroupProjection` owns the exact system tuple; every circuit's `(objnam, objtype, subtype, parent: str | None, status, use: str | None)`; every group parent's action flags; and every row's `(objnam, objtype, parent, circuit, listord, use: str | None)`. The optional fields contain normalized semantic absence, never raw sentinel spelling.
+
+`build_projection_query()` returns the exact existing wildcard shape used by `get_all_objects()`: `condition=""` and one `{"objnam": "INCR", "keys": [...]}` entry. Its fixed 12-key union is `OBJTYP`, `SUBTYP`, `PARENT`, `CIRCUIT`, `LISTORD`, `STATUS`, `USE`, `SYNC`, `SET`, `SWIM`, `VER`, and `SERVICE`; assert its key count is at most the imported `MAX_ATTRIBUTES_PER_QUERY` in both implementation and tests. Unlike `get_all_objects()`, retain the raw response long enough to distinguish mandatory malformed values from legitimate not-applicable sentinels. Define one private optional-field normalizer: missing, `None`, exact `key == value`, and exact protocol null reference `"00000"` become `None`; any other scalar string remains exact and a non-string/non-null value fails. Apply it only to circuit `PARENT`/`USE` and membership-row `USE`. The wildcard response is filtered into:
+
+- system: `OBJTYP`, `VER`, `SERVICE`;
+- every `CIRCUIT`, including target parent, target children, unrelated ordinary circuits, and other group parents: required `OBJTYP`, `SUBTYP`, `STATUS` plus normalized optional `PARENT`, `USE`;
+- every real group parent additionally: `SYNC`, `SET`, `SWIM`;
+- every `CIRCGRP` membership row, including rows outside the target: required `OBJTYP`, `PARENT`, `CIRCUIT`, `LISTORD` plus normalized optional `USE`.
+
+`parse_projection()` first validates the complete wildcard envelope: `objectList` is a list; every entry is a dict with one unique nonempty string `objnam`, dict-shaped parameters, and a real non-placeholder string `OBJTYP`. It rejects an unknown entry with absent/non-string/placeholder type because relevance cannot be excluded. Only after that validation may it ignore entries with an explicit well-formed unrelated type. It requires every relevant object exactly once, every mandatory type-specific key to have a real non-placeholder string value, each optional value to normalize successfully, and the fresh relevant inventory/topology to equal the cache used to build eligibility. An optional sentinel is data, not a malformed response: compare its normalized `None` to the baseline and fail if it later becomes a real value (or vice versa), but never require an ordinary parentless/non-color circuit to invent `PARENT` or `USE`. Apply the same parser to first, second, and final wildcard reads, with hardware-realistic negative and normalization tests at all three gates: membership-row `USE` omission/key-echo/`"00000"` normalize to absence and a real string is retained, while membership-row `PARENT` remains mandatory and rejects missing/key-echo/`"00000"`. This preserves one authoritative snapshot request on large installations; do not multiply the key count by the number of wildcard response objects.
+
+`build_subscription_batches()` instead targets exact discovered relevant object names with their type-specific keys. Split before adding an entry that would make the aggregate key count exceed `MAX_ATTRIBUTES_PER_QUERY`; an individual entry that cannot fit fails closed. Require a correlated `200` and list-shaped `objectList` for every batch. The response must contain every requested objnam exactly once, no unexpected object/key, every mandatory requested key once with a real value, and each optional requested key either as a normalizable sentinel/real value or omitted. Normalize and compare the complete initialization batch to the corresponding baseline slice. Empty, mandatory-partial, malformed, duplicate, extra, or normalized-mismatching responses are ordinary pre-dispatch `ICError` failures. Test ordinary parentless circuits whose `PARENT` is omitted, echoed, and `"00000"`; non-color circuits whose `USE` is omitted/echoed; and membership rows whose optional `USE` is omitted, echoed, `"00000"`, or real. Equivalent absence representations initialize successfully and real optional values compare exactly, while membership-row `PARENT` omission/key-echo/`"00000"` and any real optional-value change fail. The raw observer remains armed across all batches, so splitting subscriptions does not split or weaken either fresh snapshot.
+
+`validate_initial_projection()` returns the accepted uniform prestate and requires all Global Constraints, including the exact untrimmed fresh raw `VER=1.064`, exactly two distinct resolved children, and both child subtypes `GLOW`. The second preflight uses dataclass equality against the first normalized projection, not a weaker topology-only comparison or raw-sentinel spelling comparison. `validate_final_projection()` requires the exact baseline system, every circuit's `OBJTYP/SUBTYP` and normalized optional `PARENT/USE`, every unrelated circuit's baseline `STATUS`, every row's mandatory topology and normalized optional `USE`, every non-target group flag, target `SET/SWIM`, target `SYNC=OFF`, and all three target statuses `ON`. Explicitly reject no-push final type/subtype changes, including loss of the target `LITSHO` or child `GLOW` eligibility. Dynamic telemetry outside this explicit query is intentionally excluded.
+
+- [ ] **Step 7: Implement the edge-qualified tracker**
+
+Before a baseline exists, `LightGroupSyncTracker.observe()` stores relevant `(sequence, frame)` items up to `MAX_PREBASELINE_NOTIFICATIONS`; the first overflow irreversibly records an ordinary pre-dispatch `ICError`. `set_prewrite_baseline()` loads the first validated projection and replays that buffer in sequence, rejecting any partial value different from the resulting baseline while accepting exact repeated values. The tracker owns `failure_event = asyncio.Event()` and one first-error slot; the single `_record_failure()` path stores only the first error and synchronously sets that event, so a raw-observer violation wakes the active lifecycle await immediately in every phase.
+
+Parse each `NotifyList.objectList` entry in wire order rather than merging entries by object name. A missing/non-list object list, malformed entry/parameters where relevance cannot be excluded, placeholder mandatory value, or non-normalizable optional value fails closed. A present optional circuit `PARENT`/`USE` or row `USE` is normalized before comparison; an omitted optional key means no partial update, not a forced absence transition. Tests explicitly drive row `USE` omission/key-echo/`"00000"`/real-value notifications through this path and keep row `PARENT` strict: when present in a partial notification it must be real, and every full projection/subscription initialization must include it. Duplicate relevant updates are each applied in order, so change-then-restore within one frame cannot erase a violation. At every phase, an unknown objnam declaring relevant `OBJTYP` (`CIRCUIT`, `CIRCGRP`, or `SYSTEM`) is a topology change and fails irreversibly. An unknown objnam with projected keys but no real type also fails closed because relevance cannot be excluded. Maintain a small dynamic type map initialized from the cached all-object inventory: an object whose current type is irrelevant may ignore well-formed partial updates, but any explicit transition into a relevant type fails irreversibly, even if restored; a newly observed explicit irrelevant type may be tracked under the same rule.
+
+After baseline, `observe()` compares every normalized projected partial update or subscription initialization to that baseline and calls `_record_failure()` on the first difference, even if restored. `mark_before_write(pre_send_sequence, started_at)` runs inside the pre-send transport hook: it first raises any recorded prewrite failure so the transport does not send, then stores the diagnostic pre-send sequence, write time, and absolute action deadline, and only then sets the one-shot `write_started` event/flag before returning to the immediate transport invocation. Classification uses that flag, never merely “callback reached”; if the hook raises during prewrite validation, the flag remains false and the failure stays an ordinary pre-dispatch `ICError`.
+
+`mark_after_write(sequence)` runs inside the post-send hook and stores the sole onset watermark before setting a separate one-shot `watermark_ready` event. TCP calls it immediately after synchronous write return; WebSocket calls it only after the awaited send completes. After `write_started` but before `watermark_ready`, `observe()` still applies normalized collateral, topology, status-monotonicity, `SET`, and `SWIM` invariants immediately, but target `SYNC` updates are causally ambiguous and cannot establish onset/terminal or success. Once the watermark exists, only target action edges with `sequence > watermark` qualify. Observer failures are recorded rather than raised through the connection callback.
+
+Completion state is monotonic:
+
+```text
+DISPATCH_START(time) -- transport accepts send --> WATERMARK(sequence)
+WATERMARK -- later target SYNC=ON --> ONSET
+ONSET -- target SYNC=OFF by dispatch-time+60 --> TERMINAL
+TERMINAL -- 60 seconds with no invariant violation --> OBSERVATION_CLEAN
+OBSERVATION_CLEAN -- mandatory same-connection projection validates --> COMPLETE
+```
+
+Target statuses may reach `ON` before or after onset, including during an awaited WebSocket send, but only strictly post-watermark `SYNC` edges qualify the action and final success requires all target statuses `ON`. Target `SYNC` during the pre-send/post-send ambiguity window is retained as nonqualifying evidence; a later `OFF` without a fresh qualifying `ON` never completes. `SYNC=OFF` before onset is an allowed repeated baseline value, never terminal. For all-on prestates, any later `OFF` is unsafe. For all-off prestates, track each object independently: repeated `OFF` is allowed only until that object first reaches `ON`; a later `OFF` is unsafe. All other projected fields follow exact normalized baseline invariants. Once failed, the tracker never clears the error.
+
+- [ ] **Step 8: Implement `run_light_group_sync()` on one captured connection**
+
+First define one guarded-await rule for the entire method. Immediately create one task waiting on `tracker.failure_event`; do not wrap or cancel the shared `connection_closed` future. For every request task and every settle/onset/terminal/observation wait, use `asyncio.wait()` against that operation, `connection_closed`, and the shared failure waiter. Inspect readiness in the fixed order close, failure, operation; on close/failure, cancel and await only the losing operation task. Recheck close and failure synchronously after an operation result and before consuming it. This rule applies to all three wildcard reads, every subscription initialization batch, and all timer/edge waits. It gives simultaneous readiness the deterministic precedence `connection closed` > `tracker failed` > `operation succeeded` and prevents any violation from sleeping until a protocol deadline. Convert the selected failure to ordinary `ICError` while `write_started` is false and phase-aware `ICLightGroupError` once it is true.
+
+The state-changing request has an additional staged guard. First race its task against `tracker.write_started`, close, and failure so the exact pre-send boundary is observable even when WebSocket `send()` stalls. If the task completes while `write_started` is still false, propagate its pre-dispatch result/error. As soon as `write_started` is set, create a dedicated deadline-waiter task whose `asyncio.timeout_at(tracker.action_deadline)` uses the same loop-clock domain, and race close, failure, deadline, `tracker.watermark_ready`, action response, onset, and terminal. A stalled WebSocket send never sets `watermark_ready` but is still bounded from the pre-send time. Frames observed before watermark readiness undergo invariants but cannot set onset/terminal. The outer bound is authoritative and includes TCP/WebSocket transport initiation plus the response; the connection's explicit 60-second request timeout is only a second line of defense. On deadline, cancel/await the still-pending action task and classify a missing response as phase `acknowledgement`, otherwise missing onset/terminal by the first unmet gate. Simultaneous readiness uses close > failure > deadline > gate success, and `write_started=True` makes the outcome post-dispatch even when the WebSocket send never completes.
+
+The method performs this exact sequence:
+
+1. Validate cached firmware `1.064` and exact target shape—one `CIRCUIT/LITSHO`, exactly two rows, exactly two distinct resolved `CIRCUIT/GLOW` children—without I/O; raise `ValueError` if unsupported.
+2. Enter `_light_group_mutation_lifecycle() as mutation_lease`, which marks pending before it waits for already-started writers, creates one opaque identity after ownership, and yields it; reject another pending Sync before I/O, then revalidate cached shape.
+3. Capture `connection = self._connection`; reject if missing/disconnected, then immediately and synchronously assign `connection_closed = connection._capture_closed_future()` for that exact generation before any scheduling yield.
+4. Build the fixed wildcard projection query and exact-object subscription batches synchronously from the cached model; assert every request respects `MAX_ATTRIBUTES_PER_QUERY`.
+5. Construct the tracker and register an additive raw observer closure on the captured connection before the first network request. Before forwarding a frame it checks the captured `connection_closed`; if done, it records/wakes disconnection according to the current dispatch phase and never passes the frame to tracker state. There is no pre-observer fresh-read gap.
+6. Send the first wildcard `GetParamList` through the guarded-await rule and `_send_cmd_on_connection_unlocked(connection, ..., _mutation_lease=mutation_lease)`, parse/validate it, and install it as the tracker prewrite baseline; replay the bounded buffered frames before proceeding.
+7. Send every exact-object `RequestParamList` batch on that connection with that lease and guarded-await rule; require a correlated `200`, compare response initialization values to the baseline, and keep the raw observer active throughout.
+8. Guardedly await exactly `SUBSCRIPTION_SETTLE_SECONDS`, then send the second identical wildcard `GetParamList` on the captured connection under the same rule. Require exact `LightGroupProjection` equality with the first baseline and no transient prewrite failure recorded by the observer or subscription responses.
+9. Create the mixed-case `SetParamList` request task exactly once with `[{"objnam": group_objnam, "params": {"SYNC": "ON"}}]`, explicitly passing the same `mutation_lease`, `request_timeout=SYNC_ACTION_DEADLINE_SECONDS`, `tracker.mark_before_write` as `_before_write_callback`, and `tracker.mark_after_write` as `_after_write_callback`. The child is authorized by lease identity, not incorrectly required to equal `_mutation_owner`. Apply the staged action guard and classify by `tracker.write_started`, not by task creation or callback entry: a pre-send callback check failure propagates as an ordinary pre-dispatch `ICError`, while every failure after the flag is set becomes phase-aware. The outer absolute deadline begins at the pre-send hook and therefore bounds a stalled WebSocket send as well as response/onset/terminal; onset admission begins only at the post-send hook. The explicit connection request timeout prevents the connection's 30-second default from contradicting the response gate but never extends that outer bound.
+10. Starting from the callback's recorded monotonic time, enforce one absolute 60-second deadline across acknowledgement, positive onset, and terminal. Retain qualifying notifications that arrive before acknowledgement. Record `response_received` for any correlated response/explicit response error and `acknowledged` only for an exact successful response.
+11. At terminal, record its event-loop time and keep the raw observer active for exactly `SYNC_POST_TERMINAL_OBSERVATION_SECONDS`. Race the generation-bound close future captured in step 3 against the subscription settle and every onset/terminal/observation wait. Whenever `asyncio.wait()` returns closure together with any response/tracker event, handle closure first and discard the competing success edge. Automatic/manual controller reconnection may reuse the instance or replace `self._connection`, but the old generation future remains done and the guarded observer prevents any new-generation frame or response from satisfying this helper.
+12. Send the mandatory final `GetParamList` with the same projection query, lease, captured connection, and guarded-await rule. Validate it against the baseline/final rules, including exact `OBJTYP/SUBTYP` equality for every circuit, then call `tracker.raise_if_failed()` again so an unsafe frame received during the read wins over a clean response.
+13. Return the complete correlated acknowledgement dict exactly as supplied by the transport only after final validation and the last failure check. Correlation requires its real `messageID` and success requires `response == "200"`, but the helper neither requires nor invents a response-side command echo and preserves every opaque field; do not normalize it to the test-only shape `{"response": "200"}`.
+14. In `finally`, cancel/await the delegated request, shared failure waiter, and other owned internal tasks, but never cancel the captured close future; invoke the idempotent observer remover while still inside the lifecycle context. Only then may context exit invalidate `mutation_lease` and clear owner/lock/pending. There is no `await` between the last failure check and observer removal, closing the final interleaving window.
+
+Wrap a response timeout, disconnect, malformed acknowledgement, missing edge, invariant violation, or final mismatch after `tracker.write_started` becomes true in `ICLightGroupError`, chaining the cause and snapshotting the tracker flags. Use phases `acknowledgement`, `onset`, `terminal`, `observation`, and `final_projection` according to the failed gate. Unsupported cached shapes remain `ValueError`; busy lifecycle, first/second preflight, subscription/batching, callback-precheck, or connection failures while `write_started` is false remain ordinary `ICError` subclasses. Propagate `CancelledError`. Never retry and never send recovery writes.
+
+- [ ] **Step 9: Export and type-check the public contract**
+
+Add:
+
+```python
+type _LightGroupPhase = Literal[
+    "acknowledgement",
+    "onset",
+    "terminal",
+    "observation",
+    "final_projection",
+]
+
+
+class ICLightGroupError(ICError):
+    """A Color Sync failure after transport dispatch began."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: _LightGroupPhase,
+        response_received: bool,
+        acknowledged: bool,
+        onset_seen: bool,
+    ) -> None:
+        self._phase = phase
+        self._response_received = response_received
+        self._acknowledged = acknowledged
+        self._onset_seen = onset_seen
+        super().__init__(message)
+
+    @property
+    def phase(self) -> _LightGroupPhase:
+        """Return the lifecycle phase that failed."""
+        return self._phase
+
+    @property
+    def dispatch_started(self) -> bool:
+        """Return whether transport write/send initiation occurred."""
+        return True
+
+    @property
+    def response_received(self) -> bool:
+        """Return whether a correlated controller response arrived."""
+        return self._response_received
+
+    @property
+    def acknowledged(self) -> bool:
+        """Return whether the controller positively acknowledged the action."""
+        return self._acknowledged
+
+    @property
+    def onset_seen(self) -> bool:
+        """Return whether a qualifying post-send-watermark onset was observed."""
+        return self._onset_seen
+
+    def __repr__(self) -> str:
+        return (
+            "ICLightGroupError("
+            f"phase={self.phase!r}, "
+            f"dispatch_started={self.dispatch_started!r}, "
+            f"response_received={self.response_received!r}, "
+            f"acknowledged={self.acknowledged!r}, "
+            f"onset_seen={self.onset_seen!r})"
+        )
+```
+
+Store phase plus the three variable certainty values as read-only public attributes; `dispatch_started` is an always-true read-only property because constructing this exception before dispatch is forbidden. Include all five fields in `__repr__` without identifiers or payloads. The `type` alias syntax is valid because pyintellicenter requires Python `>=3.13`; do not add a compatibility dependency. Export the class from `pyintellicenter.__init__` and `__all__`. Extend the downstream typing fixture to await `ICModelController.run_light_group_sync("GROUP")` and assign the result to `dict[str, Any]`; also import `ICLightGroupError` from the package root. Assert the old/non-scoped names are absent:
+
+```python
+assert not hasattr(ICModelController, "run_light_group_command")
+assert not hasattr(ICModelController, "run_light_group_swim")
+assert not hasattr(ICModelController, "set_light_group_member_position")
+```
+
+- [ ] **Step 10: Run focused lifecycle/type gates green**
+
+```bash
+uv run pytest tests/test_light_group_sync.py tests/test_circuit_group.py tests/test_connection.py tests/test_controller.py tests/test_typing_public_api.py -q
+uv run ruff check src/pyintellicenter tests/test_light_group_sync.py tests/test_circuit_group.py
+uv run ruff format --check src/pyintellicenter tests/test_light_group_sync.py tests/test_circuit_group.py
+uv run mypy src
+```
+
+Expected: all pass. The exact payload, dispatch-start deadline/post-send watermark split, exact normalized preflight equality, full 60-second observation boundary, complete invariant matrix, realistic acknowledgement, phase metadata, mandatory final read, observer cleanup, and fail-fast mutation-isolation assertions are green.
+
+- [ ] **Step 11: Commit the Color Sync contract**
+
+```bash
+git add src/pyintellicenter/_light_group.py src/pyintellicenter/_mixins/circuit_group.py src/pyintellicenter/exceptions.py src/pyintellicenter/__init__.py tests/test_light_group_sync.py tests/test_typing_public_api.py
+git commit -m "feat: add verified light group color sync"
+```
+
+---
+
+### Task 6: Document and fully verify the pyintellicenter feature PR
+
+**Files:**
+- Modify: `docs/API.md`
+- Modify: `docs/USAGE.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: Tasks 2-5 public behavior.
+- Produces: an independently reviewable pyintellicenter feature branch with version still `0.1.21` and changes recorded under `[Unreleased]`.
+
+- [ ] **Step 1: Add exact API and usage documentation**
+
+Document:
+
+```python
+groups = controller.get_circuit_groups()
+rows = controller.get_circuit_group_members(groups[0].objnam)
+children = controller.get_circuits_in_group(groups[0].objnam)
+
+try:
+    await controller.run_light_group_sync(groups[0].objnam)
+except ValueError:
+    # Firmware/topology/prestate is outside the supported action envelope.
+    raise
+except ICLightGroupError as err:
+    if err.acknowledged or err.onset_seen:
+        # The action was acknowledged or visibly started but did not prove completion.
+        raise
+    if err.dispatch_started and not err.response_received:
+        # Dispatch began, but whether the controller received it is unknown.
+        raise
+    # The controller returned an explicit rejection/malformed response.
+    raise
+except ICError:
+    # Subscription/preflight failed before dispatch began.
+    raise
+```
+
+State that the call commonly occupies roughly 96-97 seconds plus request latency on the observed firmware: a one-second subscription settle, roughly 35-36 seconds to physical terminal, a full 60-second post-terminal observation, then a final read. State that eligibility is deliberately limited to firmware `1.064`, exactly two distinct resolved `GLOW` children, and uniform all-off/all-on prestates; no automatic retry/recovery occurs. During that complete interval, new object-changing calls through the same controller fail immediately with `ICError` instead of being delayed; read-only commands and model updates continue. A physical-panel or separate raw-connection change is outside that isolation boundary and makes Sync incomplete if it changes the monitored projection. Document the five certainty attributes and warn that any error with `dispatch_started=True` requires physical inspection before retry.
+
+- [ ] **Step 2: Add `[Unreleased]` changelog entries**
+
+Under `Added`, record dedicated TCP/WebSocket Color Sync with same-connection authoritative completion and phase-aware certainty metadata. Under `Fixed`, record real parent/membership-row modeling and the intentional change in `get_circuit_groups()`. Under `Security` or `Changed`, record no-retry, fail-fast case-insensitive controller writer isolation, exact two-GLOW/firmware envelope, full-projection transient validation, the 60-second post-terminal observation, and mandatory final read. Explicitly list Set, Swim, and member position as not implemented.
+
+- [ ] **Step 3: Scan source for forbidden writers and generic APIs**
+
+Run:
+
+```bash
+if rg -n 'run_light_group_command|run_light_group_swim|set_light_group_member_position|"SET": "ON"|"SWIM": "ON"' src/pyintellicenter; then
+  exit 1
+fi
+rg -n '"ACT"|"STATUS"' src/pyintellicenter/_light_group.py src/pyintellicenter/_mixins/circuit_group.py
+```
+
+Expected: the first command is silent in production source; negative tests and documentation may name omitted APIs. The second may show read/projection keys only; manually verify the sole action write contains only `SYNC=ON`.
+
+- [ ] **Step 4: Run the complete pyintellicenter gate**
+
+```bash
+uv sync --frozen --extra dev
+uv run pytest --cov=src/pyintellicenter --cov-report=term-missing
+uv run ruff check src tests scripts
+uv run ruff format --check src tests scripts
+uv run mypy src
+uv lock --check
+git diff --check
+git status --short
+```
+
+Expected: all tests pass, static/lock/diff checks are clean, and status lists only intended feature files.
+
+- [ ] **Step 5: Commit the documentation/changelog**
+
+```bash
+git add docs/API.md docs/USAGE.md CHANGELOG.md
+git commit -m "docs: document light group sync contract"
+```
+
+---
+
+### Task 7: Obtain two adversarial reviews and open the pyintellicenter feature PR
+
+**Files:**
+- Modify only pyintellicenter source, tests, or documentation required to resolve accepted review findings; do not touch Home Assistant `custom_components`, integration dependency files, or release-version files in this task.
+
+**Interfaces:**
+- Consumes: green Task 6 branch.
+- Produces: one reviewed pyintellicenter PR targeting `main`; no version bump in this feature PR.
+
+- [ ] **Step 1: Ask `agy` for a safety/concurrency adversarial review**
+
+Run from the pyintellicenter worktree:
+
+```bash
+agy --mode plan --sandbox --add-dir "$PWD" \
+  --model 'Claude Opus 4.6 (Thinking)' --print-timeout 20m --print \
+  'Adversarially review this issue #93 feature branch against origin/main. Find concrete correctness, race, protocol-safety, typing, compatibility, and test gaps. Focus on connection-owned enqueue-time monotonic sequencing, observer installation before the first wildcard projection with bounded pre-baseline replay, initialization-validated subscription batching under the 50-key ceiling, required-versus-normalized-optional projection fields including ordinary parentless/non-color circuits, the under-request-lock pre-send deadline and post-send causal watermark hooks, strict sequence > post-send watermark action admission including WebSocket send suspension, transient prewrite projection rejection, exact equality of fresh normalized projections around the one-second subscription settle, captured-connection/replacement identity, pending-before-wait lifecycle ownership, fail-fast later case-insensitive public SetParamList writers, pre-ACK notifications, explicit 60-second request timeout, realistic full acknowledgement shape, uniform ON/OFF prestates, sender-side SYNC edges including forbidden post-terminal re-entry, the dispatch-time 60-second onset/terminal deadline, the separate 60-second post-terminal observation, full normalized circuit/row invariants through observer removal, mandatory same-connection final projection, phase-aware ICLightGroupError metadata, no retry/recovery, exact mixed-case SetParamList payload, real CIRCUIT parent/CIRCGRP row modeling, and absence of Set/Swim/member-position APIs. Confirm action eligibility is the exact raw firmware token 1.064 plus exactly two distinct resolved GLOW children, with broader color/version parsing retained only for read/display helpers. Report findings by severity with file/line and an executable fix; do not edit files.'
+```
+
+Expected: a severity-ranked review, not implementation.
+
+- [ ] **Step 2: Ask Cursor `agent` for an independent adversarial review**
+
+```bash
+agent --print --output-format text --mode ask --sandbox enabled --trust \
+  --workspace "$PWD" --model 'claude-opus-4-8-thinking-high' \
+  'Independently adversarially review this issue #93 pyintellicenter branch versus origin/main. Look for protocol extrapolation, missing authoritative gates, notification ordering/races, deadlocks, reconnect identity bugs, observer leaks, stale queue use, lifecycle-owner or fail-fast writer-isolation gaps, malformed projection handling, backwards-compatibility breaks, absent negative tests, and accidental Set/Swim/member-position support. Verify the raw observer is installed before the first wildcard GetParamList and bounded buffered frames are replayed; exact-object subscription batches stay at or below 50 keys and initialization responses normalize only optional circuit PARENT/USE and row USE while mandatory keys remain strict; complete fresh normalized projections match exactly around the one-second settle and transient restore still rejects; event-loop time is captured under the request lock immediately before transport initiation while the causal sequence watermark is captured after TCP write/WebSocket send completion; WebSocket send-window frames cannot qualify onset; the exact one-object mixed-case SetParamList SYNC payload uses an explicit 60-second response timeout and returns a realistic full acknowledgement; onset and terminal share the dispatch-start 60-second deadline and target SYNC cannot re-enter afterward; post-terminal observation is a separate 60 seconds; every normalized circuit/row, group-flag, and system invariant remains monitored through removal; final GetParamList is mandatory on the captured connection; errors expose correct phase/certainty; and there is no retry/recovery. Confirm exact raw firmware token 1.064 and exactly two distinct resolved GLOW children. Return only actionable findings with severity and file/line; do not edit.'
+```
+
+Expected: an independent severity-ranked review.
+
+- [ ] **Step 3: Triage every finding with evidence**
+
+Create a private review ledger containing reviewer, severity, finding, disposition, evidence, and commit. Accept technically valid findings with a failing regression test first; reject findings only with a specific code/test/protocol reason. Re-run the focused test that proves every accepted fix, then the complete Task 6 gate.
+
+- [ ] **Step 4: Re-run both reviewers after material fixes**
+
+Use the same commands with an added sentence asking whether each prior finding is closed. Expected: no unresolved critical/high finding and no untested race/safety claim.
+
+- [ ] **Step 5: Push and open the feature PR**
+
+```bash
+git push -u origin feature/issue-93-light-group-sync
+gh pr create --repo joyfulhouse/pyintellicenter --base main \
+  --head feature/issue-93-light-group-sync \
+  --title "feat: model real light groups and add Color Sync" \
+  --body-file /tmp/pyintellicenter-issue-93-pr.md
+```
+
+The prepared PR body must summarize the corrected parent/row model, supported Sync matrix, exact lifecycle/error-certainty gates, evidence-scoped firmware `1.064`/exactly-two-`GLOW` eligibility, broader read-only color classification, negative scope, test commands, and both adversarial-review dispositions. Expected: an open feature PR with green GitHub Actions. Opening this feature PR is within the implementation workflow; merging it is not.
+
+---
+
+### Task 8: Prepare pyintellicenter 0.1.22 and stop at maintainer release checkpoints
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/pyintellicenter/__init__.py`
+- Modify: `uv.lock`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: maintainer-confirmed merge of the pyintellicenter feature PR and green `main`.
+- Produces: a separate release PR; after explicit maintainer merge/publish checkpoints, GitHub Release `v0.1.22` and installable PyPI `pyintellicenter==0.1.22`.
+
+- [ ] **Step 1: Stop for the feature-merge checkpoint, then create a release worktree**
+
+Do not merge the feature PR. Request maintainer/user confirmation that it has been reviewed and merged. Only after confirmation, fetch and verify `origin/main` contains the feature merge, then create the release worktree:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter fetch origin
+git -C /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter worktree add \
+  /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-release-0.1.22 \
+  -b chore/release-0.1.22 origin/main
+```
+
+Expected: the new base contains the maintainer-merged feature commits. If confirmation is absent or the merge is not fetched, stop; integration coding may continue with the temporary editable install, but release/lock work may not.
+
+- [ ] **Step 2: Bump all synchronized library version sources**
+
+Set `project.version = "0.1.22"` in `pyproject.toml`, `__version__ = "0.1.22"` in `src/pyintellicenter/__init__.py`, and move `[Unreleased]` entries under `## [0.1.22] - 2026-07-15` in `CHANGELOG.md`. Then run:
+
+```bash
+uv lock
+uv run pytest tests/test_version.py -q
+git diff --check
+```
+
+Expected: `uv.lock` records 0.1.22 and version tests pass.
+
+- [ ] **Step 3: Run the complete release gate and open the release PR**
+
+```bash
+uv sync --frozen --extra dev
+uv run pytest -q
+uv run ruff check src tests scripts
+uv run ruff format --check src tests scripts
+uv run mypy src
+git add pyproject.toml src/pyintellicenter/__init__.py uv.lock CHANGELOG.md
+git commit -m "chore: release 0.1.22"
+git push -u origin chore/release-0.1.22
+gh pr create --repo joyfulhouse/pyintellicenter --base main \
+  --head chore/release-0.1.22 --title "chore: release 0.1.22" \
+  --body "Release real light-group modeling and verified Color Sync for issue #93."
+```
+
+Expected: green release PR. Do not tag from the unmerged branch.
+
+- [ ] **Step 4: Stop for release-PR merge and publication authorization**
+
+Do not merge the release PR, create a tag, or publish a GitHub Release. Request explicit maintainer/user confirmation for those actions. The current `.github/workflows/publish.yml` triggers only when a maintainer publishes GitHub Release `v0.1.22`, then builds once, publishes to TestPyPI, and publishes to PyPI. Record the maintainer-provided release URL/job result after that external checkpoint.
+
+- [ ] **Step 5: Verify the released artifact independently**
+
+```bash
+uv run --isolated --no-project --with pyintellicenter==0.1.22 python -c \
+  'from pyintellicenter import ICModelController, ICLightGroupError, __version__; assert __version__ == "0.1.22"; assert callable(ICModelController.run_light_group_sync); assert issubclass(ICLightGroupError, Exception); print(__version__)'
+```
+
+Expected: prints `0.1.22`. This read-only artifact check may run after the maintainer confirms publication. Do not begin the integration lock update or open the integration PR until it succeeds against PyPI rather than a local editable checkout.
+
+---
+
+### Task 9: Correct Home Assistant row tracking and group entity construction
+
+**Files:**
+- Modify: `custom_components/intellicenter/coordinator.py`
+- Modify: `custom_components/intellicenter/light.py`
+- Modify: `tests/conftest.py`
+- Modify: `tests/test_light.py`
+- Modify: `tests/test_library_contract.py`
+
+**Interfaces:**
+- Consumes: API-stable, focused-green pyintellicenter feature worktree from Task 5; publication is not required for local implementation.
+- Produces: membership rows tracked as `{PARENT, CIRCUIT, LISTORD}`, existing parent light entities retained, no membership-row entity, a complete-group resolver for existing effect modeling, and a separate evidence-scoped Color Sync predicate inside `light.py`.
+
+- [ ] **Step 1: Refresh the integration branch and install a temporary editable library without repository drift**
+
+The Task 1 integration worktree may predate intervening `main` changes while the library API stabilized. Refresh it, sync its existing frozen environment, then overlay the pyintellicenter feature worktree as an uncommitted editable install:
+
+```bash
+git fetch origin
+git rebase origin/main
+uv sync --frozen
+uv pip install --python .venv/bin/python --editable \
+  /Users/bryanli/Projects/joyfulhouse/python/pyintellicenter-issue-93-sync
+uv run --no-sync python -c \
+  'from pathlib import Path; import pyintellicenter; assert "pyintellicenter-issue-93-sync" in str(Path(pyintellicenter.__file__).resolve())'
+git diff --exit-code -- custom_components/intellicenter/manifest.json pyproject.toml uv.lock
+```
+
+Expected: tests can import the stable feature API while manifest, pyproject, and lock remain byte-for-byte unchanged. Do not run `uv lock`, commit a path/git dependency, or open the integration PR in this temporary state. Tasks 9-11 may now proceed in parallel with Task 7 review/Task 8 maintainer checkpoints because the worktrees do not share repository state.
+
+- [ ] **Step 2: Write failing tracking and construction tests**
+
+Assert the exact row map:
+
+```python
+assert DEFAULT_ATTRIBUTES_MAP[CIRCGRP_TYPE] == {
+    PARENT_ATTR,
+    CIRCUIT_ATTR,
+    LISTORD_ATTR,
+}
+```
+
+Build a complete parent/two-row/two-child topology and pass all objects to `_build_entities()`. Assert one entity uses the parent objnam, child lights retain their ordinary entities, and no row objnam appears. Add zero/one/three-row, missing-child, duplicate-child, mixed-capability, and legacy standalone-row cases. The parent remains an entity. General complete `INTELLI`/`MAGIC2`/`GLOW` membership may retain existing effect rendering, but local Color Sync eligibility must additionally require cached raw firmware token exactly `1.064`, exactly two distinct resolved children, and both children exactly `OBJTYP=CIRCUIT/SUBTYP=GLOW`. Add rejection tests for absent/other firmware and raw variants (`IC: 1.064`, trailing whitespace, build suffix) that `parse_ic_version()` might interpret for display/upgrade purposes; the writer predicate intentionally does not call that semantic parser. Also reject complete all-`INTELLI` or all-`MAGIC2` groups and a malformed non-`CIRCUIT` object carrying subtype `GLOW`.
+
+- [ ] **Step 3: Run focused tests and verify red**
+
+```bash
+uv run --no-sync pytest tests/test_light.py tests/test_library_contract.py -k "group or circgrp" -v
+```
+
+Expected: row tracking still contains unsupported `SNAME`/`STATUS`/`USE`, and the current builder's vacuous `all()` accepts empty/incomplete membership.
+
+- [ ] **Step 4: Correct tracking and eliminate vacuous capability checks**
+
+Set the exact coordinator row map. In `light.py`, add a pure complete-group resolver that returns `None` unless the parent is `CIRCUIT/LITSHO`, membership is non-empty, every row resolves, the resolved count matches the row count, and child objnams are distinct:
+
+```python
+def _complete_light_group_children(
+    coordinator: IntelliCenterCoordinator, parent: PoolObject
+) -> tuple[PoolObject, ...] | None:
+    if parent.objtype != CIRCUIT_TYPE or parent.subtype != "LITSHO":
+        return None
+    members = coordinator.controller.get_circuit_group_members(parent.objnam)
+    children = coordinator.controller.get_circuits_in_group(parent.objnam)
+    if (
+        not members
+        or len(children) != len(members)
+        or len({child.objnam for child in children}) != len(children)
+    ):
+        return None
+    return tuple(children)
+
+
+def _is_complete_color_light_group(
+    coordinator: IntelliCenterCoordinator, parent: PoolObject
+) -> bool:
+    children = _complete_light_group_children(coordinator, parent)
+    return children is not None and all(
+        child.supports_color_effects for child in children
+    )
+
+
+def _is_color_sync_eligible(
+    coordinator: IntelliCenterCoordinator, parent: PoolObject
+) -> bool:
+    children = _complete_light_group_children(coordinator, parent)
+    system_info = coordinator.system_info
+    return bool(
+        system_info is not None
+        and system_info.sw_version == "1.064"
+        and children is not None
+        and len(children) == 2
+        and all(
+            child.objtype == CIRCUIT_TYPE and child.subtype == "GLOW"
+            for child in children
+        )
+    )
+```
+
+Use `_is_complete_color_light_group()` only to preserve the existing group effect capability without a vacuous `all()`. Use `_is_color_sync_eligible()` only for the new state-changing action. `_build_entities()` continues to create the existing parent light exactly once. Membership rows fail both `is_a_light` and `is_a_light_show` and create no entity.
+
+- [ ] **Step 5: Run focused consumer/model tests green**
+
+```bash
+uv run --no-sync pytest tests/test_light.py tests/test_library_contract.py tests/test_dynamic_entities.py -q
+uv run --no-sync ruff check custom_components/intellicenter/coordinator.py custom_components/intellicenter/light.py tests/test_light.py tests/test_library_contract.py
+uv run --no-sync ruff format --check custom_components/intellicenter/coordinator.py custom_components/intellicenter/light.py tests/test_light.py tests/test_library_contract.py
+```
+
+Expected: all pass and no row-derived entity is created.
+
+- [ ] **Step 6: Commit the integration model boundary**
+
+```bash
+git add custom_components/intellicenter/coordinator.py custom_components/intellicenter/light.py tests/conftest.py tests/test_light.py tests/test_library_contract.py
+git commit -m "fix: consume real light group membership model"
+```
+
+---
+
+### Task 10: Expose only the Home Assistant Color Sync entity service
+
+**Files:**
+- Modify: `custom_components/intellicenter/light.py`
+- Modify: `custom_components/intellicenter/services.yaml`
+- Modify: `tests/test_light.py`
+- Modify: `tests/test_library_contract.py`
+
+**Interfaces:**
+- Consumes: `_is_color_sync_eligible()` and `ICModelController.run_light_group_sync()`.
+- Produces: entity service `intellicenter.color_sync` -> `PoolLight.async_color_sync()`.
+
+- [ ] **Step 1: Write failing service registration and execution tests**
+
+Update the registration assertion to include exactly `color_sync` after the four existing MagicStream services. Add:
+
+```python
+async def test_color_sync_calls_dedicated_library_helper(
+    complete_group_light: PoolLight,
+    mock_coordinator: MagicMock,
+) -> None:
+    await complete_group_light.async_color_sync()
+    mock_coordinator.controller.run_light_group_sync.assert_awaited_once_with("GROUP")
+    mock_coordinator.controller.request_changes.assert_not_awaited()
+```
+
+Also assert:
+
+- ordinary `LIGHT`, `INTELLI`, `MAGIC2`, and `CIRCUIT/SUBTYP=CIRCGRP` entities raise `HomeAssistantError` with `translation_key="light_group_command_unsupported"` before the library call;
+- zero/one/three-member, missing-child, duplicate-child, mixed-capability, all-`INTELLI`, and all-`MAGIC2` `LITSHO` parents raise the same unsupported error;
+- missing firmware or any firmware other than exact `1.064` raises unsupported before the library call;
+- a library-side `ValueError` caused by a race after the local check still maps to `light_group_command_unsupported`;
+- any ordinary pre-dispatch `ICError` and an `ICLightGroupError` with a correlated explicit rejection (`response_received=True`, `acknowledged=False`, `onset_seen=False`) map to `light_group_command_failed`;
+- an `ICLightGroupError` with dispatch started but no response/onset maps to `light_group_command_uncertain`;
+- any `ICLightGroupError` with `acknowledged=True` or `onset_seen=True` maps to `light_group_command_incomplete`, taking precedence over the uncertain/rejected branches;
+- the method does not mutate `effect`, `effect_list`, `_optimistic_state`, `STATUS`, or `USE`;
+- no `color_set`, `color_swim`, or member-position service/method exists.
+
+- [ ] **Step 2: Run focused service tests and verify red**
+
+```bash
+uv run --no-sync pytest tests/test_light.py tests/test_library_contract.py -k "color_sync or light_group" -v
+```
+
+Expected: service/method/library-contract assertions fail because Color Sync is absent.
+
+- [ ] **Step 3: Register and implement the momentary service**
+
+Replace the MagicStream-only registration mapping with an entity-service mapping that retains all existing entries and adds:
+
+```python
+"color_sync": "async_color_sync"
+```
+
+Import `ICError` and `ICLightGroupError` from the installed `pyintellicenter` package, then implement:
+
+```python
+async def async_color_sync(self) -> None:
+    """Synchronize the supported two-light IntelliCenter group."""
+    if not _is_color_sync_eligible(self.coordinator, self._pool_object):
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="light_group_command_unsupported",
+        )
+    try:
+        await self._controller.run_light_group_sync(self._pool_object.objnam)
+    except ValueError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="light_group_command_unsupported",
+        ) from err
+    except ICLightGroupError as err:
+        if err.acknowledged or err.onset_seen:
+            translation_key = "light_group_command_incomplete"
+        elif err.dispatch_started and not err.response_received:
+            translation_key = "light_group_command_uncertain"
+        else:
+            translation_key = "light_group_command_failed"
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+        ) from err
+    except ICError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="light_group_command_failed",
+        ) from err
+```
+
+Add only `color_sync` to `services.yaml`, targeting integration `intellicenter`, domain `light`. Do not add fields; the entity target is the sole input.
+
+- [ ] **Step 4: Strengthen the installed-library contract**
+
+Add `run_light_group_sync` to `CONTROLLER_METHODS`, `ICLightGroupError` to `REQUIRED_SYMBOLS`, and explicit callable/subclass/attribute checks. During parallel implementation this runs against the temporary editable worktree with `--no-sync`; Task 12 must rerun it against the released/locked wheel so mocks and the editable overlay cannot hide dependency drift.
+
+- [ ] **Step 5: Run light/service contract tests green**
+
+```bash
+uv run --no-sync pytest tests/test_light.py tests/test_library_contract.py tests/test_versions.py -q
+uv run --no-sync ruff check custom_components/intellicenter/light.py tests/test_light.py tests/test_library_contract.py
+uv run --no-sync ruff format --check custom_components/intellicenter/light.py tests/test_light.py tests/test_library_contract.py
+uv run --no-sync mypy custom_components/intellicenter/light.py
+```
+
+Expected: all pass; only Color Sync is newly registered.
+
+- [ ] **Step 6: Commit the service implementation**
+
+```bash
+git add custom_components/intellicenter/light.py custom_components/intellicenter/services.yaml tests/test_light.py tests/test_library_contract.py
+git commit -m "feat: expose light group Color Sync service"
+```
+
+---
+
+### Task 11: Localize and document the Home Assistant feature
+
+**Files:**
+- Modify: `custom_components/intellicenter/strings.json`
+- Modify: `custom_components/intellicenter/translations/de.json`
+- Modify: `custom_components/intellicenter/translations/en.json`
+- Modify: `custom_components/intellicenter/translations/es.json`
+- Modify: `custom_components/intellicenter/translations/fr.json`
+- Modify: `custom_components/intellicenter/translations/it.json`
+- Modify: `custom_components/intellicenter/translations/ja.json`
+- Modify: `custom_components/intellicenter/translations/ko.json`
+- Modify: `custom_components/intellicenter/translations/nl.json`
+- Modify: `custom_components/intellicenter/translations/pt.json`
+- Modify: `custom_components/intellicenter/translations/ru.json`
+- Modify: `custom_components/intellicenter/translations/zh-Hans.json`
+- Modify: `custom_components/intellicenter/translations/zh-Hant.json`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `color_sync`, `light_group_command_unsupported`, `light_group_command_failed`, `light_group_command_uncertain`, and `light_group_command_incomplete` keys.
+- Produces: complete service/error metadata in every currently supported locale and certainty-specific end-user timing/recovery guidance.
+
+- [ ] **Step 1: Add canonical English source copy**
+
+Use these exact English strings in `strings.json` and `translations/en.json`:
+
+```json
+"color_sync": {
+  "name": "Synchronize light-group colors",
+  "description": "Synchronizes exactly two GloBrite lights in a complete IntelliCenter light group on firmware 1.064. The call waits for the physical action, a 60-second post-action observation, and a final controller read."
+}
+```
+
+```json
+"light_group_command_unsupported": {
+  "message": "Color Sync is available only on IntelliCenter firmware 1.064 for a complete light group with exactly two distinct GloBrite lights."
+},
+"light_group_command_failed": {
+  "message": "Color Sync failed before dispatch or IntelliCenter explicitly rejected it. No action was confirmed."
+},
+"light_group_command_uncertain": {
+  "message": "Color Sync dispatch started, but IntelliCenter returned no response. The action may have run. Inspect the lights and panel state before retrying."
+},
+"light_group_command_incomplete": {
+  "message": "IntelliCenter acknowledged or visibly started Color Sync, but authoritative completion was not confirmed. Inspect the lights and panel state before retrying."
+}
+```
+
+- [ ] **Step 2: Add the same five keys to all non-English locales**
+
+Use the following exact localized values. Each row is ordered as service `name`; service `description`; unsupported `message`; failed/rejected `message`; uncertain-dispatch `message`; acknowledged/started-incomplete `message`. Preserve the product/protocol names `Color Sync`, `GloBrite`, `IntelliCenter`, firmware `1.064`, and the 60-second value exactly as shown.
+
+- `de.json`: `Farben der Lichtgruppe synchronisieren`; `Synchronisiert genau zwei GloBrite-Leuchten in einer vollständigen IntelliCenter-Lichtgruppe mit Firmware 1.064. Der Aufruf wartet auf die physische Aktion, eine 60-sekündige Beobachtung nach der Aktion und eine abschließende Abfrage des Controllers.`; `Color Sync ist nur mit IntelliCenter-Firmware 1.064 für eine vollständige Lichtgruppe mit genau zwei verschiedenen GloBrite-Leuchten verfügbar.`; `Color Sync ist vor dem Senden fehlgeschlagen oder wurde von IntelliCenter ausdrücklich abgelehnt. Es wurde keine Aktion bestätigt.`; `Der Versand von Color Sync wurde begonnen, aber IntelliCenter hat nicht geantwortet. Die Aktion wurde möglicherweise ausgeführt. Prüfen Sie die Leuchten und den Bedienfeldstatus, bevor Sie es erneut versuchen.`; `IntelliCenter hat Color Sync bestätigt oder sichtbar gestartet, aber der zuverlässige Abschluss konnte nicht bestätigt werden. Prüfen Sie die Leuchten und den Bedienfeldstatus, bevor Sie es erneut versuchen.`
+- `es.json`: `Sincronizar colores del grupo de luces`; `Sincroniza exactamente dos luces GloBrite de un grupo de luces IntelliCenter completo con firmware 1.064. La llamada espera la acción física, una observación de 60 segundos posterior a la acción y una lectura final del controlador.`; `Color Sync solo está disponible con el firmware 1.064 de IntelliCenter para un grupo de luces completo con exactamente dos luces GloBrite distintas.`; `Color Sync falló antes del envío o IntelliCenter lo rechazó explícitamente. No se confirmó ninguna acción.`; `Se inició el envío de Color Sync, pero IntelliCenter no respondió. Es posible que la acción se haya ejecutado. Inspeccione las luces y el estado del panel antes de volver a intentarlo.`; `IntelliCenter confirmó o inició visiblemente Color Sync, pero no se pudo confirmar de forma fiable que finalizara. Inspeccione las luces y el estado del panel antes de volver a intentarlo.`
+- `fr.json`: `Synchroniser les couleurs du groupe de lumières`; `Synchronise exactement deux lumières GloBrite d'un groupe de lumières IntelliCenter complet avec le micrologiciel 1.064. L'appel attend l'action physique, une observation de 60 secondes après l'action et une lecture finale du contrôleur.`; `Color Sync est disponible uniquement avec le micrologiciel IntelliCenter 1.064 pour un groupe de lumières complet comportant exactement deux lumières GloBrite distinctes.`; `Color Sync a échoué avant l'envoi ou IntelliCenter l'a explicitement rejeté. Aucune action n'a été confirmée.`; `L'envoi de Color Sync a commencé, mais IntelliCenter n'a renvoyé aucune réponse. L'action a peut-être été exécutée. Inspectez les lumières et l'état du panneau avant de réessayer.`; `IntelliCenter a confirmé ou démarré visiblement Color Sync, mais la fin fiable de l'opération n'a pas pu être confirmée. Inspectez les lumières et l'état du panneau avant de réessayer.`
+- `it.json`: `Sincronizza i colori del gruppo luci`; `Sincronizza esattamente due luci GloBrite di un gruppo luci IntelliCenter completo con firmware 1.064. La chiamata attende l'azione fisica, un'osservazione di 60 secondi dopo l'azione e una lettura finale del controller.`; `Color Sync è disponibile solo con il firmware IntelliCenter 1.064 per un gruppo luci completo con esattamente due luci GloBrite distinte.`; `Color Sync non è riuscito prima dell'invio oppure IntelliCenter lo ha rifiutato esplicitamente. Non è stata confermata alcuna azione.`; `L'invio di Color Sync è iniziato, ma IntelliCenter non ha risposto. L'azione potrebbe essere stata eseguita. Controllare le luci e lo stato del pannello prima di riprovare.`; `IntelliCenter ha confermato o avviato visibilmente Color Sync, ma non è stato possibile confermare in modo affidabile il completamento. Controllare le luci e lo stato del pannello prima di riprovare.`
+- `ja.json`: `ライトグループの色を同期`; `ファームウェア 1.064 の IntelliCenter で、完全なライトグループ内の異なる 2 台の GloBrite ライトを同期します。この呼び出しは、実際の動作、動作後 60 秒間の監視、コントローラーの最終読み取りが完了するまで待機します。`; `Color Sync は、IntelliCenter ファームウェア 1.064 で、異なる GloBrite ライトが正確に 2 台ある完全なライトグループに対してのみ使用できます。`; `Color Sync は送信前に失敗したか、IntelliCenter によって明示的に拒否されました。動作は確認されていません。`; `Color Sync の送信は開始されましたが、IntelliCenter から応答がありませんでした。動作した可能性があります。再試行する前に、ライトとパネルの状態を確認してください。`; `IntelliCenter は Color Sync を確認または明らかに開始しましたが、確実な完了を確認できませんでした。再試行する前に、ライトとパネルの状態を確認してください。`
+- `ko.json`: `조명 그룹 색상 동기화`; `펌웨어 1.064를 실행하는 IntelliCenter의 완전한 조명 그룹에서 서로 다른 GloBrite 조명 두 개를 정확히 동기화합니다. 이 호출은 실제 동작, 동작 후 60초 관찰 및 최종 컨트롤러 읽기가 완료될 때까지 기다립니다.`; `Color Sync는 IntelliCenter 펌웨어 1.064에서 서로 다른 GloBrite 조명이 정확히 두 개인 완전한 조명 그룹에만 사용할 수 있습니다.`; `Color Sync가 전송 전에 실패했거나 IntelliCenter가 명시적으로 거부했습니다. 확인된 동작이 없습니다.`; `Color Sync 전송이 시작되었지만 IntelliCenter가 응답하지 않았습니다. 동작이 실행되었을 수 있습니다. 다시 시도하기 전에 조명과 패널 상태를 확인하십시오.`; `IntelliCenter가 Color Sync를 확인했거나 눈에 띄게 시작했지만 신뢰할 수 있는 완료를 확인하지 못했습니다. 다시 시도하기 전에 조명과 패널 상태를 확인하십시오.`
+- `nl.json`: `Kleuren van lichtgroep synchroniseren`; `Synchroniseert precies twee GloBrite-lampen in een complete IntelliCenter-lichtgroep met firmware 1.064. De aanroep wacht op de fysieke actie, een observatie van 60 seconden na de actie en een laatste uitlezing van de controller.`; `Color Sync is alleen beschikbaar met IntelliCenter-firmware 1.064 voor een complete lichtgroep met precies twee verschillende GloBrite-lampen.`; `Color Sync is vóór verzending mislukt of IntelliCenter heeft de opdracht expliciet geweigerd. Er is geen actie bevestigd.`; `De verzending van Color Sync is gestart, maar IntelliCenter heeft niet gereageerd. De actie is mogelijk uitgevoerd. Controleer de lampen en de paneelstatus voordat u het opnieuw probeert.`; `IntelliCenter heeft Color Sync bevestigd of zichtbaar gestart, maar de betrouwbare voltooiing kon niet worden bevestigd. Controleer de lampen en de paneelstatus voordat u het opnieuw probeert.`
+- `pt.json`: `Sincronizar cores do grupo de luzes`; `Sincroniza exatamente duas luzes GloBrite de um grupo de luzes IntelliCenter completo com o firmware 1.064. A chamada aguarda a ação física, uma observação de 60 segundos após a ação e uma leitura final do controlador.`; `Color Sync está disponível apenas com o firmware 1.064 do IntelliCenter para um grupo de luzes completo com exatamente duas luzes GloBrite distintas.`; `Color Sync falhou antes do envio ou o IntelliCenter o rejeitou explicitamente. Nenhuma ação foi confirmada.`; `O envio de Color Sync foi iniciado, mas o IntelliCenter não respondeu. A ação pode ter sido executada. Inspecione as luzes e o estado do painel antes de tentar novamente.`; `O IntelliCenter confirmou ou iniciou visivelmente o Color Sync, mas não foi possível confirmar a conclusão de forma confiável. Inspecione as luzes e o estado do painel antes de tentar novamente.`
+- `ru.json`: `Синхронизировать цвета группы освещения`; `Синхронизирует ровно два разных светильника GloBrite в полной группе освещения IntelliCenter с прошивкой 1.064. Вызов ожидает физическое действие, 60-секундное наблюдение после действия и окончательное чтение данных контроллера.`; `Color Sync доступна только с прошивкой IntelliCenter 1.064 для полной группы освещения, содержащей ровно два разных светильника GloBrite.`; `Сбой Color Sync произошёл до отправки либо IntelliCenter явно отклонил команду. Выполнение действия не подтверждено.`; `Отправка Color Sync началась, но IntelliCenter не ответил. Возможно, действие было выполнено. Перед повторной попыткой проверьте светильники и состояние панели.`; `IntelliCenter подтвердил или явно начал Color Sync, но достоверное завершение подтвердить не удалось. Перед повторной попыткой проверьте светильники и состояние панели.`
+- `zh-Hans.json`: `同步灯光组颜色`; `在固件版本为 1.064 的 IntelliCenter 上，同步完整灯光组中恰好两个不同的 GloBrite 灯。此调用会等待实际操作、操作后的 60 秒观察和最终控制器读取完成。`; `Color Sync 仅适用于运行 IntelliCenter 固件 1.064 且包含恰好两个不同 GloBrite 灯的完整灯光组。`; `Color Sync 在发送前失败，或被 IntelliCenter 明确拒绝。未确认任何操作。`; `Color Sync 已开始发送，但 IntelliCenter 未返回响应。操作可能已运行。重试前请检查灯光和面板状态。`; `IntelliCenter 已确认或明显启动 Color Sync，但未能确认操作可靠完成。重试前请检查灯光和面板状态。`
+- `zh-Hant.json`: `同步燈光群組色彩`; `在韌體版本為 1.064 的 IntelliCenter 上，同步完整燈光群組中恰好兩個不同的 GloBrite 燈。此呼叫會等待實際動作、動作後的 60 秒觀察及最終控制器讀取完成。`; `Color Sync 僅適用於執行 IntelliCenter 韌體 1.064 且包含恰好兩個不同 GloBrite 燈的完整燈光群組。`; `Color Sync 在傳送前失敗，或被 IntelliCenter 明確拒絕。未確認任何動作。`; `Color Sync 已開始傳送，但 IntelliCenter 未回應。動作可能已執行。重試前請檢查燈光與面板狀態。`; `IntelliCenter 已確認或明顯啟動 Color Sync，但無法確認操作可靠完成。重試前請檢查燈光與面板狀態。`
+
+Run a key-parity check after editing:
+
+```bash
+for file in custom_components/intellicenter/translations/*.json; do
+  jq -e '.services.color_sync.name and .services.color_sync.description and .exceptions.light_group_command_unsupported.message and .exceptions.light_group_command_failed.message and .exceptions.light_group_command_uncertain.message and .exceptions.light_group_command_incomplete.message' "$file" >/dev/null
+done
+```
+
+Expected: all 12 files exit 0. Do not leave English fallback text in a non-English file.
+
+- [ ] **Step 3: Document behavior and negative scope**
+
+Update the Light Shows feature row to mention the Color Sync action over TCP/WebSocket. Add a service example:
+
+```yaml
+action:
+  - service: intellicenter.color_sync
+    target:
+      entity_id: light.pool_light_group
+```
+
+Explain that the call usually takes roughly 96-97 seconds plus request latency on the observed firmware, waits synchronously through a 60-second post-terminal observation and final read, and supports only firmware `1.064`, exactly two distinct GloBrite members, and uniform all-off/all-on state. During the action, other IntelliCenter object mutations requested through this Home Assistant connection fail immediately rather than queueing behind it; read-only updates continue, and urgent physical-panel control remains available but may cause the action to report incomplete. Explain the distinction between explicit failure, uncertain no-response dispatch, and acknowledged/started incomplete outcomes; for the latter two, tell users to inspect the lights/panel before retrying. Explicitly state Color Set, Color Swim, and member-position controls are not exposed.
+
+- [ ] **Step 4: Add integration changelog entries under `[Unreleased]`**
+
+Under `Added`, record the `intellicenter.color_sync` service. Under `Fixed`, record that real `CIRCUIT` parents are no longer confused with `CIRCGRP` membership rows. Under `Changed`, record the pyintellicenter 0.1.22 floor and the blocking authoritative lifecycle.
+
+- [ ] **Step 5: Validate JSON, metadata, docs, and dependency drift**
+
+```bash
+for file in custom_components/intellicenter/strings.json custom_components/intellicenter/translations/*.json; do
+  python -m json.tool "$file" >/dev/null
+done
+uv run --no-sync pytest tests/test_light.py tests/test_library_contract.py tests/test_versions.py -q
+if rg -n 'color_set|color_swim|member_position' custom_components/intellicenter; then
+  exit 1
+fi
+git diff --check
+```
+
+Expected: JSON and tests pass, forbidden service/API names are absent from production integration files, and diff whitespace is clean. Negative tests and README scope documentation may name omitted features.
+
+- [ ] **Step 6: Commit localization and docs**
+
+```bash
+git add custom_components/intellicenter/strings.json custom_components/intellicenter/translations README.md CHANGELOG.md
+git commit -m "docs: localize and document Color Sync"
+```
+
+---
+
+### Task 12: Verify, adversarially review, and open the integration feature PR
+
+**Files:**
+- Modify only files required to resolve accepted review findings.
+
+**Interfaces:**
+- Consumes: released pyintellicenter 0.1.22 and green Tasks 9-11.
+- Produces: one reviewed intellicenter feature PR targeting `main`, with integration version still `3.10.0b2`.
+
+- [ ] **Step 1: Stop for the published-wheel checkpoint, then replace the editable overlay**
+
+Do not regenerate the lock or open this PR until Task 8's read-only isolated check proves `pyintellicenter==0.1.22` is on PyPI. After maintainer publication is confirmed, first remove the temporary editable overlay by restoring the frozen environment. Using `apply_patch`, set the pyintellicenter dependency string in both `custom_components/intellicenter/manifest.json` and `pyproject.toml` to exact floor `pyintellicenter>=0.1.22`; then regenerate from the registry and prove the installed distribution is not editable:
+
+```bash
+uv sync --frozen
+uv lock --upgrade-package pyintellicenter
+uv sync --frozen
+uv run python -c \
+  'from importlib import metadata; import pyintellicenter; assert pyintellicenter.__version__ == "0.1.22"; direct = metadata.distribution("pyintellicenter").read_text("direct_url.json"); assert direct is None or "editable" not in direct'
+uv run pytest tests/test_library_contract.py tests/test_versions.py -q
+git diff --check
+git add custom_components/intellicenter/manifest.json pyproject.toml uv.lock
+git commit -m "chore: require pyintellicenter 0.1.22"
+```
+
+Expected: manifest, pyproject, and lock agree on the released registry artifact; no worktree path/git source exists in the diff or `direct_url.json`.
+
+- [ ] **Step 2: Run the complete local integration gate**
+
+```bash
+uv sync --frozen
+uv run pytest tests/ -v --tb=short --cov=custom_components/intellicenter
+uv run ruff check custom_components/
+uv run ruff format --check custom_components/
+uv run mypy custom_components/intellicenter/
+uv run bandit -r custom_components/intellicenter/ -ll
+uv lock --check
+git diff --check
+git status --short
+```
+
+Expected: every local CI-equivalent gate passes; status lists only issue #93 files.
+
+- [ ] **Step 3: Ask `agy` for the Home Assistant adversarial review**
+
+```bash
+agy --mode plan --sandbox --add-dir "$PWD" \
+  --model 'Claude Opus 4.6 (Thinking)' --print-timeout 20m --print \
+  'Adversarially review this intellicenter issue #93 branch against origin/main. Verify that real CIRCUIT/LITSHO parents and CIRCGRP membership rows are modeled without duplicate entities; only color_sync is registered; eligibility is exact firmware 1.064 plus exactly two distinct resolved GLOW children while broader color helpers remain read/effect-only; ordinary/incomplete/one-or-three-member groups reject before the library call; the service awaits run_light_group_sync and separately maps unsupported ValueError, prewrite/explicit rejection, dispatched-no-response uncertainty, and acknowledged-or-started incomplete ICLightGroupError outcomes with acknowledged/onset precedence; no effect or optimistic state is invented; coordinator row tracking is exactly PARENT/CIRCUIT/LISTORD; all five locale keys and metadata are complete; pyintellicenter>=0.1.22 is a non-editable registry dependency consistent in manifest, pyproject, and lock; and Set, Swim, and member position remain absent. Report actionable findings by severity with file/line and an executable fix; do not edit.'
+```
+
+- [ ] **Step 4: Ask Cursor `agent` for an independent Home Assistant review**
+
+```bash
+agent --print --output-format text --mode ask --sandbox enabled --trust \
+  --workspace "$PWD" --model 'claude-opus-4-8-thinking-high' \
+  'Independently adversarially review this issue #93 Home Assistant branch versus origin/main. Search for duplicate row-derived entities, vacuous all() membership checks, action eligibility beyond exact firmware 1.064/exactly two distinct GLOW children, unsupported service exposure, mock-hidden or editable library drift, wrong ICLightGroupError certainty precedence/translations, optimistic/effect state leakage, missing five-key locale/service metadata, lockfile/version drift, weak negative tests, and accidental Color Set/Swim/member-position scope. Confirm the dedicated run_light_group_sync call and non-editable released 0.1.22 wheel. Return only actionable severity-ranked findings with file/line; do not edit.'
+```
+
+- [ ] **Step 5: Resolve/re-review every finding**
+
+Use the same evidence-led ledger process as Task 7. Add a failing regression test before each accepted code fix, run its focused gate, then the complete Step 2 gate. Re-run both reviewers after material changes; no critical/high finding may remain unresolved.
+
+- [ ] **Step 6: Stop for explicit live-smoke authorization, then perform one controlled production-path smoke**
+
+This changes physical lights and is not implied by permission to implement/open PRs. Stop and obtain explicit user authorization for the named private test panel and target. If authorized, configure the private Home Assistant/test instance first for TCP and then WebSocket. Confirm firmware `1.064`, `SERVICE=AUTO`, exactly two distinct GloBrite children, uniform all-off or all-on state, and all group flags off. Invoke `intellicenter.color_sync` exactly once per transport; require the service to remain pending through terminal, the full 60-second post-terminal observation, and final read, then succeed without any projected collateral change. Restore only through the official UI if the target changed. Abort on any invariant failure, timeout, disconnect, or inability to restore. Record only sanitized timing/certainty facts in the PR body; never commit identifiers or raw frames. If authorization is withheld, mark the gate not run and stop before release rather than simulating success.
+
+- [ ] **Step 7: Push and open the integration feature PR**
+
+```bash
+git push -u origin feature/issue-93-light-group-sync
+gh pr create --repo joyfulhouse/intellicenter --base main \
+  --head feature/issue-93-light-group-sync \
+  --title "feat: add verified light-group Color Sync" \
+  --body-file /tmp/intellicenter-issue-93-pr.md
+```
+
+The PR body must link the pyintellicenter feature/release, state the exact firmware-1.064/two-GloBrite supported envelope and omitted matrix, explain the four failure-certainty translations, summarize both external reviews and authorized live smoke, and list exact verification commands. Expected: open PR with green CI, hassfest, and HACS checks. This step is forbidden until Step 1 proves the published wheel and registry lock.
+
+---
+
+### Task 13: Release intellicenter 3.10.0b3 after the feature merges
+
+**Files:**
+- Modify: `custom_components/intellicenter/manifest.json`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: maintainer-confirmed integration feature merge and published pyintellicenter 0.1.22.
+- Produces: separate release PR; after explicit maintainer merge/publication checkpoints, GitHub pre-release `v3.10.0b3`.
+
+- [ ] **Step 1: Stop for the integration-merge checkpoint, then create a release worktree**
+
+Do not merge the integration feature PR. Request maintainer/user confirmation that it has merged, then fetch and verify `origin/main` contains it before creating the worktree:
+
+```bash
+git -C /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter fetch origin
+git -C /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter worktree add \
+  /Users/bryanli/Projects/joyfulhouse/homeassistant-dev/intellicenter-release-3.10.0b3 \
+  -b chore/release-3.10.0b3 origin/main
+```
+
+Expected: base contains the maintainer-merged issue #93 feature. Stop if merge confirmation or fetched ancestry is absent.
+
+- [ ] **Step 2: Synchronize release metadata**
+
+Set both manifest and pyproject versions to `3.10.0b3`; promote `[Unreleased]` entries to `## [3.10.0b3] - 2026-07-15`; run `uv lock` so the root package version changes while pyintellicenter remains 0.1.22.
+
+- [ ] **Step 3: Run release gates and open the release PR**
+
+```bash
+uv sync --frozen
+uv run pytest tests/ -q
+uv run ruff check custom_components/
+uv run ruff format --check custom_components/
+uv run mypy custom_components/intellicenter/
+uv run bandit -r custom_components/intellicenter/ -ll
+uv run pytest tests/test_versions.py -q
+git diff --check
+git add custom_components/intellicenter/manifest.json pyproject.toml uv.lock CHANGELOG.md
+git commit -m "chore: release 3.10.0b3"
+git push -u origin chore/release-3.10.0b3
+gh pr create --repo joyfulhouse/intellicenter --base main \
+  --head chore/release-3.10.0b3 --title "chore: release 3.10.0b3" \
+  --body "Pre-release with corrected light-group modeling and verified TCP/WebSocket Color Sync for issue #93."
+```
+
+Expected: green release PR with exact manifest/pyproject/lock version parity.
+
+- [ ] **Step 4: Stop for release-PR merge and GitHub pre-release publication**
+
+Do not merge the release PR, create a tag, or publish a GitHub pre-release. Request explicit maintainer/user authorization and confirmation. After the maintainer publishes `v3.10.0b3`, wait for `.github/workflows/release.yml` to attach `intellicenter.zip`, then perform the read-only archive inspection to confirm it contains the updated manifest, `services.yaml`, strings/translations, and no `.env`, cache, or test files.
+
+---
+
+## Final Acceptance Checklist
+
+- [ ] `get_circuit_groups()` returns only real parent `CIRCUIT` objects; ordered `CIRCGRP` rows and resolved children are available through corrected helpers.
+- [ ] Direct legacy standalone-row resolution remains tested, but legacy/orphan rows never enumerate as groups or entities.
+- [ ] `run_light_group_sync()` is the only group-action API; there is no generic command token, Set, Swim, or member-position writer.
+- [ ] TCP and WebSocket, uniform OFF and ON, pre-ACK notification, leading-order variation, and sender-side `SYNC` edges are tested.
+- [ ] Writer eligibility is exactly firmware `1.064`, one `CIRCUIT/LITSHO` parent, and exactly two distinct resolved `CIRCUIT/GLOW` children; broader color helpers remain read/effect-only.
+- [ ] A raw observer is installed before the first wildcard projection; its bounded pre-baseline buffer is replayed, subscription batches and initialization values are validated, the post-settle fresh projection matches exactly, and any transient projected prewrite change aborts before dispatch.
+- [ ] The connection-owned sequence is monotonic; event-loop time starts the deadline under the request lock immediately before TCP write/WebSocket send initiation, the causal sequence watermark is captured immediately after TCP write/WebSocket send completion, and only `sequence > post_send_watermark` qualifies action edges.
+- [ ] Success requires an exact `200`, positive onset and terminal by `write_started_at + 60`, a separate 60-second post-terminal observation, and a mandatory clean final `GetParamList` on the captured connection.
+- [ ] From dispatch start through observer removal, target monotonic status rules (including no post-terminal `SYNC` re-entry), all required circuit identity/status fields, normalized optional circuit `PARENT/USE`, all group flags, required row topology, normalized optional row `USE`, and system fields reject even transient-restored violations.
+- [ ] Observer fanout is additive/enqueue-time/stale-safe and cleans up on every exit; captured-connection and disconnect/reconnect races are tested.
+- [ ] Sync marks its owner-aware lifecycle pending before waiting for already-started case-insensitive public `SetParamList` writers; later writers/Sync calls fail fast instead of queueing, direct raw `ICConnection` use is explicitly outside that boundary, and no state-changing request is retried or automatically recovered.
+- [ ] `ICLightGroupError` reports phase/dispatch/response/acknowledgement/onset certainty, and Home Assistant separately maps unsupported, failed/rejected, uncertain dispatch, and acknowledged/started incomplete outcomes.
+- [ ] Home Assistant creates no row entity and exposes only `intellicenter.color_sync` on the evidence-scoped parent light, without effect or optimistic state.
+- [ ] Coordinator membership-row tracking is exactly `PARENT`, `CIRCUIT`, `LISTORD`.
+- [ ] All 12 locale files, service metadata, README, changelogs, installed-library contract, and dependency/version drift tests pass.
+- [ ] Exact firmware-`1.064`/two-`GLOW` action eligibility and broader read-only color classification are accepted in both adversarial reviews.
+- [ ] A maintainer-published, non-editable pyintellicenter 0.1.22 wheel is locked before the integration PR opens; every merge/tag/PyPI/GitHub release and live-smoke mutation occurs only at its explicit user/maintainer checkpoint.
+- [ ] Full local gates, `agy`, Cursor `agent`, GitHub Actions, hassfest, and HACS are green with no unresolved critical/high finding.

--- a/docs/superpowers/specs/2026-07-14-light-group-actions-design.md
+++ b/docs/superpowers/specs/2026-07-14-light-group-actions-design.md
@@ -1,0 +1,596 @@
+# Design: Light Group Actions and Membership Modeling (Issue #93)
+
+**Date:** 2026-07-14
+**Updated:** 2026-07-15
+**Branch:** `docs/issues-92-93-plans`
+**Issue:** [#93 — true circuit/light group entities + Sync/Swim/Set](https://github.com/joyfulhouse/intellicenter/issues/93)
+**Evidence:** [Light group protocol discovery](../evidence/2026-07-14-light-group-protocol.md)
+
+## Problem
+
+The issue originally assumed each `CIRCGRP` object represented a group. Live
+hardware disproved that model:
+
+- The controllable group is a `CIRCUIT` whose subtype is `CIRCGRP` or `LITSHO`.
+- Each `CIRCGRP` object is one membership row with a `PARENT` reference to the
+  group circuit, one singular `CIRCUIT` reference, `LISTORD`, and the
+  per-member `USE` value observed on the test unit.
+- `CIRCGRP.SNAME` and `CIRCGRP.STATUS` are unsupported placeholder echoes.
+
+Basic group on/off control already shipped through the parent circuit path in
+PR #105. Building entities directly from membership rows would create duplicate
+garbage entities. The remaining work is to correct pyintellicenter's group
+helpers and expose only the light-group action contracts that passed controlled
+official-client capture and local transport replay.
+
+## Goal
+
+1. Make pyintellicenter model real hardware groups without breaking legacy
+   fixture/API behavior unnecessarily.
+2. Expose Color Sync as a momentary action on an existing `LITSHO` light entity
+   over TCP and WebSocket, the two transports whose same-connection sender
+   lifecycle passed the final protocol gate.
+3. Omit Color Set, Color Swim, and member-position configuration because their
+   independent safety and discovery gates did not pass.
+
+## Planning Boundary
+
+Implementation remains split into separately reviewed plans so the captured
+protocol boundary cannot leak into broader group-model changes:
+
+1. capture and sanitize the official-client and local replay evidence;
+2. close the sender-side field, prestate, and timing gates identified by
+   adversarial review;
+3. correct the library group model and its compatibility contract;
+4. implement Sync on TCP and WebSocket, the only transport/action pairs that
+   passed the sender-side gate; and
+5. reject Set, Swim, unsupported action tokens, and incomplete group topology
+   before state-changing network I/O.
+
+Discovery established exact request payloads, acknowledgements, transport
+differences, collateral-change checks, and restoration evidence. Adversarial
+review found that the action-active field differed by receiving client and
+that the original 60-second gate was not a valid universal bound. The final
+same-connection gate passed Sync over both transports and rejected TCP Swim
+after a late mixed target state. Production implementation waits only for the
+separately reviewed implementation plan. Discovery did not establish a
+member-position writer or finite option set, so no position implementation
+plan or select is in scope.
+
+## Non-Goals
+
+- Do not create switch or light entities for `CIRCGRP` membership rows.
+- Do not duplicate the parent circuit's existing on/off light/switch entity.
+- Do not add group creation/deletion, membership editing, or arbitrary circuit
+  batching.
+- Do not infer group type from membership-row attributes.
+- Do not optimistically change a group effect or member position.
+- Do not expose unsupported `CIRCGRP.SNAME` or `CIRCGRP.STATUS` values.
+- Do not serialize the disproved `{ACT: token, STATUS: ON}` proposal.
+- Do not expose Color Set, Color Swim on either transport, or member-position
+  selects.
+
+## Corrected Hardware Model
+
+```text
+CIRCUIT parent (SUBTYP=LITSHO)
+  <- CIRCGRP membership row A (PARENT=parent, CIRCUIT=child A, LISTORD=1)
+  <- CIRCGRP membership row B (PARENT=parent, CIRCUIT=child B, LISTORD=2)
+
+CIRCUIT child A (SUBTYP=GLOW)
+CIRCUIT child B (SUBTYP=GLOW)
+```
+
+The parent circuit owns identity, display name, power, and group actions. The
+rows own membership references and order. Discovery did not prove a supported
+per-member writer. Referenced child circuits own each physical light's ordinary
+state and capabilities.
+
+## Protocol Discovery Results
+
+Discovery used firmware `1.064` in `SERVICE=AUTO`. Independent TCP and
+WebSocket baselines were identical and contained exactly one complete target:
+one `LITSHO` parent, two `CIRCGRP` membership rows, and two resolved `GLOW`
+children. Complete, non-empty membership remains a mandatory read-model
+predicate; the initial writer narrows eligibility to this exact firmware,
+member count, and child subtype.
+
+The official client repeated each valid action twice with exact mixed-case
+`SetParamList`, one parent object, and one dedicated parameter:
+
+| Action | Accepted official runs | Parent params | Correlated response | Official completion |
+| --- | --- | --- | --- | --- |
+| Sync | 3 and 4 | `{"SYNC": "ON"}` | `200` | complete lifecycle |
+| Set | 2 and 3 | `{"SET": "ON"}` | `200` | complete lifecycle |
+| Swim | 1 and 2 | `{"SWIM": "ON"}` | `200` | complete lifecycle |
+
+The semantic lifecycle tolerated leading-order variation, but its
+action-active key depended on the receiving client. For every action, the
+official browser connection saw parent `SWIM=ON` then `SWIM=OFF`, while the
+simultaneous local observer saw parent `SYNC=ON` then `SYNC=OFF`. Both saw the
+parent and resolved children reach `STATUS=ON`. Browser terminal timings were
+about 36 seconds for Sync, 75 seconds for Swim, and 103 seconds for Set. Only
+the parent and two children persisted `STATUS=OFF` to `STATUS=ON`; no
+membership or unrelated inventory delta remained. Each valid official run was
+restored and checked twice. Earlier Sync runs 1 and 2 and Set run 1 were
+discarded because an unrelated generic circuit changed during their capture
+windows.
+
+Initial cross-client local replay produced a narrower matrix:
+
+| Action | TCP | WebSocket | Initial result |
+| --- | --- | --- | --- |
+| Sync | five-push cross-client lifecycle passed | five-push cross-client lifecycle passed | advance both transports |
+| Set | `200`, four leading pushes, then no terminal edge and persisted action flags | same failure | omit this local path and reject before state-changing I/O |
+| Swim | `200`, four leading pushes; a 60-second read appeared clean | `200`, four leading pushes, then stuck action flags | advance TCP to a longer run; omit WebSocket |
+
+Both Set replays lacked the final `SYNC=OFF` and left `SYNC`, `SET`, and
+`SWIM` persisted as `ON` on the target and another group with
+`SUBTYP=CIRCGRP`. WebSocket Swim left the same action flags stuck `ON`.
+
+The final production-shaped harness subscribed and sent on one connection,
+armed before the write, retained pre-response notifications, observed for 180
+seconds, and finished with full in-band inventory reads:
+
+| Action | Transport / prestate | Sender-side result | Persistent result |
+| --- | --- | --- | --- |
+| Sync | TCP / all off | `SYNC=ON` at 0.219557 s; target statuses on at 1.255901–1.258996 s; `SYNC=OFF` at 35.286805 s | only the three expected target statuses changed |
+| Sync | TCP / all on | `SYNC=ON` at 0.275896 s; `SYNC=OFF` at 36.238773 s | no status edge and no inventory delta |
+| Sync | WebSocket / all off | `SYNC=ON` at 0.852700 s; target statuses on at 0.852716–0.852729 s; `SYNC=OFF` at 35.852674 s | only the three expected target statuses changed |
+| Sync | WebSocket / all on | `SYNC=ON` at 0.765173 s; `SYNC=OFF` at 35.773954 s | no status edge and no inventory delta |
+| Swim | TCP / all off | `SYNC=ON` at 0.593273 s; target statuses on at 0.602877–0.602899 s; `SYNC=OFF` at 74.567605 s; both children off at 83.613525–83.614324 s | mixed final state: parent on, both children off |
+
+Every write received a correlated `200` in at most 0.011 seconds. No run
+produced a collateral-group action-flag edge. The sender-side field was `SYNC`
+on both transports. Sync therefore passed on TCP and WebSocket from uniform
+all-off and all-on prestates. Mixed prestates remain unsupported.
+
+TCP Swim failed. Its late child-off edges show that neither its terminal flag
+nor its earlier 60-second read represented a stable supported result. No
+Swim-from-on run was justified after the all-off contract failed. Set and Swim
+are omitted on both transports and rejected before state-changing I/O.
+
+Sync uses a Sync-specific 60-second terminal bound: both official and all four
+sender-side Sync observations completed in at most 36.370 seconds. This value
+is not generalized to Set or Swim. Because Swim demonstrated late status
+changes after a terminal flag, Sync completion also retains a 60-second
+post-terminal observation interval and an in-band final projection read. All
+Sync captures remained free of late target or collateral edges throughout
+their 180-second windows.
+
+The official Web App bundle used for discovery had SHA-256
+`933e2fc35fd5e5fe26477f0199873bedaf4c266d510f6e8259e3684da18317fd`.
+It exposed no member-position writer: the relevant chips were hidden,
+membership-row `USE` was neither read nor written, and no membership-row `ACT`
+or `LISTORD` write existed. There is no verified writable/readable field or
+finite option map, so member positioning is omitted.
+
+Every failed state was restored through a freshly reloaded official UI. The
+same-connection restores each contained one exact parent `STATUS=OFF` write and
+a correlated `200`; independent TCP and WebSocket reads matched the applicable
+quiet baseline exactly. The complete sanitized record, including the one
+unrelated between-run transition, fresh quiet gate, accepted run numbers, and
+limitations, is in the linked evidence document.
+
+## pyintellicenter Design
+
+### Read helpers
+
+Correct `_mixins/circuit_group.py` around the parent/row relationship:
+
+- `get_circuit_group_members(parent_objnam: str) -> list[PoolObject]` returns
+  `OBJTYP=CIRCGRP` rows whose `PARENT` matches the parent circuit, sorted by
+  nonnegative numeric `LISTORD` with negative/malformed/missing values last and
+  `objnam` as a total deterministic tiebreaker.
+- `get_circuits_in_group(group_or_row_objnam: str) -> list[PoolObject]`
+  resolves each member row's singular `CIRCUIT` reference, preserving row order
+  and skipping missing references safely.
+- `circuit_group_has_color_lights(parent_objnam: str) -> bool` evaluates the
+  resolved child circuits without implying command eligibility.
+- `get_color_light_groups() -> list[PoolObject]` returns parent group circuits
+  that contain color lights, never membership rows. Action eligibility remains
+  the narrower complete `OBJTYP=CIRCUIT/SUBTYP=LITSHO` predicate.
+
+For compatibility, `get_circuits_in_group()` also accepts a legacy standalone
+`CIRCGRP` object with a space-separated `CIRCUIT` value. When passed a real
+membership row with `PARENT`, it resolves the parent and aggregates all sibling
+rows. Existing artificial fixtures therefore keep working while real hardware
+gets correct results.
+
+`get_circuit_groups() -> list[PoolObject]` returns only unique parent
+`OBJTYP=CIRCUIT` objects whose `SUBTYP` is `CIRCGRP` or `LITSHO`, in model
+order. `OBJTYP=CIRCGRP` always means a membership row; `SUBTYP=CIRCGRP` on a
+`CIRCUIT` means a parent group. It never promotes an orphan or malformed
+membership row. This is an intentional correction to a pre-1.0 public helper.
+Legacy compatibility is confined to a direct
+`get_circuits_in_group(legacy_objnam)` call for an exact standalone fixture
+shape; legacy rows do not appear in group enumeration or color-group results.
+Add tests and documentation that make this boundary explicit.
+
+### Command helper and completion substrate
+
+Add one dedicated public helper for the action that passed the sender-side
+gate:
+
+```python
+async def run_light_group_sync(group_objnam: str) -> dict[str, Any]:
+```
+
+The cached target shape is rejected before any network request. There is no
+public Set or Swim command entry point. The helper then captures the current
+connection, takes a controller-wide mutation lifecycle lock, and performs a
+fresh, in-band preflight. Before the write it requires:
+
+- exactly one `SYSTEM` with the raw wire token `VER=1.064` and `SERVICE=AUTO`;
+- a parent `OBJTYP=CIRCUIT/SUBTYP=LITSHO` with exactly two membership rows;
+- two distinct, fully resolved `CIRCUIT/SUBTYP=GLOW` children;
+- a uniform all-off or all-on target power prestate, rejecting mixed state; and
+- `SYNC`, `SET`, and `SWIM` all `OFF` on the target and every other parent
+  `CIRCUIT` whose subtype is `LITSHO` or `CIRCGRP`.
+
+The initial collateral-sensitive projection contains system version/mode;
+required identity/type/subtype/status plus normalized optional parent/`USE` for
+every `CIRCUIT`; action flags for every real group parent; and required
+`PARENT`/`CIRCUIT`/`LISTORD` plus normalized optional `USE` for every `CIRCGRP`
+membership row. It is one existing-shape wildcard `GetParamList` with a fixed
+12-key union, not a per-object request whose size grows with installation
+inventory. For those optional fields only, missing, `None`, exact key-name
+echo, and `"00000"` normalize to one absent value and are compared to baseline.
+Mandatory fields never accept those sentinels. This matches ordinary
+parentless/non-color circuits instead of requiring unsupported attributes to
+become real. Dynamic temperature, RPM, flow, and schedule telemetry is
+excluded.
+
+The connection layer adds a non-replacing raw observer that assigns one
+monotonic sequence number when each notification is accepted, before the
+existing callback queue. The observer is installed before the first wildcard
+projection read. It holds a bounded pre-baseline buffer and fails closed on
+overflow; once that response validates, buffered frames are replayed against
+the baseline in sequence. It parses every `NotifyList` entry in wire order,
+fails closed on malformed frames where relevance cannot be excluded, and never
+lets duplicate change-then-restore entries collapse into a clean frame. Its
+first irreversible violation sets a one-shot failure signal synchronously so
+the active request or timer wait wakes immediately. Exact-object
+`RequestParamList` subscriptions are
+split into batches at the existing 50-key ceiling. Every initialization
+response must contain every requested object exactly once, no duplicate or
+extra entry, every mandatory key with a real value, and every optional key as a
+normalizable value or omission; its normalized projection must equal the
+baseline slice rather than being applied blindly. After
+the same one-second settle interval exercised in discovery, the helper repeats
+the wildcard preflight on the captured connection and requires it to match the
+first projection. Any intervening projected deviation fails even if it later
+returns to baseline.
+
+The connection send primitive accepts separate private pre-send and post-send
+hooks. While the connection request lock is held, the pre-send hook records the
+event-loop monotonic deadline origin and marks dispatch started immediately
+before synchronous TCP write or awaited WebSocket send. A pre-send callback
+failure leaves that flag false and prevents the transport call. The post-send
+hook captures the notification sequence immediately after TCP write returns or
+WebSocket send finishes. Only notifications whose sequence is greater than
+that causal post-send watermark can establish onset. This excludes a
+notification received after observer registration but before the packet, and
+conservatively excludes frames processed while awaited WebSocket send is
+suspended; those frames still undergo invariant checks. The controller races
+the action task against the pre-send signal and immediately arms the absolute
+60-second deadline, so a stalled WebSocket send is bounded without using its
+pre-send sequence as false causal evidence.
+
+The helper serializes exact mixed-case `SetParamList` directly with one parent
+object and `{"SYNC": "ON"}`. It requires a correlated
+`response == "200"`, a post-watermark parent `SYNC=ON` edge, and a later parent
+`SYNC=OFF` edge within 60 seconds. Leading status/action order may vary. The
+all-off discovery runs produced post-watermark parent/child `STATUS=ON`
+updates, but production success proves the target statuses through the
+monotonic tracker plus mandatory final projection rather than making each
+status push a separate lifecycle edge. The all-on prestate does not require
+redundant status notifications.
+
+The observer enforces normalized invariants from dispatch start until removal:
+
+- an all-on target object never leaves `STATUS=ON`;
+- after each all-off target object reaches `STATUS=ON`, it never returns off;
+- every circuit `OBJTYP`, `SUBTYP`, and normalized optional `PARENT`, plus
+  target `SET`, `SWIM`, and normalized optional `USE`, never deviate from
+  baseline;
+- every unrelated circuit `STATUS` and normalized optional `USE` remains at baseline, so an
+  unrelated schedule/panel transition conservatively fails the action rather
+  than weakening causal attribution;
+- every other group action flag remains `OFF`; and
+- system mode and all membership topology/order/normalized optional `USE`
+  remain unchanged.
+
+Target `SYNC` may make only its qualifying `OFF -> ON -> OFF` transition. A
+later `SYNC=ON` re-entry after terminal is a permanent failure even if another
+`OFF` and clean final read follow.
+
+The tracker also retains the cached all-object type inventory. A notification
+introducing an unknown `CIRCUIT`, `CIRCGRP`, or `SYSTEM`—or an unknown object
+with projected keys but no trustworthy type—is an irreversible topology
+failure even if it disappears before the next wildcard read. A dynamic type map
+lets well-formed partial updates for currently irrelevant objects remain
+outside the projection, but an explicit transition into `CIRCUIT`, `CIRCGRP`,
+or `SYSTEM` fails irreversibly even if the same or a later frame restores it.
+
+After the terminal edge, the observer remains armed for a 60-second quiet
+interval. The helper then performs one fresh in-band projection read on the
+same captured connection. It must prove the target parent and both children
+`STATUS=ON`, all group action flags `OFF`, and every other projected value,
+including every circuit's `OBJTYP` and `SUBTYP`, equal to the
+post-subscription baseline. A clean read never substitutes for a missing onset
+or terminal edge.
+
+Add a phase-aware `ICLightGroupError(ICError)` for failures after dispatch
+begins. It records `phase`, an always-true `dispatch_started`, `response_received`,
+`acknowledged`, and `onset_seen`; the original cause remains chained. Cached
+eligibility-shape rejection uses `ValueError`; fresh projection, subscription,
+preflight, connection, and read failures before dispatch retain an ordinary
+`ICError` type. This avoids misusing request-response
+`ICTimeoutError` for a missing lifecycle edge and lets consumers distinguish an
+explicit rejection, uncertain delivery, acknowledged-but-incomplete action,
+and failed final verification. `phase` names the gate that failed, so an onset
+push may coexist with `phase="acknowledgement"` when its correlated response
+never arrives.
+
+The helper returns the complete correlated transport acknowledgement exactly
+as supplied—including its real `messageID`, `response`, and any opaque vendor
+fields—only after authoritative completion. It does not require or invent a
+response-side command echo; tests prove unchanged passthrough with a realistic
+full response rather than a bare `{"response":"200"}`. It never retries a state-changing request and never optimistically
+mutates model state. It explicitly gives the state-changing request the same
+60-second response bound as the dispatch-start lifecycle instead of inheriting the
+connection's shorter default. Sync marks an exclusive mutation lifecycle
+pending before waiting for already-started case-insensitive `SetParamList`
+work. Those earlier writes drain first; later `send_cmd()` calls,
+`request_changes()`, coalesced flushes, and a second Sync fail immediately with
+an ordinary pre-dispatch `ICError` rather than queueing for roughly two minutes.
+Both coalescing entry points perform that check synchronously before appending a
+future or mutation, so a later convenience call cannot hide behind the
+coalesce lock and replay after Sync. Pending requests retain their own proposed
+changes; canceling one before batch detachment removes that request and rebuilds
+the aggregate in admission order, preventing a canceled latest-value override
+from surviving the lifecycle boundary. Once a batch is detached, cancellation
+never causes a retry or requeue of its possibly dispatched mutation.
+Read-only traffic and model callbacks continue. A private captured-connection
+send primitive preserves metrics/error translation without reacquiring the
+lock and is used only by the Sync helper while it owns the lifecycle. One fresh
+opaque identity lease authorizes the explicitly delegated action task without
+confusing that child for the lock-owning task; cleanup awaits every child and
+invalidates the lease before releasing ownership. A
+separately created raw `ICConnection` or the physical panel remains outside
+that boundary; a projected external change makes the action incomplete.
+
+Immediately after capturing the live connection, the helper synchronously
+captures a one-shot close future bound to that exact connection generation.
+Every wildcard read, subscription initialization, action response, settle,
+onset, terminal, and post-terminal wait races it and the tracker's first-failure
+signal; disconnect or invariant failure therefore aborts the current
+pre/post-dispatch phase immediately, never after only a generic deadline.
+Reusing the instance creates a distinct future without clearing the old
+completed one, and a replacement generation/connection cannot contribute
+completion frames. Although raw observer state survives transport replacement,
+the action's observer closure checks the captured future before every frame and
+stops forwarding once it is done. Simultaneous readiness is handled in the
+fixed order closure, tracker failure, deadline, then response/action success.
+
+Do not add `set_light_group_member_position()`. Discovery found no official
+writer, durable readable field, or finite option set. Complete membership is
+not provisional: the capture did not prove that `LITSHO` alone is a sufficient
+and safe capability predicate.
+
+## Coordinator Tracking
+
+Replace the current unsupported `CIRCGRP_TYPE` tracking keys with verified row
+semantics:
+
+- always track `PARENT`, `CIRCUIT`, and `LISTORD`;
+- do not add `USE` as configuration state because no member-position
+  read/write contract passed;
+- do not expose `ACT`, `SYNC`, `SET`, or `SWIM` as durable entity state; the
+  helper subscribes to verified action flags as internal momentary monitoring
+  data;
+- remove `SNAME` and `STATUS` from membership-row tracking.
+
+The parent group remains a normal `CIRCUIT_TYPE` object and continues using the
+existing circuit tracking and `PoolLight`/`PoolCircuit` creation paths.
+
+## Home Assistant Design
+
+### Momentary group actions
+
+Extend `light.py`'s existing entity-service registration with:
+
+- `color_sync` -> `PoolLight.async_color_sync()`.
+
+The method is available through the service registry but validates at call time
+that cached firmware's raw `sw_version` token is exactly `1.064` and its entity
+is a `LITSHO` parent with exactly two distinct resolved `GLOW` children. This
+state-changing evidence gate intentionally does not use the integration's
+display/upgrade `parse_ic_version()` helper: prefixes, suffixes, or whitespace
+were not captured and remain unsupported even if a semantic parser could
+interpret them. The library repeats all validation from fresh raw reads.
+Unsupported targets raise a translated
+`light_group_command_unsupported` error before state-changing I/O.
+
+Valid calls await `run_light_group_sync()` through a group-specific error
+wrapper. Pre-write connection/read failures and explicit panel rejection use
+`light_group_command_failed`. A dispatch with no response uses
+`light_group_command_uncertain`. An acknowledged or observed-started action
+whose lifecycle/final verification fails uses
+`light_group_command_incomplete` and tells the user to inspect the lights.
+`ICLightGroupError` phase fields, rather than a generic timeout assumption,
+select the truthful translation.
+
+Color Sync is an action, not a persistent Home Assistant effect. It does not
+enter `effect_list`, and the entity does not invent an effect after a press.
+Color Set and Color Swim are not registered because their local safety gates
+failed.
+
+Add service metadata and translations for all supported locales, following the
+existing Capture/Thumper/Hold/Recall service pattern. Document that the service
+call waits for the physical action lifecycle, 60-second post-terminal interval,
+and final read and therefore normally blocks a calling script for roughly 96
+seconds and can exceed 120 seconds at the timeout boundary. While it runs, new
+object mutations through the same Home Assistant controller fail immediately
+rather than being delayed; read updates continue. The physical panel remains
+available for urgent control, with the explicit consequence that a projected
+change can make Color Sync report incomplete.
+
+### Member position selects
+
+Do not create member-position selects. The deployed official client provided
+no writer or finite option map, and membership-row `USE` was not proven as a
+durable writable setting. Existing membership rows remain model-only objects
+and never create entities.
+
+## Data Flow
+
+```text
+Group service -> PoolLight -> pyintellicenter group command -> parent CIRCUIT
+  -> fresh preflight + scoped subscription + pre-send tracker
+  -> correlated acknowledgement + sender-side SYNC lifecycle
+  -> 60-second post-terminal interval + required in-band final projection
+  -> existing PoolLight state
+```
+
+## Error Handling
+
+- Disconnected coordinators make entities unavailable through `PoolEntity`.
+- Invalid firmware/target shape is rejected before network I/O; mixed prestates
+  are rejected by the fresh preflight before the write.
+- Pre-write failure, explicit rejection, uncertain dispatch, and
+  acknowledged/started-but-incomplete failure become distinct translated
+  `HomeAssistantError` messages.
+- Empty, mixed-capability, missing, or unresolved group membership rejects
+  commands before network I/O.
+- Set and Swim are absent on both transports and rejected before any
+  state-changing I/O if an internal compatibility boundary receives them.
+- A `200` without authoritative completion is a protocol failure.
+- Sync requires both post-watermark sender-side `SYNC` edges, a 60-second
+  post-terminal interval, and one bounded in-band final read; missing edges,
+  transient/late changes, or mismatched/collateral state are failures and are
+  not retried.
+- A timeout never triggers an automatic `STATUS=OFF` recovery because that
+  could unexpectedly turn lights off. The translated error tells the user that
+  the group may require a manual off/on clear.
+- One controller-wide lifecycle drains already-started writes before Color Sync
+  and then rejects every later case-insensitive `SetParamList` sent through the
+  same controller, including public `send_cmd()`, direct changes, coalesced
+  writes, and a second Sync. It never silently delays them through the long
+  observation window.
+- Command services never operate on a plain `CIRCGRP` group or ordinary light.
+
+## Testing
+
+### pyintellicenter tests
+
+- real-hardware parent plus multiple membership-row aggregation;
+- deterministic `LISTORD` ordering, including duplicate numeric and multiple
+  negative/malformed-order tiebreaks;
+- missing parent and missing child references;
+- compatibility with legacy space-separated fixtures;
+- color-capability detection against resolved children;
+- exact mixed-case `SetParamList` serialization for Sync without `ACT` or
+  `STATUS`, a realistic full correlated response shape, plus proof that no Set
+  or Swim serializer is exposed;
+- sender-side `SYNC` field and 60-second bound on both transports; split
+  pre-send deadline/post-send watermark behavior including a WebSocket frame
+  during send suspension; pre-write rejection of other raw firmware tokens,
+  member counts/subtypes, and mixed prestates;
+- invalid command/target rejection without network calls;
+- empty, mixed, missing, and unresolved membership rejection;
+- additive enqueue-sequenced observer behavior, notification between observer
+  registration and write exclusion, notification before response retention,
+  stale queued notification exclusion, and leading-order-independent lifecycle
+  completion;
+- observer-before-first-read bounded buffering, batched subscriptions with
+  initialization validation, hardware-realistic optional circuit `PARENT`/`USE`
+  and membership-row `USE` omission/key-echo/null-reference normalization at
+  wildcard, subscription-initialization, and notification gates, strict required
+  membership-row `PARENT` coverage in full responses and placeholder rejection
+  whenever present in notifications, one-second settling, and a
+  full matching normalized wildcard second preflight;
+- fail-fast controller isolation against another group action, public mixed-case
+  and uppercase `send_cmd()`, direct changes, and coalesced mutations, while
+  read-only requests remain live;
+- Sync all-off and all-on completion; no-leading-edge and no-terminal-edge
+  rejection; 60-second post-terminal enforcement; transient target/action/
+  collateral flip-and-restore rejection; final-read mismatch, disconnect/
+  reconnect/captured-instance replacement/cancellation cleanup, no retry, and
+  no optimistic mutation;
+- collateral projection coverage for every circuit's required
+  `OBJTYP`/`SUBTYP`/`STATUS` and normalized optional `PARENT`/`USE`, every
+  membership row's required topology/optional normalized `USE`, group flags,
+  and system mode while excluding legitimate dynamic telemetry;
+- phase-aware error metadata for explicit rejection, uncertain dispatch,
+  acknowledged lifecycle failure, and final-verification failure;
+- no member-position helper or option-map API.
+
+### intellicenter tests
+
+- membership rows never create light or switch entities;
+- parent `LITSHO` continues to create exactly one light entity;
+- Sync service registration and exact controller calls;
+- no Color Set or Color Swim service and no member-position select entities;
+- ordinary lights, plain circuit groups, other firmware, non-two-member groups,
+  and non-`GLOW` children reject action services;
+- translated unsupported, pre-write failed, dispatch-uncertain, and
+  acknowledged/started-incomplete failures;
+- coordinator row tracking excludes unsupported `SNAME`/`STATUS`;
+- coordinator row tracking does not promote `USE` or action flags to durable
+  entity state;
+- regression coverage for the hardware-shaped fixture from the issue comment.
+
+Run targeted tests throughout development, then the full lint, format, type,
+security, and pytest suites in both repositories. Finish with one snapshot/
+restore live smoke test and independent adversarial reviews from `agy` and
+Cursor `agent`.
+
+## Documentation
+
+- Explain that group on/off uses the existing parent light entity.
+- Document Color Sync on TCP and WebSocket as a momentary entity service.
+- State the initial firmware `1.064`, two-member `GLOW` eligibility boundary
+  and roughly 96-second normal service duration.
+- State that Color Set, Color Swim, and member-position selects are unavailable
+  because their protocol gates did not pass.
+- Correct any documentation that describes a `CIRCGRP` row as a complete group.
+
+## PR and Release Topology
+
+- pyintellicenter branch: `feature/issue-93-light-group-sync`, related to #93 but
+  not closing the Home Assistant issue.
+- integration branch: repository-local `feature/issue-93-light-group-sync`,
+  closing #93 only for the verified capabilities named in the final PR
+  title/body.
+- Both branches start from their repositories' fetched `origin/main` commits in
+  external isolated worktrees.
+- Prefer existing stable generic controller primitives where they keep protocol
+  details inside pyintellicenter. If the integration calls a new public helper,
+  merge and release the library first, then update `manifest.json`,
+  `pyproject.toml`, and `uv.lock` atomically to the first compatible version.
+- Opening the feature PR does not authorize merging, publishing to PyPI,
+  tagging, or releasing. Those are explicit maintainer checkpoints. The
+  integration branch may be developed against the local library worktree, but
+  its dependency lock and green PR wait for the published library release.
+- Never use a Git branch dependency in the Home Assistant manifest and never
+  leave the requirement compatible with a library version missing an imported
+  API.
+
+## Acceptance Criteria
+
+- Parent circuits and membership rows are modeled according to captured
+  hardware, with legacy fixture compatibility covered by tests.
+- Sync ships on TCP and WebSocket only for firmware `1.064` groups containing
+  exactly two distinct `GLOW` children, with a correlated acknowledgement,
+  post-send-watermark lifecycle edges, a 60-second post-terminal interval,
+  invariant projection, and authoritative final read.
+- Set, Swim on both transports, and member-position selects remain absent and
+  are rejected before state-changing I/O where applicable.
+- No row-derived duplicate light or switch entities exist.
+- Automated tests cover malformed data, unsupported targets, failures, dynamic
+  discovery, and exact captured commands.
+- Both repositories pass full verification, the hardware snapshot is restored,
+  and all confirmed `agy`/Cursor findings are resolved or documented before PR
+  handoff.

--- a/docs/superpowers/specs/2026-07-14-system-delay-status-cancel-design.md
+++ b/docs/superpowers/specs/2026-07-14-system-delay-status-cancel-design.md
@@ -1,0 +1,347 @@
+# Design: System Delay Status and Cancellation (Issue #92)
+
+**Date:** 2026-07-14
+**Updated:** 2026-07-15
+**Branch:** `docs/issues-92-93-plans`
+**Issue:** [#92 — delay status + Cancel Delays button](https://github.com/joyfulhouse/intellicenter/issues/92)
+
+## Problem
+
+IntelliCenter can keep equipment running while a heater-cooldown or
+valve-rotation delay completes. Home Assistant currently exposes neither the
+active delay nor the panel's "Cancel Systems Delay" action, so a delayed
+shutdown can look like a failed command.
+
+The issue's original implementation model is disproved on the project's live
+IntelliCenter 1.064 unit:
+
+- `CIRCUIT.DLY` is unsupported; the panel echoes the requested key name.
+- `HEATER.DLY` is the configured cooldown duration, not active state.
+- `VALVE.DLY` is configuration, not active state.
+- `_5451.VALVE` and `_5451.HEATING` are global delay-enable settings. Writing
+  them off would change configuration and is not an acceptable substitute for
+  cancelling one active delay.
+
+A sensor and button built from those values would either remain unknown or
+silently disable safety-related configuration. This design therefore makes
+protocol evidence a release gate rather than an implementation detail.
+
+## Goal
+
+Expose every delay capability that the local protocol can prove safely:
+
+1. A `System delay active` binary sensor when a reliable active-state signal
+   exists.
+2. A `Cancel system delays` button when a distinct, acknowledged cancellation
+   command exists.
+
+The two capabilities are independently gated. A verified cancellation action
+may ship without a sensor; an unverified or configuration-mutating action must
+not ship.
+
+## Planning Boundary
+
+Protocol discovery is a separate prerequisite plan, not a conditional branch
+inside the feature implementation plan. Discovery records the sanitized
+command, acknowledgement predicate, state attribute/value mapping, supported
+delay types and firmware scope, passive runtime capability predicate, and one
+selected row from the decision table below. Those results are added to this
+specification and reviewed before an implementation plan is written.
+
+## Discovery Progress (2026-07-15)
+
+The button and sensor gates have diverged:
+
+- The deployed official `bundle.web.js` asset inspected for this gate had
+  SHA-256
+  `933e2fc35fd5e5fe26477f0199873bedaf4c266d510f6e8259e3684da18317fd`—the
+  same identified asset recorded in the issue #93 evidence—and contains no
+  transient `Cancel Systems Delay` operation. Its only related writes change
+  persistent heater/valve delay-enable or duration settings. Those writes are
+  explicitly forbidden by this design, so the cancellation button gate has
+  failed and no local replay is authorized.
+- Read-only TCP and WebSocket calls to `GetActiveStatusMessages` both returned
+  a correlated `200` with an empty answer while no delay was active. This proves
+  that the read command exists on firmware `1.064`; it does not establish the
+  active schema, delay-type coverage, push delivery, or a runtime capability
+  predicate.
+- The sensor gate therefore remains unresolved. No production helper, entity,
+  coordinator key, or polling behavior is approved.
+
+The discovery observer has been extended and locally verified on its isolated
+non-production branch. It issues only privacy-safe, bounded, read-only
+`GetActiveStatusMessages` checks while retaining `NotifyList` frames; nested
+answers and labels are privacy-aliased and resource-bounded. That polling is
+discovery instrumentation, not permission to add production polling. If
+repeated natural delays produce only query responses and no authoritative
+push/model signal, the push-driven sensor architecture fails and no sensor
+ships.
+
+Before selecting `sensor only` or `unsupported`, discovery still requires two
+independent natural heater cooldown transitions, one over TCP and one over
+WebSocket, with inactive -> active -> inactive reads and corresponding
+notification evidence. Two independent valve-delay transitions, again one per
+transport, are additionally required before a generic “system delay” sensor may
+claim valve coverage. Matching results may satisfy this cross-transport gate;
+divergent single observations select unsupported/no capability and cannot claim
+transport-scoped support without a separately amended, reviewed plan containing
+within-transport repeats. No production feature plan or PR starts until those
+results are sanitized, added here, and adversarially reviewed.
+
+## Non-Goals
+
+- Do not infer delay state from elapsed time, requested circuit state, heater
+  configuration, or optimistic Home Assistant state.
+- Do not write `CIRCUIT.DLY`, `HEATER.DLY`, `VALVE.DLY`, `_5451.VALVE`, or
+  `_5451.HEATING` as a cancellation mechanism unless an official-client capture
+  proves that exact operation and a before/after snapshot proves configuration
+  is unchanged.
+- Do not implement panel delay configuration controls.
+- Do not add polling; state must come from the initial model or push updates.
+- Do not require physical hardware in automated tests.
+
+## Protocol Discovery Gate
+
+Discovery happens before feature code and uses the official panel/Web App
+operation as the source of truth.
+
+### Preconditions and snapshot
+
+Before changing equipment:
+
+1. Confirm the panel is in Auto mode and the integration is connected.
+2. Select a known Pool/Spa transition that can produce a normal delay without
+   involving cleaners, freeze protection, service mode, or unrelated circuits.
+3. Record firmware, current body/circuit/heater/valve states, heat modes,
+   setpoints, group/light states, and the values of every observed delay-related
+   attribute.
+4. Start one experimental client only after the snapshot is complete.
+
+### Capture sequence
+
+For every heater-cooldown or valve-rotation delay type that the entities will
+claim to represent:
+
+1. Subscribe to notifications for the relevant system, body, circuit, heater,
+   and valve objects, and retain bounded `GetActiveStatusMessages` reads.
+2. Produce a natural delay through the official UI.
+3. Record canonical inactive -> active -> natural completion values, correlate
+   any non-empty active-status answer with `NotifyList`, and query the same
+   objects after completion.
+4. Repeat natural completion to establish repeatability and distinguish a
+   durable push/model signal from query-only or transient data.
+5. Restore the initial equipment, heat-mode, setpoint, and configuration
+   snapshot through the official UI and verify it twice.
+
+Cancellation and simultaneous-cancellation capture steps are not applicable to
+the identified asset/firmware: the dated Discovery Progress gate found no
+transient operation and authorizes no replay. Those steps may be reconsidered
+only after a different precisely identified official asset supplies a distinct
+non-configuration-mutating command and this specification is reviewed again.
+
+The state gate passes only if the same readable attribute reports an explicit
+inactive value before/after the delay and an explicit active value during it.
+An attribute that exists only as a transient command echo cannot drive the
+binary sensor.
+
+Raw captures retained as development evidence must redact network addresses,
+property names, identifiers, and credentials. Captures are not committed when
+they contain private installation data.
+
+### Abort conditions
+
+Disconnect the experimental client and restore from the official panel if any
+of the following occurs:
+
+- an unrelated actuator changes;
+- the panel leaves Auto mode;
+- delay-enable configuration changes;
+- the response is malformed, unsupported, or not acknowledged;
+- the connection drops during a state-changing step;
+- the original state cannot be restored promptly.
+
+### Decision table
+
+| Evidence | Result |
+|---|---|
+| Reliable active-state signal and distinct cancellation command | Ship sensor and button |
+| Distinct cancellation command, no reliable active-state signal | Ship button only; keep sensor out of scope |
+| Reliable active-state signal, no safe cancellation command | Ship sensor only; keep button out of scope |
+| Cancellation changes delay configuration or cannot be acknowledged | Do not ship the button |
+| No reliable state and no safe cancellation | Close the feature as unsupported with captured evidence; no speculative PR |
+
+### Runtime capability predicate
+
+Each shipped entity requires a passive, deterministic setup-time capability
+predicate derived from the approved discovery evidence. Setup must never test a
+cancellation command. The predicate may use a read-only protocol response or a
+firmware range only when captures establish that range explicitly. Current
+state validity alone is not a capability predicate.
+
+If no passive predicate can distinguish supported installations, that entity
+does not ship. A button-only outcome is therefore allowed only when the button
+has an independent passive capability predicate.
+
+## Architecture
+
+### Protocol boundary
+
+Raw command shape and state interpretation belong in `pyintellicenter` when
+they require knowledge beyond the library's existing generic public API.
+
+If discovery identifies a dedicated protocol operation, add the controller
+helper `cancel_system_delays()` and, when applicable, the nullable
+`is_system_delay_active()` accessor. The helper must:
+
+- target only the captured object/command;
+- await and return the panel response;
+- preserve the library's existing command-error translation;
+- avoid optimistic model mutation;
+- expose unsupported/malformed state as `None`, not `False`.
+
+If the captured operation is exactly expressible through the existing stable
+`request_changes()` contract without new parsing or semantics, the integration
+may use that public primitive and no library release is required.
+
+### Coordinator tracking
+
+When discovery identifies a readable attribute, add only that verified
+object/attribute to `DEFAULT_ATTRIBUTES_MAP`. The existing push path then
+updates the model and entity listeners. Unsupported placeholder echoes are
+treated as malformed/unknown rather than inactive. Capability is recorded
+separately from the current attribute value so a supported sensor remains
+present and becomes unknown during a malformed update instead of disappearing.
+
+Discovery must identify the exact owning `SYSTEM` object. Runtime setup requires
+exactly one object matching that captured identity/type contract; zero or
+multiple matches are ambiguous and create neither entity.
+
+### Home Assistant entities
+
+Add `Platform.BUTTON` to `PLATFORMS` only when the cancellation gate passes and
+create `custom_components/intellicenter/button.py`.
+
+The `Cancel system delays` button:
+
+- is attached to the integration device;
+- is available only while the coordinator is connected;
+- uses `mdi:timer-cancel-outline` and no misleading button device class;
+- awaits the controller command through `_async_execute_command()`;
+- raises the existing translated `command_failed` error on rejection, timeout,
+  or disconnect;
+- does not optimistically clear the sensor;
+- uses the stable unique ID
+  `{entry_id}_{system_objnam}CANCEL_SYSTEM_DELAYS`;
+- serializes presses through the entity platform so only one cancellation is
+  in flight at a time.
+
+When the state gate passes, add a `System delay active` binary sensor from the
+verified system object. It uses `BinarySensorDeviceClass.RUNNING`, the name
+`+ System delay`, and nullable state semantics:
+
+- canonical active value -> `True`;
+- canonical inactive value -> `False`;
+- missing, echoed, or malformed value -> `None`.
+
+The builder creates the sensor when the independent passive capability
+predicate passes, regardless of the current state value. Its stable unique ID
+follows the existing `PoolEntity` convention:
+`{entry_id}_{system_objnam}{verified_state_attribute}`. A missing, echoed, or
+malformed initial or later value renders the supported entity unknown. The
+sensor updates only from the verified attribute in coordinator push data.
+
+### Data flow
+
+```text
+Panel notification -> pyintellicenter model -> IntelliCenterCoordinator
+  -> System delay binary sensor -> Home Assistant state
+
+Button press -> controller cancellation helper -> panel acknowledgement
+  -> later panel notification -> binary sensor state
+```
+
+The button never fabricates the second line's final notification.
+
+## Error Handling
+
+- A disconnected coordinator makes both entities unavailable.
+- Protocol rejection, timeout, or connection loss during cancellation becomes a
+  translated `HomeAssistantError` and leaves observed state unchanged.
+- The library helper normalizes rejection, request timeout, and mid-command
+  disconnect into the existing `ICError` hierarchy; the integration translates
+  those exact errors to `command_failed`.
+- Missing or malformed delay state is unknown, not inactive.
+- Unsupported firmware does not get a partially functional entity. Entity
+  creation is gated on the proven model/attribute contract, not firmware
+  version guesses.
+
+## Testing
+
+### pyintellicenter tests, when a library helper is required
+
+- exact captured command/object/parameter serialization;
+- acknowledgement passthrough;
+- command rejection and timeout propagation;
+- active/inactive/missing/echoed/malformed state parsing;
+- no optimistic mutation of model state.
+
+### intellicenter tests
+
+- `Platform.BUTTON` setup and unload behavior;
+- button creation, name, unique ID, icon, device attachment, and availability;
+- successful press awaits the controller exactly once;
+- rejection/timeout becomes `HomeAssistantError`;
+- binary sensor true/false/unknown mappings, when included;
+- absent, echoed, malformed, and ambiguous capability evidence creates no
+  entity and never sends a setup-time cancellation command;
+- a supported sensor remains present but unknown when its state later becomes
+  missing, echoed, or malformed;
+- push-update propagation for the verified state attribute;
+- dynamic setup does not create duplicates;
+- rapid duplicate presses never put two cancellations in flight;
+- regression guard proving `DLY` configuration values cannot create the active
+  sensor or drive its state.
+
+All protocol tests use the exact sanitized frames captured from hardware. The
+full lint, format, type, security, and pytest suites run in both repositories,
+followed by one controlled live smoke test with snapshot and restoration.
+
+## Documentation
+
+- Document what kinds of system delay the entities represent.
+- State that cancellation skips the current operational delay but does not
+  disable configured heater or valve protections.
+- Warn that cancelling a live delay can stop equipment or begin valve movement
+  immediately.
+- If only one capability passes discovery, document only that capability and
+  keep the issue/PR title accurate.
+
+## PR and Release Topology
+
+- Integration branch: `feat/issue-92-delay-status-cancel`, based on the fetched
+  `intellicenter/origin/main` commit used by the implementation plan.
+- The first post-spec plan performs protocol discovery only. Feature worktrees
+  and implementation PRs start after the captured contract and selected
+  decision-table result are written into this spec and approved.
+- Reserve `feat/issue-92-delay-protocol` in pyintellicenter only if discovery
+  requires a new public helper or parser.
+- The pyintellicenter PR, if any, is related to issue #92 but does not close the
+  Home Assistant issue.
+- The integration PR is the only PR that may close #92, and only when every
+  capability named in its title has passed the discovery gate.
+- Never merge integration code that calls a newer library API while retaining a
+  requirement compatible with older pyintellicenter versions. If a new API is
+  required, release the library first and update `manifest.json`,
+  `pyproject.toml`, and `uv.lock` atomically.
+
+## Acceptance Criteria
+
+- Every shipped state or command is backed by an official-client capture and a
+  live round-trip on the supported test unit.
+- Cancellation leaves delay-enable configuration and unrelated equipment
+  unchanged.
+- Original equipment state is restored after validation.
+- Automated tests cover success, failure, unknown state, and the disproved
+  `DLY` regression.
+- `agy` and Cursor `agent` independently review the final diff, and all confirmed
+  findings are resolved or documented before the draft PR is handed off.


### PR DESCRIPTION
## Summary
Docs-only. Folds the protocol-discovery record (evidence, plans, design specs) from the stray `docs/issues-92-93-*` branches into `main`, so the evidence cited in the closing comments of #92 and #93 survives branch cleanup.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)