### PR TITLE
fix: adopt entities created by the pre-fork integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Entities from the pre-fork integrations were not adopted** - Replacing the jlvaillant or dwradcliffe integration with this one left every entity behind. Those integrations build their `unique_id` as `<entry_id><objnam>` with no separator while this one joins the two with an underscore, and because both ship the same `intellicenter` domain and config-flow `VERSION = 1`, Home Assistant keeps the existing config entry and never runs a migration - so no entity's unique_id matched. The old registry entries were left as unavailable and every entity returned as a `..._2` duplicate, silently breaking the automations, dashboard cards and history that referenced them. Legacy unique_ids are now rewritten in the entity registry during setup, so entities keep their `entity_id`, name, area and customizations.
+
 ## [3.10.0b3] - 2026-08-23
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,6 +36,20 @@ Or use this one-click link:
    `config/custom_components/intellicenter/`.
 3. **Restart Home Assistant.**
 
+## Migrating from the jlvaillant or dwradcliffe integration
+
+If you are replacing
+[jlvaillant/intellicenter](https://github.com/jlvaillant/intellicenter) or
+[dwradcliffe/intellicenter](https://github.com/dwradcliffe/intellicenter),
+install this integration over the old one and restart. Your existing config
+entry is reused and your entities are adopted automatically: entity IDs, names,
+areas and customizations are preserved, so automations and dashboards keep
+working.
+
+Do not delete the old config entry first — removing it discards the entity
+registry entries this integration adopts, and everything comes back with fresh
+entity IDs.
+
 ## Adding the Integration
 
 Your IntelliCenter is usually discovered automatically via Zeroconf/mDNS:

--- a/custom_components/intellicenter/__init__.py
+++ b/custom_components/intellicenter/__init__.py
@@ -124,10 +124,61 @@ def _is_transient_connection_error(err: Exception) -> bool:
     return isinstance(err, OSError) and err.errno in _TRANSIENT_OS_ERRNOS
 
 
+@callback
+def _async_migrate_legacy_unique_ids(
+    hass: HomeAssistant, entry: IntelliCenterConfigEntry
+) -> None:
+    """Adopt entities created by the pre-fork integrations.
+
+    The jlvaillant/dwradcliffe integrations built their unique_id by
+    concatenating the entry id and the objnam with no separator
+    (``f"{entry_id}{objnam}"``); this integration joins them with an underscore.
+    Both ship the same ``intellicenter`` domain and the same config-flow
+    ``VERSION = 1``, so a user replacing those integrations with this one keeps
+    their config entry, HA never calls ``async_migrate_entry``, and every
+    entity's unique_id silently fails to match. The old registry entries are
+    left behind as unavailable and the entities come back as ``.._2``
+    duplicates, breaking every automation, dashboard card and history graph
+    that referenced them.
+
+    Rewriting the unique_id in place keeps the original entity_id, name,
+    area and settings. Entries already carrying the separator are skipped, as
+    are rewrites that would collide with an existing entry (which would mean
+    both formats are somehow present - the newer one wins and the stale entry
+    is left for the user to remove).
+    """
+    registry = er.async_get(hass)
+    prefix = entry.entry_id
+    for registry_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        unique_id = registry_entry.unique_id
+        if not unique_id.startswith(prefix) or unique_id.startswith(f"{prefix}_"):
+            continue
+        new_unique_id = f"{prefix}_{unique_id[len(prefix) :]}"
+        if registry.async_get_entity_id(
+            registry_entry.domain, registry_entry.platform, new_unique_id
+        ):
+            _LOGGER.debug(
+                "Not migrating %s: %s already exists",
+                registry_entry.entity_id,
+                new_unique_id,
+            )
+            continue
+        _LOGGER.info(
+            "Migrating %s to the current unique_id format", registry_entry.entity_id
+        )
+        registry.async_update_entity(
+            registry_entry.entity_id, new_unique_id=new_unique_id
+        )
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: IntelliCenterConfigEntry
 ) -> bool:
     """Set up IntelliCenter integration from a config entry."""
+    # Adopt any entities left by the pre-fork integrations before the platforms
+    # build theirs, so they are matched by unique_id instead of duplicated.
+    _async_migrate_legacy_unique_ids(hass, entry)
+
     # Get configuration options with defaults
     keepalive_interval = entry.options.get(
         CONF_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_INTERVAL

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,13 +8,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from pyintellicenter import ICCommandError, ICConnectionError, ICTimeoutError
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.intellicenter import (
     PLATFORMS,
     OnOffControlMixin,
     PoolEntity,
+    _async_migrate_legacy_unique_ids,
     async_setup,
     async_setup_entry,
     async_unload_entry,
@@ -651,3 +654,125 @@ class TestPyIntellicenter020Adoption:
         assert removed_batches == [{"C0002"}]
         assert "C0002" not in coordinator._known_objnams
         assert coordinator._pending_redispatch == set()
+
+
+# ---------------------------------------------------------------------------
+# Legacy unique_id adoption
+# ---------------------------------------------------------------------------
+
+LEGACY_ENTRY_ID = "legacy_entry_id"
+
+
+def _legacy_entry(hass: HomeAssistant, entry_id: str = LEGACY_ENTRY_ID) -> ConfigEntry:
+    """Return a registered config entry for the unique_id migration tests.
+
+    The entity registry refuses to link an entity to a config entry hass does
+    not know about, so the entry has to be a real one added to hass.
+    """
+    entry = MockConfigEntry(
+        domain="intellicenter",
+        entry_id=entry_id,
+        data={CONF_HOST: "192.168.1.100"},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_migrate_legacy_unique_id_adopts_entity(hass: HomeAssistant) -> None:
+    """A pre-fork unique_id is rewritten in place, keeping the entity_id."""
+    registry = er.async_get(hass)
+    entry = _legacy_entry(hass)
+    registry_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "intellicenter",
+        f"{LEGACY_ENTRY_ID}PMP01",
+        config_entry=entry,
+        suggested_object_id="filter",
+    )
+
+    _async_migrate_legacy_unique_ids(hass, entry)
+
+    migrated = registry.async_get(registry_entry.entity_id)
+    assert migrated is not None
+    assert migrated.entity_id == "binary_sensor.filter"
+    assert migrated.unique_id == f"{LEGACY_ENTRY_ID}_PMP01"
+
+
+async def test_migrate_legacy_unique_id_preserves_attribute_suffix(
+    hass: HomeAssistant,
+) -> None:
+    """The attribute suffix on multi-attribute entities survives the rewrite."""
+    registry = er.async_get(hass)
+    entry = _legacy_entry(hass)
+    registry_entry = registry.async_get_or_create(
+        "sensor",
+        "intellicenter",
+        f"{LEGACY_ENTRY_ID}PMP01RPM",
+        config_entry=entry,
+    )
+
+    _async_migrate_legacy_unique_ids(hass, entry)
+
+    migrated = registry.async_get(registry_entry.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == f"{LEGACY_ENTRY_ID}_PMP01RPM"
+
+
+async def test_migrate_leaves_current_format_untouched(hass: HomeAssistant) -> None:
+    """An entity already on the current format is not rewritten."""
+    registry = er.async_get(hass)
+    entry = _legacy_entry(hass)
+    registry_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "intellicenter",
+        f"{LEGACY_ENTRY_ID}_PMP01",
+        config_entry=entry,
+    )
+
+    _async_migrate_legacy_unique_ids(hass, entry)
+
+    migrated = registry.async_get(registry_entry.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == f"{LEGACY_ENTRY_ID}_PMP01"
+
+
+async def test_migrate_skips_on_collision(hass: HomeAssistant) -> None:
+    """A rewrite that would collide is skipped, leaving both entries intact."""
+    registry = er.async_get(hass)
+    entry = _legacy_entry(hass)
+    legacy = registry.async_get_or_create(
+        "binary_sensor",
+        "intellicenter",
+        f"{LEGACY_ENTRY_ID}PMP01",
+        config_entry=entry,
+        suggested_object_id="filter_legacy",
+    )
+    current = registry.async_get_or_create(
+        "binary_sensor",
+        "intellicenter",
+        f"{LEGACY_ENTRY_ID}_PMP01",
+        config_entry=entry,
+        suggested_object_id="filter_current",
+    )
+
+    _async_migrate_legacy_unique_ids(hass, entry)
+
+    assert registry.async_get(legacy.entity_id).unique_id == f"{LEGACY_ENTRY_ID}PMP01"
+    assert registry.async_get(current.entity_id).unique_id == f"{LEGACY_ENTRY_ID}_PMP01"
+
+
+async def test_migrate_ignores_other_config_entries(hass: HomeAssistant) -> None:
+    """Entities belonging to a different config entry are left alone."""
+    registry = er.async_get(hass)
+    entry = _legacy_entry(hass)
+    other_entry = _legacy_entry(hass, entry_id="other_entry_id")
+    other = registry.async_get_or_create(
+        "binary_sensor",
+        "intellicenter",
+        "other_entry_idPMP01",
+        config_entry=other_entry,
+    )
+
+    _async_migrate_legacy_unique_ids(hass, entry)
+
+    assert registry.async_get(other.entity_id).unique_id == "other_entry_idPMP01"


### PR DESCRIPTION
## Bug

Users arriving from [jlvaillant/intellicenter](https://github.com/jlvaillant/intellicenter) or [dwradcliffe/intellicenter](https://github.com/dwradcliffe/intellicenter) **silently lose every entity they had**. The old entries are left behind as `unavailable` and each entity returns as a `..._2` duplicate, breaking every automation, dashboard card, script and history graph that referenced the original `entity_id`.

Nothing logs an error — it just looks like the integration re-discovered everything. No open issue tracks this; I hit it while testing the switch from dwradcliffe myself.

Given the README positions this as the maintained continuation, and upstream threads point users here (jlvaillant#87 has several "switching to the fork fixed it" comments), this is likely on the path of most new installs.

## Root cause

The pre-fork integrations concatenate the entry id and objnam with **no separator**:

```python
# jlvaillant + dwradcliffe, custom_components/intellicenter/__init__.py
my_id = self._entry_id + self._poolObject.objnam
if self._attribute_key != STATUS_ATTR:
    my_id += self._attribute_key
```

This integration joins them with an underscore:

```python
my_id = f"{self._entry_id}_{self._pool_object.objnam}"
```

Both ship the same `intellicenter` domain **and** the same config-flow `VERSION = 1`. So the config entry is reused, Home Assistant never calls `async_migrate_entry` (and this integration's is a no-op stub anyway), and not a single unique_id matches.

## Fix

`_async_migrate_legacy_unique_ids` runs at the top of `async_setup_entry`, before the platforms build anything, and rewrites legacy unique_ids in the entity registry. Rewriting in place preserves the `entity_id`, friendly name, area, category and every user customization.

`async_migrate_entry` would be the natural home, but HA only invokes it when `entry.version` differs from the config flow's — and both sides are `VERSION = 1`, so it never fires. Bumping `VERSION` purely to trigger it would force a migration on existing users of *this* integration too, for no benefit.

Guards: entries already carrying the separator are skipped; a rewrite that would collide with an existing entry is skipped and logged at debug; only entries belonging to this config entry are considered; the attribute suffix on multi-attribute entities (`…PMP01RPM`) rides along, since only the prefix boundary is touched. The sweep is idempotent and costs one registry pass per setup.

**Worth recording for reviewers:** I initially expected `water_heater` to need special handling, since `PoolWaterHeater.unique_id` appends `LOTMP` on top of the base id. It does not — the legacy integration overrides `unique_id` the same way (`dwradcliffe/intellicenter`, `water_heater.py:118`), so only the separator differs there too. `climate` (`_climate`) and `select` (`_SELECT`) have no legacy counterpart, so there is nothing to adopt. The separator really is the only difference across every platform.

## Test plan

- 5 new tests in `tests/test_init.py`: adoption keeps the `entity_id`, the attribute suffix survives, current-format entries are untouched, collisions are skipped leaving both entries intact, and other config entries are ignored.
- **Full suite: 569 passed.** `ruff check` / `ruff format --check` / `mypy` (strict) / `bandit -ll` all clean, Python 3.14.4 via `uv sync --frozen`.
- **End-to-end on Home Assistant 2026.8.3** against a mock panel built on pyintellicenter's own `tests/mock_server.py`, with a registry seeded into the exact state a dwradcliffe user arrives with (20 legacy entities, three carrying user customizations):

  | | `main` | `main` + this PR |
  |---|---|---|
  | adopted | 0 / 20 | **20 / 20** |
  | orphaned | 20 | **0** |
  | `_2` duplicates | 18 | **0** |

  Entities came back live (`switch.my_pool` = `on` under its custom name, pump RPM `3068`), and a second restart on the already-migrated registry logged zero migrations. Full method and output in [this comment](https://github.com/joyfulhouse/intellicenter/pull/117#issuecomment-5432001826).

## Docs

- `CHANGELOG.md` — `Unreleased → Fixed` entry.
- `INSTALL.md` — new "Migrating from the jlvaillant or dwradcliffe integration" section, including the warning not to delete the old config entry first (doing so discards the registry entries this adopts).

## Release note

Branched from `main` (3.10.0b3), so it lands on the 3.10 line. Happy to backport to a 3.9.x patch if you'd rather ship it sooner — it is the kind of thing that only helps if it lands *before* users switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)