### PR TITLE
fix: report a pump as running from its telemetry, not its STATUS (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pumps always reported as running** (#112) - A pump's binary sensor read `on` whether or not the pump was turning. IntelliCenter sets a pump's `STATUS` to `10` while the pump is *enabled*, not while it is running, so on variable-speed pumps STATUS sits at `10` at 0 RPM. The panel also never pushes `STATUS` for a pump - only the `RPM`/`PWR`/`GPM` telemetry - so the sensor never updated when a pump started or stopped either. Running state is now derived from whichever of those three the pump publishes, and the entity updates on the same attributes. Single-speed pumps publish none of them and keep the previous STATUS behaviour; existing pump entities carry over unchanged. Thanks to @sheyman1 for the report.
+
 ## [3.10.0b3] - 2026-08-23
 
 ### Added

--- a/custom_components/intellicenter/binary_sensor.py
+++ b/custom_components/intellicenter/binary_sensor.py
@@ -29,6 +29,7 @@ from pyintellicenter import (
     CIRCUIT_ATTR,
     CIRCUIT_TYPE,
     DAY_ATTR,
+    GPM_ATTR,
     HEATER_ATTR,
     HEATER_TYPE,
     HTMODE_ATTR,
@@ -39,6 +40,8 @@ from pyintellicenter import (
     PHLO_ATTR,
     PUMP_STATUS_ON,
     PUMP_TYPE,
+    PWR_ATTR,
+    RPM_ATTR,
     SCHED_TYPE,
     SERVICE_ATTR,
     STATUS_ATTR,
@@ -76,6 +79,7 @@ def _build_entities(
     | ChemAlertBinarySensor
     | FirmwareUpdateBinarySensor
     | HeaterBinarySensor
+    | PumpBinarySensor
     | ScheduleBinarySensor
     | SystemModeBinarySensor
 ]:
@@ -85,6 +89,7 @@ def _build_entities(
         | ChemAlertBinarySensor
         | FirmwareUpdateBinarySensor
         | HeaterBinarySensor
+        | PumpBinarySensor
         | ScheduleBinarySensor
         | SystemModeBinarySensor
     ] = []
@@ -115,14 +120,7 @@ def _build_entities(
                 )
             )
         elif obj.objtype == PUMP_TYPE:
-            sensors.append(
-                PoolBinarySensor(
-                    coordinator,
-                    obj,
-                    value_for_on=PUMP_STATUS_ON,
-                    device_class=BinarySensorDeviceClass.RUNNING,
-                )
-            )
+            sensors.append(PumpBinarySensor(coordinator, obj))
         elif obj.objtype == CHEM_TYPE and obj.subtype == CHEM_CONTROLLER_SUBTYPE:
             sensors.append(ChemAlertBinarySensor(coordinator, obj))
             # IntelliChem alarm indicators (diagnostic entities)
@@ -233,6 +231,65 @@ class PoolBinarySensor(PoolEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if sensor is on."""
         return bool(self._pool_object[self._attribute_key] == self._value_for_on)
+
+
+# Real-time telemetry a variable-speed pump publishes while it turns. A pump
+# that publishes none of these has only STATUS to go on.
+PUMP_ACTIVITY_ATTRS = (RPM_ATTR, PWR_ATTR, GPM_ATTR)
+
+
+class PumpBinarySensor(PoolEntity, BinarySensorEntity):
+    """Pump running state, derived from telemetry rather than STATUS.
+
+    IntelliCenter reports a pump's STATUS as ``PUMP_STATUS_ON`` ("10") while the
+    pump is *enabled*, not while it is turning: on VSF pumps STATUS sits at "10"
+    at 0 RPM, so a STATUS-keyed sensor reads ``on`` permanently (issue #112).
+    The panel also never pushes STATUS for a pump - only the RPM/PWR/GPM
+    telemetry - so a STATUS-keyed ``isUpdated`` never fires when a pump starts
+    or stops, even where STATUS does move.
+
+    Any of RPM, PWR or GPM reading above zero therefore means running. The
+    telemetry is re-read on each evaluation rather than latched at construction:
+    a pump's first dispatch can arrive before the panel has backfilled these
+    attributes, the same gap the coordinator's ``_pending_redispatch`` covers.
+    Single-speed pumps publish no telemetry at all and fall back to the STATUS
+    comparison, so their behaviour is unchanged.
+
+    ``attribute_key`` stays at its ``STATUS_ATTR`` default so ``unique_id`` -
+    and therefore every existing pump entity - carries over unchanged.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    @property
+    def _activity_values(self) -> list[float]:
+        """Return each pump telemetry reading that parses as a number.
+
+        An attribute the pump does not publish is absent (``None``) or empty and
+        is skipped; a published zero parses and counts as "not turning".
+        """
+        values: list[float] = []
+        for attribute in PUMP_ACTIVITY_ATTRS:
+            try:
+                values.append(float(self._pool_object[attribute]))
+            except (TypeError, ValueError):
+                continue
+        return values
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while the pump is actually turning."""
+        values = self._activity_values
+        if not values:
+            # Single-speed pump: no telemetry, so STATUS is all we have.
+            return bool(self._pool_object[STATUS_ATTR] == PUMP_STATUS_ON)
+        return any(value > 0 for value in values)
+
+    def isUpdated(self, updates: dict[str, dict[str, Any]]) -> bool:
+        """Return whether telemetry - or, absent it, STATUS - changed."""
+        return self._check_attributes_updated(
+            updates, *PUMP_ACTIVITY_ATTRS, STATUS_ATTR
+        )
 
 
 class ChemAlertBinarySensor(PoolEntity, BinarySensorEntity):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -32,6 +32,7 @@ from custom_components.intellicenter.binary_sensor import (
     FirmwareUpdateBinarySensor,
     HeaterBinarySensor,
     PoolBinarySensor,
+    PumpBinarySensor,
     ScheduleBinarySensor,
     SystemModeBinarySensor,
     _build_entities,
@@ -137,6 +138,27 @@ def pool_object_pump_sensor() -> PoolObject:
             "SUBTYP": "VS",
             "SNAME": "Pool Pump",
             "STATUS": "10",
+        },
+    )
+
+
+@pytest.fixture
+def pool_object_vsf_pump() -> PoolObject:
+    """Return a PoolObject for a VSF pump that publishes RPM/PWR/GPM telemetry.
+
+    STATUS is "10" (the pump is enabled) while every telemetry reading is zero -
+    the idle-VSF case from issue #112, where a STATUS-keyed sensor reads on.
+    """
+    return PoolObject(
+        "PMP02",
+        {
+            "OBJTYP": PUMP_TYPE,
+            "SUBTYP": "VSF",
+            "SNAME": "Spa Jets",
+            "STATUS": "10",
+            "RPM": "0",
+            "PWR": "0",
+            "GPM": "0",
         },
     )
 
@@ -378,14 +400,9 @@ async def test_pump_sensor_running(
     pool_object_pump_sensor: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test pump sensor when running."""
+    """A single-speed pump with no telemetry falls back to STATUS."""
 
-    sensor = PoolBinarySensor(
-        mock_coordinator,
-        pool_object_pump_sensor,
-        value_for_on="10",  # Pump running value
-        device_class=BinarySensorDeviceClass.RUNNING,
-    )
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_pump_sensor)
 
     assert sensor.is_on is True
     assert sensor._attr_device_class == BinarySensorDeviceClass.RUNNING
@@ -396,19 +413,100 @@ async def test_pump_sensor_stopped(
     pool_object_pump_sensor: PoolObject,
     mock_coordinator: MagicMock,
 ) -> None:
-    """Test pump sensor when stopped."""
+    """A single-speed pump reads off when STATUS leaves the running value."""
 
-    # Set pump to stopped
     pool_object_pump_sensor.update({STATUS_ATTR: "4"})
 
-    sensor = PoolBinarySensor(
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_pump_sensor)
+
+    assert sensor.is_on is False
+
+
+async def test_pump_sensor_idle_despite_status_on(
+    hass: HomeAssistant,
+    pool_object_vsf_pump: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Zero telemetry means off even while STATUS still reads "10" (issue #112)."""
+
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_vsf_pump)
+
+    assert sensor.is_on is False
+
+
+@pytest.mark.parametrize(
+    ("telemetry", "expected"),
+    [
+        ({"RPM": "3068", "PWR": "1300", "GPM": "53"}, True),
+        ({"RPM": "3068", "PWR": "0", "GPM": "0"}, True),
+        ({"RPM": "0", "PWR": "1300", "GPM": "0"}, True),
+        ({"RPM": "0", "PWR": "0", "GPM": "53"}, True),
+        ({"RPM": "0", "PWR": "0", "GPM": "0"}, False),
+    ],
+)
+async def test_pump_sensor_any_telemetry_above_zero_means_running(
+    hass: HomeAssistant,
+    pool_object_vsf_pump: PoolObject,
+    mock_coordinator: MagicMock,
+    telemetry: dict[str, str],
+    expected: bool,
+) -> None:
+    """Any of RPM, PWR or GPM above zero reports the pump as running."""
+
+    pool_object_vsf_pump.update(telemetry)
+
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_vsf_pump)
+
+    assert sensor.is_on is expected
+
+
+async def test_pump_sensor_ignores_unparseable_telemetry(
+    hass: HomeAssistant,
+    pool_object_vsf_pump: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Empty telemetry is skipped; the remaining readings still decide."""
+
+    pool_object_vsf_pump.update({"RPM": "", "PWR": "1300", "GPM": ""})
+
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_vsf_pump)
+
+    assert sensor.is_on is True
+
+
+async def test_pump_sensor_updates_on_telemetry(
+    hass: HomeAssistant,
+    pool_object_vsf_pump: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Telemetry-only pushes update the entity; the panel never pushes STATUS."""
+
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_vsf_pump)
+
+    assert sensor.isUpdated({"PMP02": {"RPM": "3069"}}) is True
+    assert sensor.isUpdated({"PMP02": {"PWR": "1306"}}) is True
+    assert sensor.isUpdated({"PMP02": {"GPM": "53"}}) is True
+    assert sensor.isUpdated({"PMP02": {STATUS_ATTR: "4"}}) is True
+    assert sensor.isUpdated({"PMP02": {"SNAME": "Renamed"}}) is False
+    assert sensor.isUpdated({"OTHER": {"RPM": "3069"}}) is False
+
+
+async def test_pump_sensor_unique_id_unchanged(
+    hass: HomeAssistant,
+    pool_object_vsf_pump: PoolObject,
+    mock_coordinator: MagicMock,
+) -> None:
+    """The entity keys off STATUS_ATTR, so existing pump entities carry over."""
+
+    sensor = PumpBinarySensor(mock_coordinator, pool_object_vsf_pump)
+    legacy = PoolBinarySensor(
         mock_coordinator,
-        pool_object_pump_sensor,
+        pool_object_vsf_pump,
         value_for_on="10",
         device_class=BinarySensorDeviceClass.RUNNING,
     )
 
-    assert sensor.is_on is False
+    assert sensor.unique_id == legacy.unique_id
 
 
 async def test_schedule_sensor_active(


### PR DESCRIPTION
## Bug

`PUMP` binary sensors read **`on` permanently** on variable-speed pumps, regardless of whether the pump is turning. Reported in #112: a bubbler pump showing running at 0 GPM / 0 W / 0 RPM while the Pentair app correctly shows it off. Fixes #112.

Two pumps on one panel, read at the same moment:

| entity | STATUS | RPM | PWR | GPM | sensor | actual |
|---|---|---|---|---|---|---|
| `binary_sensor.filter` (PMP01) | 10 | 3068 | 1300 | 53 | on | running |
| `binary_sensor.spa_jets` (PMP02) | 10 | 0 | 0 | 0 | on | **idle** |

## Root cause

`_build_entities` gives every `PUMP` object a `PoolBinarySensor` keyed on STATUS:

```python
elif obj.objtype == PUMP_TYPE:
    sensors.append(
        PoolBinarySensor(
            coordinator, obj,
            value_for_on=PUMP_STATUS_ON,      # "10"
            device_class=BinarySensorDeviceClass.RUNNING,
        )
    )
```

IntelliCenter sets `STATUS` to `"10"` while a pump is **enabled**, not while it is turning, so on a VSF pump it sits at `"10"` at 0 RPM.

There is a second half. The panel never pushes `STATUS` for a pump — only the telemetry:

```
NotifyList {"objectList":[{"objnam":"PMP01","params":{"RPM":"3069"}}]}
NotifyList {"objectList":[{"objnam":"PMP01","params":{"PWR":"1306"}}]}
```

So a STATUS-keyed `isUpdated` never fires when a pump starts or stops, even on a panel where `STATUS` does move. The sensor is both wrong and stuck.

## Fix

New `PumpBinarySensor` derives `is_on` from whichever of `RPM`, `PWR` and `GPM` the pump publishes — any reading above zero means running — and keys `isUpdated` on those plus `STATUS`. All three are already in `DEFAULT_ATTRIBUTES_MAP[PUMP_TYPE]`, so nothing new is subscribed.

Two deliberate choices:

- **Telemetry is re-read on each evaluation rather than latched in `__init__`.** A pump's first dispatch can arrive before the panel has backfilled these attributes — the same gap the coordinator's `_pending_redispatch` covers for the PWR/RPM/GPM sensors in `sensor.py`. Latching at construction would misclassify such a pump as "no telemetry" permanently.
- **`attribute_key` stays at its `STATUS_ATTR` default**, so `unique_id` is unchanged and existing pump entities carry over. There is a test asserting this against the previous construction.

Single-speed pumps publish no telemetry and fall back to the STATUS comparison, so **their behaviour is unchanged**.

## Test plan

- 9 new tests in `tests/test_binary_sensor.py`: the idle-VSF case from #112, a parameterized sweep over which telemetry is non-zero, unparseable/empty readings, telemetry-only `isUpdated` dispatch, single-speed STATUS fallback, and `unique_id` carry-over.
- **Full suite: 573 passed.** `ruff check` / `ruff format --check` / `mypy` (strict) / `bandit -ll` all clean, Python 3.14.4 via `uv sync --frozen`.
- **End-to-end on Home Assistant 2026.8.3** against a mock panel built on pyintellicenter's own `tests/mock_server.py`: reproduced the defect on `main` (idle pump `on`), confirmed the fix (running pump `on`, idle pump `off`), with both entities keeping their `entity_id` and `unique_id` while being adopted from a pre-existing registry. Full method and output in [this comment](https://github.com/joyfulhouse/intellicenter/pull/116#issuecomment-5432003674).

## Docs

- `CHANGELOG.md` — `Unreleased → Fixed` entry. The README's Pumps row already advertises "Running status", which this makes true, so it needed no change.

## Release note

Branched from `main` (3.10.0b3), so it lands on the 3.10 line. Happy to backport to a 3.9.x patch if you'd rather ship it sooner.

## Caveat

A mock reproduces the STATUS/telemetry relationship I inferred from the reports; only an actual bubbler pump proves the panel behaves that way in the field. Worth a confirmation from @sheyman1 before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
