### PR TITLE
feat: re-adopt connected delegation on pyintellicenter 0.2.2 (release 3.10.0b3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.0b3] - 2026-08-23
+
 ### Added
 
 - **Color Sync light-group action** (#93) - Added the blocking `intellicenter.color_sync` service for complete light groups with exactly two distinct GloBrite members on firmware 1.064, available over TCP and WebSocket.
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Requires pyintellicenter >= 0.2.0** (#113) - Adopts the 0.2.0 connection-handler API: `async_unload_entry` and Home Assistant shutdown now await the full controller teardown (`astop()`), so an unload or reload can never race a half-closed connection, and model updates flow through the new `subscribe()` API (the handler subclass keeps lifecycle events only). Entity availability deliberately stays on the coordinator's callback-driven flag rather than the handler's `connected` property, whose flag flips True only after `on_reconnected` has run (adopting it would have rendered every entity unavailable on each reconnect - caught in adversarial review). Also picks up the library's notification burst batching, per-frame overflow coalescing, discovery rewrite, and hot-path performance fixes.
+- **Requires pyintellicenter >= 0.2.2** (#113, #114) - Adopts the 0.2.x connection-handler API: `async_unload_entry` and Home Assistant shutdown now await the full controller teardown (`astop()`), so an unload or reload can never race a half-closed connection; model updates flow through the `subscribe()` API (the handler subclass keeps lifecycle events only); and equipment deleted at the panel is removed at runtime (see "Ghost-equipment entity removal"). Entity availability now **delegates to the handler's `connected` property**, which on pyintellicenter 0.2.2 reflects the live transport during a reconnect's in-`start()` backfill dispatch - so entities render available as the reconnect's fresh state fans out, with no spurious "unavailable" flicker. (An earlier revision kept a separate callback-driven flag because pyintellicenter 0.2.0/0.2.1 set the handler flag only *after* that dispatch, which would have flickered every entity unavailable on each reconnect; pyintellicenter 0.2.2 (#89) fixed the library and this re-adopts delegation.) Also picks up the library's notification burst batching, per-frame overflow coalescing, discovery rewrite, and hot-path performance fixes.
 - **Requires pyintellicenter >= 0.1.22** (#93) - The Color Sync action uses the protocol library's blocking authoritative lifecycle: it observes the physical action, continues through a 60-second post-terminal window, and performs a final controller read while isolating other mutations on the Home Assistant connection.
 
 ### Fixed

--- a/custom_components/intellicenter/coordinator.py
+++ b/custom_components/intellicenter/coordinator.py
@@ -334,7 +334,6 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         self._handler.subscribe(None, self._handle_model_updates)
 
         self._stop_listener: CALLBACK_TYPE | None = None
-        self._connected = False
 
         # Dynamic-entity-addition state (issue #42).
         # `_known_objnams` is the set of object identifiers the platforms have
@@ -376,17 +375,22 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
     def connected(self) -> bool:
         """Return True if connected to the IntelliCenter.
 
-        Deliberately the coordinator's own callback-driven flag, NOT the
-        handler's ``connected`` property (pyintellicenter 0.2.0). The library
-        flips its flag False immediately on connection loss (before the
-        debounced ``on_disconnected``) but True only AFTER ``on_reconnected``
-        has already run - so reading it during the reconnect fan-out would
-        render every entity unavailable, with no later fan-out to correct it
-        (found in adversarial review). The connection callbacks are the
-        debounced, fan-out-aligned source of truth for entity availability;
-        do not "simplify" this back to ``self._handler.connected``.
+        Delegates to the handler's ``connected`` property (pyintellicenter
+        >= 0.2.2), which is ``not stopped and (handler flag or live
+        transport)``. Crucially it reads ``True`` throughout a (re)connect's
+        in-``start()`` object snapshot/backfill dispatch - the socket is up even
+        though the handler's own flag is not set until ``start()`` returns - and
+        ``False`` on a genuine outage or after stop. Gating entity availability
+        on it is therefore correct: entities render available as the reconnect's
+        fresh state fans out, with no spurious "unavailable" flicker.
+
+        History: pyintellicenter 0.2.0/0.2.1 set the handler flag only *after*
+        that in-``start()`` dispatch, so an earlier attempt to delegate here
+        rendered every entity momentarily unavailable on each reconnect and was
+        reverted. The library fixed it in 0.2.2 (#89) by or-ing the live
+        transport into ``connected``; the manifest pin requires ``>= 0.2.2``.
         """
-        return self._connected
+        return self._handler.connected
 
     async def async_start(self) -> None:
         """Start the connection to the IntelliCenter."""
@@ -411,7 +415,6 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
 
         # Start the connection
         await self._handler.start()
-        self._connected = True
 
         # Snapshot the objects discovered during the initial connection. Anything
         # that appears in the model after this point is treated as newly-added
@@ -434,8 +437,10 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
         # Stop the handler and wait for the teardown. The model-update
         # subscription stays registered (see __init__): the stopped controller
         # dispatches nothing, and removing it would starve a restarted handler.
+        # ``connected`` reads False immediately once the handler is stopped
+        # (its ``_stopped`` guard), even before the teardown task closes the
+        # socket.
         await self._handler.astop()
-        self._connected = False
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch data from the IntelliCenter.
@@ -715,8 +720,12 @@ class IntelliCenterCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]])
 
         Args:
             connected: True if connected, False if disconnected
+
+        Entity availability is read live from ``self._handler.connected`` (see
+        the ``connected`` property); this callback's job is the fan-out below -
+        rendering the availability change - plus surfacing equipment added while
+        the connection was down.
         """
-        self._connected = connected
         # A reconnect re-fetches the full object list into the model; surface any
         # equipment that was added while the connection was down.
         if connected:

--- a/custom_components/intellicenter/manifest.json
+++ b/custom_components/intellicenter/manifest.json
@@ -11,9 +11,9 @@
   "issue_tracker": "https://github.com/joyfulhouse/intellicenter/issues",
   "quality_scale": "platinum",
   "requirements": [
-    "pyintellicenter>=0.2.0"
+    "pyintellicenter>=0.2.2"
   ],
-  "version": "3.10.0b2",
+  "version": "3.10.0b3",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intellicenter"
-version = "3.10.0b2"
+version = "3.10.0b3"
 description = "Home Assistant custom integration for Pentair IntelliCenter"
 readme = "README.md"
 license = "GPL-3.0-only"
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2025.11.3",
-    "pyintellicenter>=0.2.0",
+    "pyintellicenter>=0.2.2",
 ]
 
 [tool.ruff]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -334,12 +334,11 @@ class TestIntelliCenterCoordinator:
         # Initially not connected
         assert coordinator.connected is False
 
-        # The flag follows the debounced connection callbacks, NOT the
-        # handler's ``connected`` property (see the property's docstring for
-        # the reconnect callback-ordering hazard).
-        coordinator.async_set_connection_state(True)
+        # connected delegates to the handler (pyintellicenter >= 0.2.2): the
+        # handler's own flag or-ed with the live transport, gated on not-stopped.
+        coordinator._handler._is_connected = True
         assert coordinator.connected is True
-        coordinator.async_set_connection_state(False)
+        coordinator._handler._is_connected = False
         assert coordinator.connected is False
 
     async def test_coordinator_model_property(self, hass: HomeAssistant) -> None:
@@ -394,7 +393,9 @@ def _make_started_coordinator(hass: HomeAssistant) -> IntelliCenterCoordinator:
     coordinator.model.add_object(
         "C0002", {"OBJTYP": "CIRCUIT", "SNAME": "Spa Jets", "STATUS": "OFF"}
     )
-    coordinator._connected = True
+    # connected delegates to the handler; drive its flag directly (the real
+    # controller has no live connection in unit tests).
+    coordinator._handler._is_connected = True
     return coordinator
 
 
@@ -417,6 +418,9 @@ class TestConnectionStatePropagation:
         coordinator.async_set_updated_data({"C0001": {"STATUS": "OFF"}})
         assert coordinator.data == {"C0001": {"STATUS": "OFF"}}
 
+        # A real disconnect clears the handler flag (via _on_disconnect) before
+        # the debounced on_disconnected drives async_set_connection_state.
+        coordinator._handler._is_connected = False
         coordinator.async_set_connection_state(False)
         assert coordinator.data == {}
         assert coordinator.connected is False
@@ -438,7 +442,9 @@ class TestConnectionStatePropagation:
         entity.async_write_ha_state.assert_not_called()
 
         # Disconnect: the entity must re-render as unavailable even though it
-        # was not named in the last push diff.
+        # was not named in the last push diff. (_on_disconnect clears the
+        # handler flag before the debounced on_disconnected fan-out.)
+        coordinator._handler._is_connected = False
         coordinator.async_set_connection_state(False)
         entity._handle_coordinator_update()
         entity.async_write_ha_state.assert_called_once()
@@ -446,6 +452,7 @@ class TestConnectionStatePropagation:
 
         # Reconnect: it must come back too.
         entity.async_write_ha_state.reset_mock()
+        coordinator._handler._is_connected = True
         coordinator.async_set_connection_state(True)
         entity._handle_coordinator_update()
         entity.async_write_ha_state.assert_called_once()
@@ -530,18 +537,20 @@ class TestPyIntellicenter020Adoption:
             await hass.async_block_till_done()
             mock_stop.assert_awaited_once()
 
-    async def test_reconnect_callback_ordering_yields_available_entities(
+    async def test_reconnect_backfill_dispatch_yields_available_entities(
         self, hass: HomeAssistant
     ) -> None:
-        """Entities must render available during the on_reconnected fan-out.
+        """Entities render available during a reconnect's in-start() backfill.
 
-        pyintellicenter's ``_starter`` invokes ``on_reconnected`` BEFORE it
-        sets the handler's ``_is_connected`` flag, so ``handler.connected`` is
-        still False while the reconnect fan-out runs. If the coordinator's
-        ``connected`` delegated to that property (an earlier revision of this
-        adoption did), every reconnect would render every entity unavailable
-        with no later fan-out to correct it. Availability must come from the
-        callback-driven coordinator flag.
+        pyintellicenter dispatches a (re)connect's object snapshot/backfill from
+        *within* ``controller.start()``, after the socket is up but before the
+        handler sets its own ``_is_connected`` flag. ``coordinator.connected``
+        delegates to ``handler.connected``, which on pyintellicenter >= 0.2.2
+        or-s in the live transport - so it reads True throughout that dispatch.
+        The entity must therefore render available as the reconnect's fresh
+        state fans out, NOT the momentary-unavailable flicker that plain
+        flag-delegation caused on 0.2.0/0.2.1 (the reason the first attempt was
+        reverted; #89 fixed the library and this re-adopts delegation).
         """
         coordinator = _make_started_coordinator(hass)
         c0001 = coordinator.model["C0001"]
@@ -549,14 +558,15 @@ class TestPyIntellicenter020Adoption:
         entity = PoolEntity(coordinator, c0001)
         entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
 
-        # Simulate a disconnect that reached the coordinator...
-        coordinator._connected = False
-        # ...and the library's reconnect callback, delivered while the
-        # handler's own flag is still False (the real invocation order).
+        # In-start() state: the handler's own flag is not yet set, but the
+        # transport is up (as it is throughout the backfill dispatch).
         coordinator._handler._is_connected = False
-        coordinator._handler.on_reconnected(coordinator._controller)
+        coordinator._controller._connection = MagicMock(connected=True)
 
+        # The reconnect's backfill fans out through the real subscription path.
+        coordinator._controller._notify_updated({"C0001": {"STATUS": "OFF"}})
         entity._handle_coordinator_update()
+
         assert entity.available is True
         entity.async_write_ha_state.assert_called_once()
 

--- a/tests/test_library_contract.py
+++ b/tests/test_library_contract.py
@@ -18,6 +18,7 @@ To regenerate ``CONTROLLER_METHODS`` after the integration changes::
 from __future__ import annotations
 
 import inspect
+from unittest.mock import MagicMock
 
 import pyintellicenter
 
@@ -222,20 +223,47 @@ def test_sensor_diagnostic_helpers_are_available() -> None:
     assert callable(pyintellicenter.ICModelController.get_sensor_calibration)
 
 
-def test_connection_handler_020_surface() -> None:
-    """The installed library exposes the 0.2.0 handler API the coordinator uses.
+def test_connection_handler_surface() -> None:
+    """The installed library exposes the handler API the coordinator uses.
 
-    The coordinator awaits ``astop()`` in ``async_stop`` and registers its
-    update tap via ``subscribe()``. Both shipped in pyintellicenter 0.2.0 - a
-    stale pin would only fail in production without these assertions. (The
-    handler's ``connected`` property is deliberately NOT used for entity
-    availability: it flips True only after ``on_reconnected`` has run - see
-    ``IntelliCenterCoordinator.connected``.)
+    The coordinator awaits ``astop()`` in ``async_stop`` (0.2.0), registers its
+    update tap via ``subscribe()`` (0.2.0), and gates entity availability on the
+    ``connected`` property (0.2.2 semantics, see the behavioral test below). A
+    stale pin would only fail in production without these assertions.
     """
     handler_cls = pyintellicenter.ICConnectionHandler
     assert inspect.iscoroutinefunction(handler_cls.astop)
     assert callable(handler_cls.subscribe)
     assert callable(pyintellicenter.ICModelController.subscribe)
+    assert isinstance(inspect.getattr_static(handler_cls, "connected"), property)
+
+
+def test_handler_connected_reflects_live_transport() -> None:
+    """handler.connected is True during a (re)connect's in-start() backfill.
+
+    ``IntelliCenterCoordinator.connected`` delegates to ``handler.connected``
+    and relies on the pyintellicenter >= 0.2.2 behavior that it or-s in the
+    controller's live transport: it must read True when the socket is up even
+    though the handler has not yet set its own post-start flag - the window in
+    which a reconnect's object snapshot/backfill dispatches. Without this the
+    integration would flicker every entity unavailable on each reconnect (the
+    reason plain flag-delegation was reverted before 0.2.2, #89). A stale pin
+    (< 0.2.2) fails here rather than only in production.
+    """
+    controller = pyintellicenter.ICModelController(
+        "192.0.2.1", pyintellicenter.PoolModel({})
+    )
+    handler = pyintellicenter.ICConnectionHandler(controller)
+
+    # Handler's own flag is not set (as during the in-start() dispatch), but the
+    # transport is up: connected must still read True.
+    assert handler._is_connected is False
+    controller._connection = MagicMock(connected=True)
+    assert handler.connected is True
+
+    # Genuine outage (no transport, flag unset): False.
+    controller._connection = None
+    assert handler.connected is False
 
 
 def test_model_supports_removal_reconciliation() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "intellicenter"
-version = "3.10.0b2"
+version = "3.10.0b3"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },
@@ -1136,7 +1136,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.11.3" },
-    { name = "pyintellicenter", specifier = ">=0.2.0" },
+    { name = "pyintellicenter", specifier = ">=0.2.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1756,16 +1756,16 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orjson" },
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/9c/bc39605ebd8bd36fb089b0df6c668d8d1c3d25ce54c6efd9fe8f1ebebc1c/pyintellicenter-0.2.0.tar.gz", hash = "sha256:9f9da7cd4a8ef4af9c37ba45605c629cd044a2babdbd6fc95fef7e9788b4bf8e", size = 82102, upload-time = "2026-08-23T03:39:01.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/99/fbb277fdb89b2e6f177a0b128869e1acf4aad8f8b81f8e7789fa1c28f1d1/pyintellicenter-0.2.2.tar.gz", hash = "sha256:b78514ca07013f4797d5e071677e21c567d9731c907ed958585ea6ddc12c885b", size = 82753, upload-time = "2026-08-24T04:55:46.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/75/1cc79734ac54aecc71fc7cb42d7ff16071a1edc51c1f48eb24c3f6c3fcdd/pyintellicenter-0.2.0-py3-none-any.whl", hash = "sha256:54363255a57f3d6a3b81344e0f7b95d80b2176c40520773ca690647d723b50b5", size = 96979, upload-time = "2026-08-23T03:38:59.881Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e8/6b6f3181df76ed688b07d6c9f009da79d5a1f187987f63b5423ae127b151/pyintellicenter-0.2.2-py3-none-any.whl", hash = "sha256:73e098413e412d2b13e7fb94d2aa4f665ae1a7ded4fa376a55d05d37e381365b", size = 97665, upload-time = "2026-08-24T04:55:45.725Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the pyintellicenter pin to **>=0.2.2** (manifest + pyproject + uv.lock) and the integration version to **3.10.0b3**, and **re-adopts entity-availability delegation** to the handler's `connected` property — the change reverted in #113 (`e04a7fa`), now unblocked by the library fix.

`IntelliCenterCoordinator.connected` returns `self._handler.connected` again; the duplicated callback-driven `self._connected` flag and its four assignments (`__init__`, `async_start`, `async_stop`, `async_set_connection_state`) are removed. `async_set_connection_state` still fans out connection events and surfaces runtime-added equipment.

### Why this is correct now

pyintellicenter **0.2.2** ([joyfulhouse/pyintellicenter#89](https://github.com/joyfulhouse/pyintellicenter/pull/89)) changed `ICConnectionHandler.connected` to `not self._stopped and (self._is_connected or self._controller.connected)`. A (re)connect's reconcile + attribute backfill dispatches from *within* `controller.start()` — socket up, but the handler's own flag not set until `start()` returns. Or-ing in the live transport makes `connected` read `True` throughout that dispatch, so gating availability on it no longer flickers entities `unavailable` on each reconnect (the exact defect that forced the #113 revert). The `not _stopped` guard keeps `stop()`/unload immediately `False`.

## Tests

- `test_coordinator_connected_property` + `test_reconnect_backfill_dispatch_yields_available_entities` now assert the delegated behavior (available during the in-`start()` backfill).
- `test_library_contract.py::test_handler_connected_reflects_live_transport` pins the 0.2.2 transport-aware `connected` — fails against a stale pin (< 0.2.2).
- **564 tests passing**; ruff, ruff-format, mypy strict, bandit clean; installed pyintellicenter 0.2.2.

## Adversarial review

- **Grok (cursor-agent, grok-4.5-high): MERGE** — all severities empty; validated every `connected`-state scenario (before start, setup-failure `finally`, unload, reconnect backfill, outage, steady), confirmed no leftover `_connected` refs, and that the tests genuinely exercise delegation and the contract test fails on < 0.2.2.
- **Codex: attempted** — the CLI hit a transient TLS/websocket fault in this environment; retrying. Any findings will be posted here.

Depends on pyintellicenter 0.2.2 (already on PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)